### PR TITLE
feat: Add F/A-18C Composite Panel Layout v1 assets and documentation

### DIFF
--- a/Doc/Vision/assets/fa18c_composite_panel_fullscreen_v2.svg
+++ b/Doc/Vision/assets/fa18c_composite_panel_fullscreen_v2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">F/A-18C Normalized Full-Screen Layout Diagram</title>
+  <desc id="desc">Generic full-screen diagram showing the normalized export strip on the left and the main simulator view on the right.</desc>
+  <rect width="100%" height="100%" fill="#0d1216" />
+  <rect x="550" y="0" width="1050" height="900" fill="#101d28" stroke="#415564" stroke-width="2" />
+  <rect x="0" y="0" width="550" height="900" fill="#101416" stroke="#8ca4b8" stroke-width="3" />
+  <g font-family="DejaVu Sans Mono, monospace">
+    <text x="578" y="46" fill="#f0f4f8" font-size="24" font-weight="700">Main Simulator View</text>
+    <text x="578" y="76" fill="#8aa0b2" font-size="18">The playable camera occupies the remaining screen space.</text>
+    <text x="24" y="46" fill="#f0f4f8" font-size="24" font-weight="700">Export Strip</text>
+    <text x="24" y="76" fill="#8aa0b2" font-size="18">VLM input is cut from this strip first, then split into three regions.</text>
+    <line x1="590" y1="495" x2="1540" y2="495" stroke="#4f6676" stroke-width="2" stroke-dasharray="8 8" />
+    <line x1="590" y1="630" x2="1540" y2="468" stroke="#38515e" stroke-width="2" />
+    <g id="fullscreen_left_ddi">
+      <rect x="135" y="15" width="280" height="280" rx="20" ry="20" fill="#18272d" stroke="#74d1ff" stroke-width="4" />
+      <text x="153" y="57" fill="#f4f7fb" font-size="22" font-weight="700">Left DDI</text>
+      <text x="153" y="85" fill="#74d1ff" font-size="16">left_ddi</text>
+    </g>
+    <g id="fullscreen_ampcd">
+      <rect x="135" y="310" width="280" height="280" rx="20" ry="20" fill="#1b3138" stroke="#6ee7c8" stroke-width="4" />
+      <text x="153" y="352" fill="#f4f7fb" font-size="22" font-weight="700">AMPCD</text>
+      <text x="153" y="380" fill="#6ee7c8" font-size="16">ampcd</text>
+    </g>
+    <g id="fullscreen_right_ddi">
+      <rect x="135" y="605" width="280" height="280" rx="20" ry="20" fill="#18272d" stroke="#74d1ff" stroke-width="4" />
+      <text x="153" y="647" fill="#f4f7fb" font-size="22" font-weight="700">Right DDI</text>
+      <text x="153" y="675" fill="#74d1ff" font-size="16">right_ddi</text>
+    </g>
+  </g>
+</svg>

--- a/Doc/Vision/assets/fa18c_composite_panel_v1.svg
+++ b/Doc/Vision/assets/fa18c_composite_panel_v1.svg
@@ -1,49 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1440" viewBox="0 0 2560 1440" role="img" aria-labelledby="title desc">
-  <title id="title">F/A-18C Composite Panel Layout v1</title>
-  <desc id="desc">Dark neutral matte background with no cockpit scenery or decorative texture.</desc>
-  <rect width="2560" height="1440" fill="#101416" />
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="1440" viewBox="0 0 880 1440" role="img" aria-labelledby="title desc">
+  <title id="title">F/A-18C Native Viewport Layout v1</title>
+  <desc id="desc">Dark neutral matte background for the three stacked native display exports, with no main camera view.</desc>
+  <rect width="880" height="1440" fill="#101416" />
   <g font-family="DejaVu Sans Mono, monospace">
     <g id="left_ddi">
-      <rect x="32" y="32" width="768" height="768" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
-      <text x="60" y="94" fill="#f4f7fb" font-size="40" font-weight="700">Left DDI</text>
-      <text x="60" y="144" fill="#74d1ff" font-size="28">left_ddi · 左 DDI</text>
-      <text x="60" y="756" fill="#d0dae4" font-size="24">OCR priority: high</text>
+      <rect x="216" y="24" width="448" height="448" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
+      <text x="244" y="86" fill="#f4f7fb" font-size="40" font-weight="700">Left DDI</text>
+      <text x="244" y="136" fill="#74d1ff" font-size="28">left_ddi · 左 DDI</text>
+      <text x="244" y="428" fill="#d0dae4" font-size="24">OCR priority: high</text>
     </g>
     <g id="ampcd">
-      <rect x="896" y="32" width="768" height="768" rx="26" ry="26" fill="#1b3138" stroke="#6ee7c8" stroke-width="6" />
-      <text x="924" y="94" fill="#f4f7fb" font-size="40" font-weight="700">AMPCD</text>
-      <text x="924" y="144" fill="#6ee7c8" font-size="28">ampcd · AMPCD</text>
-      <text x="924" y="756" fill="#d0dae4" font-size="24">OCR priority: high</text>
+      <rect x="216" y="496" width="448" height="448" rx="26" ry="26" fill="#1b3138" stroke="#6ee7c8" stroke-width="6" />
+      <text x="244" y="558" fill="#f4f7fb" font-size="40" font-weight="700">AMPCD</text>
+      <text x="244" y="608" fill="#6ee7c8" font-size="28">ampcd · AMPCD</text>
+      <text x="244" y="900" fill="#d0dae4" font-size="24">OCR priority: high</text>
     </g>
     <g id="right_ddi">
-      <rect x="1760" y="32" width="768" height="768" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
-      <text x="1788" y="94" fill="#f4f7fb" font-size="40" font-weight="700">Right DDI</text>
-      <text x="1788" y="144" fill="#74d1ff" font-size="28">right_ddi · 右 DDI</text>
-      <text x="1788" y="756" fill="#d0dae4" font-size="24">OCR priority: high</text>
-    </g>
-    <g id="warning_panel">
-      <rect x="32" y="832" width="848" height="248" rx="26" ry="26" fill="#3d251e" stroke="#ff8b6b" stroke-width="6" />
-      <text x="60" y="894" fill="#f4f7fb" font-size="40" font-weight="700">Warning Panel</text>
-      <text x="60" y="944" fill="#ff8b6b" font-size="28">warning_panel · 告警灯区</text>
-      <text x="60" y="1036" fill="#d0dae4" font-size="24">OCR priority: high</text>
-    </g>
-    <g id="ufc">
-      <rect x="912" y="832" width="736" height="248" rx="26" ry="26" fill="#2c2f34" stroke="#f6d365" stroke-width="6" />
-      <text x="940" y="894" fill="#f4f7fb" font-size="40" font-weight="700">UFC</text>
-      <text x="940" y="944" fill="#f6d365" font-size="28">ufc · UFC</text>
-      <text x="940" y="1036" fill="#d0dae4" font-size="24">OCR priority: high</text>
-    </g>
-    <g id="ifei">
-      <rect x="1680" y="832" width="848" height="248" rx="26" ry="26" fill="#202b24" stroke="#b7f171" stroke-width="6" />
-      <text x="1708" y="894" fill="#f4f7fb" font-size="40" font-weight="700">IFEI</text>
-      <text x="1708" y="944" fill="#b7f171" font-size="28">ifei · IFEI</text>
-      <text x="1708" y="1036" fill="#d0dae4" font-size="24">OCR priority: high</text>
-    </g>
-    <g id="standby_hud">
-      <rect x="912" y="1112" width="736" height="296" rx="26" ry="26" fill="#203037" stroke="#b9c7ff" stroke-width="6" />
-      <text x="940" y="1174" fill="#f4f7fb" font-size="40" font-weight="700">Standby / HUD</text>
-      <text x="940" y="1224" fill="#b9c7ff" font-size="28">standby_hud · 备用仪表/HUD</text>
-      <text x="940" y="1364" fill="#d0dae4" font-size="24">OCR priority: medium</text>
+      <rect x="216" y="968" width="448" height="448" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
+      <text x="244" y="1030" fill="#f4f7fb" font-size="40" font-weight="700">Right DDI</text>
+      <text x="244" y="1080" fill="#74d1ff" font-size="28">right_ddi · 右 DDI</text>
+      <text x="244" y="1372" fill="#d0dae4" font-size="24">OCR priority: high</text>
     </g>
   </g>
 </svg>

--- a/Doc/Vision/assets/fa18c_composite_panel_v1.svg
+++ b/Doc/Vision/assets/fa18c_composite_panel_v1.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1440" viewBox="0 0 2560 1440" role="img" aria-labelledby="title desc">
+  <title id="title">F/A-18C Composite Panel Layout v1</title>
+  <desc id="desc">Dark neutral matte background with no cockpit scenery or decorative texture.</desc>
+  <rect width="2560" height="1440" fill="#101416" />
+  <g font-family="DejaVu Sans Mono, monospace">
+    <g id="left_ddi">
+      <rect x="32" y="32" width="768" height="768" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
+      <text x="60" y="94" fill="#f4f7fb" font-size="40" font-weight="700">Left DDI</text>
+      <text x="60" y="144" fill="#74d1ff" font-size="28">left_ddi · 左 DDI</text>
+      <text x="60" y="756" fill="#d0dae4" font-size="24">OCR priority: high</text>
+    </g>
+    <g id="ampcd">
+      <rect x="896" y="32" width="768" height="768" rx="26" ry="26" fill="#1b3138" stroke="#6ee7c8" stroke-width="6" />
+      <text x="924" y="94" fill="#f4f7fb" font-size="40" font-weight="700">AMPCD</text>
+      <text x="924" y="144" fill="#6ee7c8" font-size="28">ampcd · AMPCD</text>
+      <text x="924" y="756" fill="#d0dae4" font-size="24">OCR priority: high</text>
+    </g>
+    <g id="right_ddi">
+      <rect x="1760" y="32" width="768" height="768" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
+      <text x="1788" y="94" fill="#f4f7fb" font-size="40" font-weight="700">Right DDI</text>
+      <text x="1788" y="144" fill="#74d1ff" font-size="28">right_ddi · 右 DDI</text>
+      <text x="1788" y="756" fill="#d0dae4" font-size="24">OCR priority: high</text>
+    </g>
+    <g id="warning_panel">
+      <rect x="32" y="832" width="848" height="248" rx="26" ry="26" fill="#3d251e" stroke="#ff8b6b" stroke-width="6" />
+      <text x="60" y="894" fill="#f4f7fb" font-size="40" font-weight="700">Warning Panel</text>
+      <text x="60" y="944" fill="#ff8b6b" font-size="28">warning_panel · 告警灯区</text>
+      <text x="60" y="1036" fill="#d0dae4" font-size="24">OCR priority: high</text>
+    </g>
+    <g id="ufc">
+      <rect x="912" y="832" width="736" height="248" rx="26" ry="26" fill="#2c2f34" stroke="#f6d365" stroke-width="6" />
+      <text x="940" y="894" fill="#f4f7fb" font-size="40" font-weight="700">UFC</text>
+      <text x="940" y="944" fill="#f6d365" font-size="28">ufc · UFC</text>
+      <text x="940" y="1036" fill="#d0dae4" font-size="24">OCR priority: high</text>
+    </g>
+    <g id="ifei">
+      <rect x="1680" y="832" width="848" height="248" rx="26" ry="26" fill="#202b24" stroke="#b7f171" stroke-width="6" />
+      <text x="1708" y="894" fill="#f4f7fb" font-size="40" font-weight="700">IFEI</text>
+      <text x="1708" y="944" fill="#b7f171" font-size="28">ifei · IFEI</text>
+      <text x="1708" y="1036" fill="#d0dae4" font-size="24">OCR priority: high</text>
+    </g>
+    <g id="standby_hud">
+      <rect x="912" y="1112" width="736" height="296" rx="26" ry="26" fill="#203037" stroke="#b9c7ff" stroke-width="6" />
+      <text x="940" y="1174" fill="#f4f7fb" font-size="40" font-weight="700">Standby / HUD</text>
+      <text x="940" y="1224" fill="#b9c7ff" font-size="28">standby_hud · 备用仪表/HUD</text>
+      <text x="940" y="1364" fill="#d0dae4" font-size="24">OCR priority: medium</text>
+    </g>
+  </g>
+</svg>

--- a/Doc/Vision/assets/fa18c_composite_panel_v2.svg
+++ b/Doc/Vision/assets/fa18c_composite_panel_v2.svg
@@ -1,24 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="880" height="1440" viewBox="0 0 880 1440" role="img" aria-labelledby="title desc">
-  <title id="title">F/A-18C Native Viewport Layout v1</title>
-  <desc id="desc">Dark neutral matte background for the three stacked native display exports, with no main camera view.</desc>
+  <title id="title">F/A-18C Native Viewport Layout v2 Strip Preview</title>
+  <desc id="desc">Dark neutral matte preview background for the native export strip.</desc>
   <rect width="880" height="1440" fill="#101416" />
   <g font-family="DejaVu Sans Mono, monospace">
+    <text x="28" y="48" fill="#d9e2ea" font-size="24" font-weight="700">Normalized Export Strip</text>
+    <text x="28" y="80" fill="#8ba1b3" font-size="18">Three native display exports resolved inside the left stack.</text>
     <g id="left_ddi">
       <rect x="216" y="24" width="448" height="448" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
       <text x="244" y="86" fill="#f4f7fb" font-size="40" font-weight="700">Left DDI</text>
-      <text x="244" y="136" fill="#74d1ff" font-size="28">left_ddi · Left DDI</text>
+      <text x="244" y="136" fill="#74d1ff" font-size="28">left_ddi</text>
       <text x="244" y="428" fill="#d0dae4" font-size="24">OCR priority: high</text>
     </g>
     <g id="ampcd">
       <rect x="216" y="496" width="448" height="448" rx="26" ry="26" fill="#1b3138" stroke="#6ee7c8" stroke-width="6" />
       <text x="244" y="558" fill="#f4f7fb" font-size="40" font-weight="700">AMPCD</text>
-      <text x="244" y="608" fill="#6ee7c8" font-size="28">ampcd · AMPCD</text>
+      <text x="244" y="608" fill="#6ee7c8" font-size="28">ampcd</text>
       <text x="244" y="900" fill="#d0dae4" font-size="24">OCR priority: high</text>
     </g>
     <g id="right_ddi">
       <rect x="216" y="968" width="448" height="448" rx="26" ry="26" fill="#18272d" stroke="#74d1ff" stroke-width="6" />
       <text x="244" y="1030" fill="#f4f7fb" font-size="40" font-weight="700">Right DDI</text>
-      <text x="244" y="1080" fill="#74d1ff" font-size="28">right_ddi · Right DDI</text>
+      <text x="244" y="1080" fill="#74d1ff" font-size="28">right_ddi</text>
       <text x="244" y="1372" fill="#d0dae4" font-size="24">OCR priority: high</text>
     </g>
   </g>

--- a/Doc/Vision/fa18c_composite_panel_EN_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_EN_v1.md
@@ -79,3 +79,32 @@ Currently outside the first composite-panel priority scope, requiring manual con
 
 - Asset path: `Doc/Vision/assets/fa18c_composite_panel_v1.svg`
 - The sample image is generated from the frozen layout and is only used to validate region naming, crop stability, and human readability
+
+## Three-Screen Native Viewport PoC
+
+- The first PoC only validates `left_ddi`, `ampcd`, and `right_ddi`
+- These three regions are exported through DCS native monitor viewports: `LEFT_MFCD`, `CENTER_MFCD`, and `RIGHT_MFCD`
+- The composite export canvas is fixed at `2560x1440` and must live on a desktop region extended to the right of the main screen
+- Install command:
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode extended-right --main-width 1920 --main-height 1080
+```
+
+- After installation, select `SimTutor_FA18C_CompositePanel_v1` in DCS Options
+- The recommended total DCS resolution is `main_width + 2560` by `max(main_height, 1440)`
+- This PoC does not yet export `warning_panel`, `ufc`, `ifei`, or `standby_hud` as native viewports
+- If you only have one screen, use single-monitor mode instead:
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode single-monitor --main-width 1920 --main-height 1080
+```
+
+- Single-monitor mode places the three MFCD/AMPCD exports on the top band and keeps the main camera on the lower band
+- For `3440x1440` and similar 21:9 screens, the ultrawide mode is usually better:
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode ultrawide-left-stack --main-width 3440 --main-height 1440
+```
+
+- This mode stacks the three exported screens vertically in the extra left strip and keeps a full `2560x1440` `16:9` main view on the right

--- a/Doc/Vision/fa18c_composite_panel_EN_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_EN_v1.md
@@ -1,0 +1,81 @@
+# F/A-18C Composite Panel Layout v1
+
+`layout_id`: `fa18c_composite_panel_v1`
+
+This document freezes the first v0.4 visual input layout. The goal is to help Qwen3.5 recognize display pages, text, and annunciator states more reliably, not to recreate a photoreal cockpit screenshot.
+
+## Fixed Coverage
+
+- `left_ddi`
+- `ampcd`
+- `right_ddi`
+- `warning_panel`
+- `ufc`
+- `ifei`
+- `standby_hud`
+
+## Explicitly Excluded
+
+- Outside scenery
+- Large cockpit background areas
+- Unrelated consoles
+- Extra cropped regions that are not required by the current pack
+
+## Region Naming Rules
+
+- All future VLM prompts, manifests, documents, and debug output may only use these 7 `region_id` values
+- Alias drift is forbidden; for example, do not rename `ampcd` to `mpcd`
+- The region order is fixed: `left_ddi -> ampcd -> right_ddi -> warning_panel -> ufc -> ifei -> standby_hud`
+
+## Region Definitions
+
+| region_id | English Name | Position and Size (x,y,w,h) | Primary Content |
+| --- | --- | --- | --- |
+| `left_ddi` | Left DDI | `32,32,768,768` | Left DDI pages such as FCS/HSI/ENG |
+| `ampcd` | AMPCD | `896,32,768,768` | Central AMPCD page text and symbols |
+| `right_ddi` | Right DDI | `1760,32,768,768` | Right DDI pages such as BIT/FCS |
+| `warning_panel` | Warning Panel | `32,832,848,248` | `MASTER CAUTION`, caution/warning/advisory lamps, and fire-related indicators |
+| `ufc` | UFC | `912,832,736,248` | UFC display and COMM-related readouts |
+| `ifei` | IFEI | `1680,832,848,248` | Engine/fuel display and BINGO-related readouts |
+| `standby_hud` | Standby / HUD | `912,1112,736,296` | Standby instruments and any small HUD crop required by the pack |
+
+## Step Priority Boundary
+
+Prefer the composite panel first:
+
+- `S02`
+- `S07`
+- `S08`
+- `S09`
+- `S15`
+- `S18`
+- `S21`
+- `S22`
+- `S23`
+- `S24`
+- `S25`
+
+Still prefer DCS-BIOS first:
+
+- `S01`
+- `S03`
+- `S04`
+- `S06`
+- `S10`
+- `S12`
+- `S13`
+
+Currently outside the first composite-panel priority scope, requiring manual confirmation or remaining out of layout:
+
+- `S05`
+- `S11`
+- `S14`
+- `S16`
+- `S17`
+- `S19`
+- `S20`
+
+## Sample Asset
+
+- Asset path: `Doc/Vision/assets/fa18c_composite_panel_v1.svg`
+- The sample image is generated from the frozen layout and is only used to validate region naming, crop stability, and human readability

--- a/Doc/Vision/fa18c_composite_panel_EN_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_EN_v1.md
@@ -1,110 +1,99 @@
-# F/A-18C Composite Panel Layout v1
+# F/A-18C Native Viewport Layout v1
 
 `layout_id`: `fa18c_composite_panel_v1`
 
-This document freezes the first v0.4 visual input layout. The goal is to help Qwen3.5 recognize display pages, text, and annunciator states more reliably, not to recreate a photoreal cockpit screenshot.
+This document freezes the current v0.4 visual-input contract: only the three DCS-native display exports remain in scope. `warning_panel`, `ufc`, `ifei`, and `standby_hud` are no longer part of the visual contract.
 
 ## Fixed Coverage
 
 - `left_ddi`
 - `ampcd`
 - `right_ddi`
-- `warning_panel`
-- `ufc`
-- `ifei`
-- `standby_hud`
 
-## Explicitly Excluded
+## Explicitly Removed From Visual Input
 
-- Outside scenery
-- Large cockpit background areas
-- Unrelated consoles
-- Extra cropped regions that are not required by the current pack
+- `MASTER CAUTION` and the left/right warning-caution-advisory blocks
+- All `IFEI` numeric content and BINGO readouts
+- UFC scratchpad, option windows, and COMM1/COMM2 displays
+- Standby instruments and any HUD crop
+- Outside scenery, the main camera view, large cockpit background areas, and unrelated consoles
+
+These signals should now come from DCS-BIOS instead of image recognition.
 
 ## Region Naming Rules
 
-- All future VLM prompts, manifests, documents, and debug output may only use these 7 `region_id` values
+- All future VLM prompts, manifests, documents, and debug output may only use these 3 `region_id` values
 - Alias drift is forbidden; for example, do not rename `ampcd` to `mpcd`
-- The region order is fixed: `left_ddi -> ampcd -> right_ddi -> warning_panel -> ufc -> ifei -> standby_hud`
+- The region order is fixed: `left_ddi -> ampcd -> right_ddi`
 
 ## Region Definitions
 
-| region_id | English Name | Position and Size (x,y,w,h) | Primary Content |
-| --- | --- | --- | --- |
-| `left_ddi` | Left DDI | `32,32,768,768` | Left DDI pages such as FCS/HSI/ENG |
-| `ampcd` | AMPCD | `896,32,768,768` | Central AMPCD page text and symbols |
-| `right_ddi` | Right DDI | `1760,32,768,768` | Right DDI pages such as BIT/FCS |
-| `warning_panel` | Warning Panel | `32,832,848,248` | `MASTER CAUTION`, caution/warning/advisory lamps, and fire-related indicators |
-| `ufc` | UFC | `912,832,736,248` | UFC display and COMM-related readouts |
-| `ifei` | IFEI | `1680,832,848,248` | Engine/fuel display and BINGO-related readouts |
-| `standby_hud` | Standby / HUD | `912,1112,736,296` | Standby instruments and any small HUD crop required by the pack |
+The canonical canvas is fixed to `880x1440`, matching the cropped left export strip used in the current ultrawide deployment.
+
+| region_id | English Name | Position and Size (x,y,w,h) | Native DCS viewport | Primary Content |
+| --- | --- | --- | --- | --- |
+| `left_ddi` | Left DDI | `216,24,448,448` | `LEFT_MFCD` | Left DDI pages such as FCS/HSI |
+| `ampcd` | AMPCD | `216,496,448,448` | `CENTER_MFCD` | Center AMPCD page text and symbology |
+| `right_ddi` | Right DDI | `216,968,448,448` | `RIGHT_MFCD` | Right DDI pages such as BIT/FCS |
 
 ## Step Priority Boundary
 
-Prefer the composite panel first:
+Prefer native viewports first:
 
-- `S02`
-- `S07`
 - `S08`
-- `S09`
 - `S15`
 - `S18`
-- `S21`
-- `S22`
-- `S23`
-- `S24`
-- `S25`
 
 Still prefer DCS-BIOS first:
 
 - `S01`
 - `S03`
 - `S04`
+- `S05`
 - `S06`
+- `S07`
+- `S09`
 - `S10`
+- `S11`
 - `S12`
 - `S13`
+- `S21`
 
-Currently outside the first composite-panel priority scope, requiring manual confirmation or remaining out of layout:
+Currently outside the first native-viewport scope, requiring manual confirmation or remaining out of layout:
 
-- `S05`
-- `S11`
+- `S02`
 - `S14`
 - `S16`
 - `S17`
 - `S19`
 - `S20`
+- `S22`
+- `S23`
+- `S24`
+- `S25`
 
 ## Sample Asset
 
 - Asset path: `Doc/Vision/assets/fa18c_composite_panel_v1.svg`
-- The sample image is generated from the frozen layout and is only used to validate region naming, crop stability, and human readability
+- The sample image only validates the three `region_id` values, their order, and border treatment; it does not represent the main game camera layout
 
-## Three-Screen Native Viewport PoC
+## Current Deployment Layout
 
-- The first PoC only validates `left_ddi`, `ampcd`, and `right_ddi`
-- These three regions are exported through DCS native monitor viewports: `LEFT_MFCD`, `CENTER_MFCD`, and `RIGHT_MFCD`
-- The composite export canvas is fixed at `2560x1440` and must live on a desktop region extended to the right of the main screen
-- Install command:
+The frozen deployment layout is the current `3440x1440` ultrawide single-monitor setup:
 
-```bash
-python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode extended-right --main-width 1920 --main-height 1080
-```
+- DCS monitor setup uses `ultrawide-left-stack`
+- The left `880px` strip stacks the three native display exports vertically
+- The right side keeps a full `2560x1440` `16:9` playable main view
+- The VLM side must only consume the left `880x1440` export strip and must not ingest the right-side main camera
 
-- After installation, select `SimTutor_FA18C_CompositePanel_v1` in DCS Options
-- The recommended total DCS resolution is `main_width + 2560` by `max(main_height, 1440)`
-- This PoC does not yet export `warning_panel`, `ufc`, `ifei`, or `standby_hud` as native viewports
-- If you only have one screen, use single-monitor mode instead:
-
-```bash
-python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode single-monitor --main-width 1920 --main-height 1080
-```
-
-- Single-monitor mode places the three MFCD/AMPCD exports on the top band and keeps the main camera on the lower band
-- For `3440x1440` and similar 21:9 screens, the ultrawide mode is usually better:
+Install command:
 
 ```bash
 python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode ultrawide-left-stack --main-width 3440 --main-height 1440
 ```
 
-- This mode stacks the three exported screens vertically in the extra left strip and keeps a full `2560x1440` `16:9` main view on the right
+After installation:
+
+- Select `SimTutor_FA18C_CompositePanel_v1` in DCS Options
+- Set the resolution to `3440x1440`
+- `single-monitor` and `extended-right` remain available for debugging, but they are no longer the frozen visual contract

--- a/Doc/Vision/fa18c_composite_panel_EN_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_EN_v1.md
@@ -85,6 +85,7 @@ The frozen deployment layout is the current `3440x1440` ultrawide single-monitor
 - The left `880px` strip stacks the three native display exports vertically
 - The right side keeps a full `2560x1440` `16:9` playable main view
 - The VLM side must only consume the left `880x1440` export strip and must not ingest the right-side main camera
+- On a `16:9` single screen, `single-monitor` now uses the same left-stack geometry family and only scales the export strip by screen height, so downstream code does not need a second single-screen layout model
 
 Install command:
 
@@ -96,4 +97,10 @@ After installation:
 
 - Select `SimTutor_FA18C_CompositePanel_v1` in DCS Options
 - Set the resolution to `3440x1440`
-- `single-monitor` and `extended-right` remain available for debugging, but they are no longer the frozen visual contract
+- For a `16:9` single-screen setup, use:
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode single-monitor --main-width 1920 --main-height 1080
+```
+
+- `single-monitor` and `ultrawide-left-stack` now share the same left-stack three-viewport family; `extended-right` remains debug-only

--- a/Doc/Vision/fa18c_composite_panel_EN_v2.md
+++ b/Doc/Vision/fa18c_composite_panel_EN_v2.md
@@ -1,0 +1,96 @@
+# F/A-18C Normalized Native Viewport Layout v2
+
+`layout_id`: `fa18c_composite_panel_v2`
+
+This document freezes the v2 visual-input contract for v0.4. v2 no longer treats pixel coordinates as the source of truth. Instead, the layout is defined by a normalized left export strip plus three normalized regions inside that strip.
+
+## Fixed Visual Scope
+
+- `left_ddi`
+- `ampcd`
+- `right_ddi`
+
+All other evidence remains DCS-BIOS-first, including:
+
+- `MASTER CAUTION` and the left/right warning-caution-advisory blocks
+- `IFEI` numeric values and BINGO
+- UFC scratchpad, option displays, and COMM1/COMM2 windows
+- standby / HUD
+
+## v2 Geometry Rules
+
+- First cut the left export strip from the full screen using normalized strip geometry
+- Then cut the three viewport regions from inside that strip using normalized region geometry
+- Downstream VLM code must not hard-code full-screen pixel crops for `left_ddi / ampcd / right_ddi`
+
+The frozen `strip_norm` is:
+
+- `anchor: left`
+- `x_norm: 0.0`
+- `y_norm: 0.0`
+- `height_norm: 1.0`
+- `target_aspect_ratio: 880 / 1440`
+- `min_main_view_width_px: 640`
+
+## Region Order
+
+The order is fixed:
+
+- `left_ddi`
+- `ampcd`
+- `right_ddi`
+
+Alias drift is forbidden. For example, do not rename `ampcd` to `mpcd`.
+
+## Reference Assets
+
+- Strip preview: `Doc/Vision/assets/fa18c_composite_panel_v2.svg`
+- Full-screen diagram: `Doc/Vision/assets/fa18c_composite_panel_fullscreen_v2.svg`
+
+Notes:
+
+- Both SVGs use English labels only
+- The strip preview only shows the internal export-strip structure
+- The full-screen diagram only shows the normalized relationship between the left export strip and the right main simulator view; it is not tied to a specific monitor resolution
+
+## Step Priority Boundary
+
+Prefer native viewports first:
+
+- `S08`
+- `S15`
+- `S18`
+
+Still prefer DCS-BIOS first:
+
+- `S01`
+- `S03`
+- `S04`
+- `S05`
+- `S06`
+- `S07`
+- `S09`
+- `S10`
+- `S11`
+- `S12`
+- `S13`
+- `S21`
+
+Currently outside the first native-viewport scope, requiring manual confirmation or remaining out of layout:
+
+- `S02`
+- `S14`
+- `S16`
+- `S17`
+- `S19`
+- `S20`
+- `S22`
+- `S23`
+- `S24`
+- `S25`
+
+## Monitor Setup Behavior
+
+- `single-monitor` and `ultrawide-left-stack` share the same normalized left-stack solver
+- `extended-right` remains a debug mode, but its three viewports are still solved from the same normalized region geometry
+- This keeps capture, cropping, and VLM references on one geometry model

--- a/Doc/Vision/fa18c_composite_panel_ZH_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_ZH_v1.md
@@ -79,3 +79,32 @@
 
 - 资产路径：`Doc/Vision/assets/fa18c_composite_panel_v1.svg`
 - 样例图按冻结版式生成，仅用于验证区域命名、裁切稳定性和人工可读性
+
+## 三屏真视口 PoC（首轮）
+
+- 首轮只验证 `left_ddi`、`ampcd`、`right_ddi`
+- 这三块通过 DCS 原生 `LEFT_MFCD`、`CENTER_MFCD`、`RIGHT_MFCD` monitor viewport 导出
+- 组合画布固定放在主屏右侧扩展桌面，尺寸固定为 `2560x1440`
+- 生成安装命令：
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode extended-right --main-width 1920 --main-height 1080
+```
+
+- 安装后需要在 DCS Options 中选择 `SimTutor_FA18C_CompositePanel_v1`
+- 推荐总分辨率为 `main_width + 2560` 乘以 `max(main_height, 1440)`
+- 本轮不包含 `warning_panel`、`ufc`、`ifei`、`standby_hud` 的真视口导出
+- 如果只有一块屏幕，可改用单屏模式：
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode single-monitor --main-width 1920 --main-height 1080
+```
+
+- 单屏模式会把三块 MFCD/AMPCD 缩放排在屏幕上半区，主视角放在下半区
+- 如果是 `3440x1440` 这类 21:9 屏幕，更推荐超宽屏模式：
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode ultrawide-left-stack --main-width 3440 --main-height 1440
+```
+
+- 该模式会把三块导出屏竖着排在最左侧多出来的窄条里，右侧保留完整 `2560x1440` 的 `16:9` 主视角

--- a/Doc/Vision/fa18c_composite_panel_ZH_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_ZH_v1.md
@@ -1,0 +1,81 @@
+# F/A-18C 组合面板图版式 v1
+
+`layout_id`: `fa18c_composite_panel_v1`
+
+本文件冻结 v0.4 首版视觉输入版式。目标是让 Qwen3.5 更稳定地识别显示页、字符和灯态，不追求真实座舱截图的还原感。
+
+## 固定覆盖范围
+
+- `left_ddi`
+- `ampcd`
+- `right_ddi`
+- `warning_panel`
+- `ufc`
+- `ifei`
+- `standby_hud`
+
+## 明确不包含
+
+- 外景
+- 座舱大面积背景
+- 无关控制台
+- 非 pack 当前需要的额外局部裁切
+
+## 区域命名规则
+
+- 后续 VLM prompt、manifest、文档和调试输出只允许使用上述 7 个 `region_id`
+- 禁止别名漂移，例如把 `ampcd` 写成 `mpcd`
+- 区域顺序固定为：`left_ddi -> ampcd -> right_ddi -> warning_panel -> ufc -> ifei -> standby_hud`
+
+## 区域定义
+
+| region_id | 中文名 | 位置与尺寸 (x,y,w,h) | 主要内容 |
+| --- | --- | --- | --- |
+| `left_ddi` | 左 DDI | `32,32,768,768` | 左 DDI 页面，如 FCS/HSI/ENG |
+| `ampcd` | AMPCD | `896,32,768,768` | 中央 AMPCD 页面文字与符号 |
+| `right_ddi` | 右 DDI | `1760,32,768,768` | 右 DDI 页面，如 BIT/FCS |
+| `warning_panel` | 告警灯区 | `32,832,848,248` | `MASTER CAUTION`、告警/注意/提示灯、火警相关灯 |
+| `ufc` | UFC | `912,832,736,248` | UFC 显示与 COMM 相关读数 |
+| `ifei` | IFEI | `1680,832,848,248` | 发动机/燃油与 BINGO 相关显示 |
+| `standby_hud` | 备用仪表/HUD | `912,1112,736,296` | standby 仪表与 pack 所需的 HUD 小区域 |
+
+## 步骤优先级边界
+
+优先依赖组合图：
+
+- `S02`
+- `S07`
+- `S08`
+- `S09`
+- `S15`
+- `S18`
+- `S21`
+- `S22`
+- `S23`
+- `S24`
+- `S25`
+
+仍优先依赖 DCS-BIOS：
+
+- `S01`
+- `S03`
+- `S04`
+- `S06`
+- `S10`
+- `S12`
+- `S13`
+
+当前不归入首版组合图优先范围，属于手工确认或布局外：
+
+- `S05`
+- `S11`
+- `S14`
+- `S16`
+- `S17`
+- `S19`
+- `S20`
+
+## 样例图
+
+- 资产路径：`Doc/Vision/assets/fa18c_composite_panel_v1.svg`
+- 样例图按冻结版式生成，仅用于验证区域命名、裁切稳定性和人工可读性

--- a/Doc/Vision/fa18c_composite_panel_ZH_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_ZH_v1.md
@@ -85,6 +85,7 @@
 - 左侧 `880px` 窄条竖排导出 3 块原生视口
 - 右侧保留完整 `2560x1440` 的 `16:9` 正常游戏画面
 - VLM 侧只应消费左侧这块 `880x1440` 导出带，不能把右侧主视角送进模型
+- 对 `16:9` 单屏，`single-monitor` 现在也使用同一套左栈布局语义，只是按屏幕高度缩放左侧导出带，避免后续代码维护两套单屏几何
 
 安装命令：
 
@@ -96,4 +97,10 @@ python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode ultrawide-lef
 
 - 在 DCS Options 中选择 `SimTutor_FA18C_CompositePanel_v1`
 - 分辨率设为 `3440x1440`
-- 如果只是临时调试，`single-monitor` 和 `extended-right` 仍可用，但它们不再是冻结后的标准视觉 contract
+- 如果是 `16:9` 单屏，可使用：
+
+```bash
+python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode single-monitor --main-width 1920 --main-height 1080
+```
+
+- `single-monitor` 与 `ultrawide-left-stack` 共享同一套左栈三视口布局；`extended-right` 仅保留为调试模式

--- a/Doc/Vision/fa18c_composite_panel_ZH_v1.md
+++ b/Doc/Vision/fa18c_composite_panel_ZH_v1.md
@@ -1,110 +1,99 @@
-# F/A-18C 组合面板图版式 v1
+# F/A-18C 原生视口布局 v1
 
 `layout_id`: `fa18c_composite_panel_v1`
 
-本文件冻结 v0.4 首版视觉输入版式。目标是让 Qwen3.5 更稳定地识别显示页、字符和灯态，不追求真实座舱截图的还原感。
+本文件冻结 v0.4 当前实际使用的视觉输入方案：只保留 DCS 原生可稳定导出的 3 块显示器视口，不再把 `warning_panel`、`ufc`、`ifei`、`standby_hud` 放进视觉 contract。
 
 ## 固定覆盖范围
 
 - `left_ddi`
 - `ampcd`
 - `right_ddi`
-- `warning_panel`
-- `ufc`
-- `ifei`
-- `standby_hud`
 
-## 明确不包含
+## 明确不再纳入视觉输入
 
-- 外景
-- 座舱大面积背景
-- 无关控制台
-- 非 pack 当前需要的额外局部裁切
+- `MASTER CAUTION` 与左右告警/注意/提示灯整块
+- `IFEI` 全部数字与 BINGO 读数
+- `UFC` scratchpad、option windows、COMM1/COMM2 显示
+- 备用仪表与 HUD 小裁切
+- 外景、主视角、座舱大面积背景、无关控制台
+
+上面这些信息在当前方案中优先走 DCS-BIOS，不再要求 VLM 从图像里识别。
 
 ## 区域命名规则
 
-- 后续 VLM prompt、manifest、文档和调试输出只允许使用上述 7 个 `region_id`
+- 后续 VLM prompt、manifest、文档和调试输出只允许使用这 3 个 `region_id`
 - 禁止别名漂移，例如把 `ampcd` 写成 `mpcd`
-- 区域顺序固定为：`left_ddi -> ampcd -> right_ddi -> warning_panel -> ufc -> ifei -> standby_hud`
+- 区域顺序固定为：`left_ddi -> ampcd -> right_ddi`
 
 ## 区域定义
 
-| region_id | 中文名 | 位置与尺寸 (x,y,w,h) | 主要内容 |
-| --- | --- | --- | --- |
-| `left_ddi` | 左 DDI | `32,32,768,768` | 左 DDI 页面，如 FCS/HSI/ENG |
-| `ampcd` | AMPCD | `896,32,768,768` | 中央 AMPCD 页面文字与符号 |
-| `right_ddi` | 右 DDI | `1760,32,768,768` | 右 DDI 页面，如 BIT/FCS |
-| `warning_panel` | 告警灯区 | `32,832,848,248` | `MASTER CAUTION`、告警/注意/提示灯、火警相关灯 |
-| `ufc` | UFC | `912,832,736,248` | UFC 显示与 COMM 相关读数 |
-| `ifei` | IFEI | `1680,832,848,248` | 发动机/燃油与 BINGO 相关显示 |
-| `standby_hud` | 备用仪表/HUD | `912,1112,736,296` | standby 仪表与 pack 所需的 HUD 小区域 |
+画布尺寸固定为 `880x1440`，对应当前实际部署里从超宽屏左侧导出带裁出来的 3 屏竖排区域。
+
+| region_id | 中文名 | 位置与尺寸 (x,y,w,h) | 对应 DCS 原生视口 | 主要内容 |
+| --- | --- | --- | --- | --- |
+| `left_ddi` | 左 DDI | `216,24,448,448` | `LEFT_MFCD` | 左 DDI 页面，如 FCS/HSI |
+| `ampcd` | AMPCD | `216,496,448,448` | `CENTER_MFCD` | 中央 AMPCD 页面文字与符号 |
+| `right_ddi` | 右 DDI | `216,968,448,448` | `RIGHT_MFCD` | 右 DDI 页面，如 BIT/FCS |
 
 ## 步骤优先级边界
 
-优先依赖组合图：
+优先依赖原生视口：
 
-- `S02`
-- `S07`
 - `S08`
-- `S09`
 - `S15`
 - `S18`
-- `S21`
-- `S22`
-- `S23`
-- `S24`
-- `S25`
 
 仍优先依赖 DCS-BIOS：
 
 - `S01`
 - `S03`
 - `S04`
+- `S05`
 - `S06`
+- `S07`
+- `S09`
 - `S10`
+- `S11`
 - `S12`
 - `S13`
+- `S21`
 
-当前不归入首版组合图优先范围，属于手工确认或布局外：
+当前不归入首版原生视口优先范围，属于手工确认或布局外：
 
-- `S05`
-- `S11`
+- `S02`
 - `S14`
 - `S16`
 - `S17`
 - `S19`
 - `S20`
+- `S22`
+- `S23`
+- `S24`
+- `S25`
 
 ## 样例图
 
 - 资产路径：`Doc/Vision/assets/fa18c_composite_panel_v1.svg`
-- 样例图按冻结版式生成，仅用于验证区域命名、裁切稳定性和人工可读性
+- 样例图只用于验证 3 个 `region_id` 的命名、顺序和边框，不表示主视角布局
 
-## 三屏真视口 PoC（首轮）
+## 当前实际导出方案
 
-- 首轮只验证 `left_ddi`、`ampcd`、`right_ddi`
-- 这三块通过 DCS 原生 `LEFT_MFCD`、`CENTER_MFCD`、`RIGHT_MFCD` monitor viewport 导出
-- 组合画布固定放在主屏右侧扩展桌面，尺寸固定为 `2560x1440`
-- 生成安装命令：
+当前冻结的实际显示方案是 `3440x1440` 单屏超宽模式：
 
-```bash
-python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode extended-right --main-width 1920 --main-height 1080
-```
+- DCS monitor setup 使用 `ultrawide-left-stack`
+- 左侧 `880px` 窄条竖排导出 3 块原生视口
+- 右侧保留完整 `2560x1440` 的 `16:9` 正常游戏画面
+- VLM 侧只应消费左侧这块 `880x1440` 导出带，不能把右侧主视角送进模型
 
-- 安装后需要在 DCS Options 中选择 `SimTutor_FA18C_CompositePanel_v1`
-- 推荐总分辨率为 `main_width + 2560` 乘以 `max(main_height, 1440)`
-- 本轮不包含 `warning_panel`、`ufc`、`ifei`、`standby_hud` 的真视口导出
-- 如果只有一块屏幕，可改用单屏模式：
-
-```bash
-python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode single-monitor --main-width 1920 --main-height 1080
-```
-
-- 单屏模式会把三块 MFCD/AMPCD 缩放排在屏幕上半区，主视角放在下半区
-- 如果是 `3440x1440` 这类 21:9 屏幕，更推荐超宽屏模式：
+安装命令：
 
 ```bash
 python -m tools.install_dcs_monitor_setup --dcs-variant DCS --mode ultrawide-left-stack --main-width 3440 --main-height 1440
 ```
 
-- 该模式会把三块导出屏竖着排在最左侧多出来的窄条里，右侧保留完整 `2560x1440` 的 `16:9` 主视角
+安装后：
+
+- 在 DCS Options 中选择 `SimTutor_FA18C_CompositePanel_v1`
+- 分辨率设为 `3440x1440`
+- 如果只是临时调试，`single-monitor` 和 `extended-right` 仍可用，但它们不再是冻结后的标准视觉 contract

--- a/Doc/Vision/fa18c_composite_panel_ZH_v2.md
+++ b/Doc/Vision/fa18c_composite_panel_ZH_v2.md
@@ -1,0 +1,96 @@
+# F/A-18C 归一化原生视口布局 v2
+
+`layout_id`: `fa18c_composite_panel_v2`
+
+本文件冻结当前 v0.4 视觉输入 contract 的 v2 版本。v2 不再以像素坐标作为权威，而是以“整屏上的左侧导出带 + 导出带内部 3 个 region”的归一化几何作为唯一真源。
+
+## 固定视觉范围
+
+- `left_ddi`
+- `ampcd`
+- `right_ddi`
+
+其余证据仍优先走 DCS-BIOS，包括：
+
+- `MASTER CAUTION` 与左右告警/注意/提示灯
+- `IFEI` 数字与 BINGO
+- `UFC` scratchpad、option displays、COMM1/COMM2 显示
+- standby / HUD
+
+## v2 几何规则
+
+- 第一步：按整屏归一化 `strip` 切出左侧导出带
+- 第二步：按 `strip` 内部归一化 `regions` 切出 3 块视口
+- 后续 VLM 不允许直接按全屏像素硬切 `left_ddi / ampcd / right_ddi`
+
+`strip_norm` 当前冻结为：
+
+- `anchor: left`
+- `x_norm: 0.0`
+- `y_norm: 0.0`
+- `height_norm: 1.0`
+- `target_aspect_ratio: 880 / 1440`
+- `min_main_view_width_px: 640`
+
+## region 顺序
+
+顺序固定为：
+
+- `left_ddi`
+- `ampcd`
+- `right_ddi`
+
+禁止任何别名漂移，例如把 `ampcd` 写成 `mpcd`。
+
+## 参考资产
+
+- strip 预览：`Doc/Vision/assets/fa18c_composite_panel_v2.svg`
+- 全屏结构图：`Doc/Vision/assets/fa18c_composite_panel_fullscreen_v2.svg`
+
+说明：
+
+- 两张 SVG 都使用英文标签
+- strip 预览图只展示导出带内部结构
+- 全屏结构图只展示“左侧导出带 + 右侧模拟器主画面”的归一化关系，不绑定具体物理分辨率
+
+## 步骤优先级边界
+
+优先依赖原生视口：
+
+- `S08`
+- `S15`
+- `S18`
+
+仍优先依赖 DCS-BIOS：
+
+- `S01`
+- `S03`
+- `S04`
+- `S05`
+- `S06`
+- `S07`
+- `S09`
+- `S10`
+- `S11`
+- `S12`
+- `S13`
+- `S21`
+
+当前不归入首版原生视口优先范围，属于手工确认或布局外：
+
+- `S02`
+- `S14`
+- `S16`
+- `S17`
+- `S19`
+- `S20`
+- `S22`
+- `S23`
+- `S24`
+- `S25`
+
+## Monitor Setup 行为
+
+- `single-monitor` 与 `ultrawide-left-stack` 共享同一套 normalized left-stack solver
+- `extended-right` 保留为调试模式，但其 3 块视口也由同一套 normalized region 几何求解
+- 这意味着后续采帧、切图、VLM 引用都只需要维护一套几何逻辑

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ Relevant DCS-side scripts live under:
 ### Typical Live Bring-Up
 
 1. Install the hook files with `python -m tools.install_dcs_hook`.
-2. If you are testing the viewport PoC, install the monitor setup with `python -m tools.install_dcs_monitor_setup --mode <extended-right|single-monitor> --main-width <screen_width> --main-height <screen_height>`.
+2. If you are testing the viewport PoC, install the monitor setup with `python -m tools.install_dcs_monitor_setup --mode <extended-right|ultrawide-left-stack|single-monitor> --main-width <screen_width> --main-height <screen_height>`.
 3. For `extended-right`, ensure a right-side extended desktop region exists with at least `2560x1440` pixels.
 4. In DCS Options, select `SimTutor_FA18C_CompositePanel_v1` as the monitor setup and set the total resolution to the tool's printed recommended resolution.
 5. Ensure DCS or DCS.openbeta loads the copied Lua files.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,36 @@ Install the DCS hook files into Saved Games:
 python -m tools.install_dcs_hook --dcs-variant DCS
 ```
 
+Install the monitor setup for the F/A-18C three-screen viewport PoC:
+
+```bash
+python -m tools.install_dcs_monitor_setup \
+  --dcs-variant DCS \
+  --mode extended-right \
+  --main-width 1920 \
+  --main-height 1080
+```
+
+Install the single-monitor variant that places left/center/right MFCDs on the top band of one screen:
+
+```bash
+python -m tools.install_dcs_monitor_setup \
+  --dcs-variant DCS \
+  --mode single-monitor \
+  --main-width 1920 \
+  --main-height 1080
+```
+
+Install the ultrawide variant that stacks the three exported screens in the extra left strip and keeps a full 16:9 main view on the right:
+
+```bash
+python -m tools.install_dcs_monitor_setup \
+  --dcs-variant DCS \
+  --mode ultrawide-left-stack \
+  --main-width 3440 \
+  --main-height 1440
+```
+
 ## Repository Layout
 
 - `core/`: pure domain logic, procedure engine, gating, scoring, overlay planning
@@ -530,9 +560,12 @@ Relevant DCS-side scripts live under:
 ### Typical Live Bring-Up
 
 1. Install the hook files with `python -m tools.install_dcs_hook`.
-2. Ensure DCS or DCS.openbeta loads the copied Lua files.
-3. Start `python live_dcs.py`.
-4. Trigger help with Enter on stdin or send `help` to the configured UDP help port.
+2. If you are testing the viewport PoC, install the monitor setup with `python -m tools.install_dcs_monitor_setup --mode <extended-right|single-monitor> --main-width <screen_width> --main-height <screen_height>`.
+3. For `extended-right`, ensure a right-side extended desktop region exists with at least `2560x1440` pixels.
+4. In DCS Options, select `SimTutor_FA18C_CompositePanel_v1` as the monitor setup and set the total resolution to the tool's printed recommended resolution.
+5. Ensure DCS or DCS.openbeta loads the copied Lua files.
+6. Start `python live_dcs.py`.
+7. Trigger help with Enter on stdin or send `help` to the configured UDP help port.
 
 ## Output Artifacts
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ python -m tools.install_dcs_monitor_setup \
   --main-height 1080
 ```
 
+Note: the generated DCS monitor-setup file/profile name remains `SimTutor_FA18C_CompositePanel_v1` for Saved Games compatibility, while the active vision layout contract is `fa18c_composite_panel_v2`.
+
 Install the single-monitor variant that solves the normalized left-stack layout on one screen and keeps the main view on the right:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Install the DCS hook files into Saved Games:
 python -m tools.install_dcs_hook --dcs-variant DCS
 ```
 
-Install the monitor setup for the F/A-18C three-screen viewport PoC:
+Install the monitor setup for the F/A-18C normalized three-viewport PoC:
 
 ```bash
 python -m tools.install_dcs_monitor_setup \
@@ -96,7 +96,7 @@ python -m tools.install_dcs_monitor_setup \
   --main-height 1080
 ```
 
-Install the single-monitor variant that places left/center/right MFCDs on the top band of one screen:
+Install the single-monitor variant that solves the normalized left-stack layout on one screen and keeps the main view on the right:
 
 ```bash
 python -m tools.install_dcs_monitor_setup \
@@ -106,7 +106,7 @@ python -m tools.install_dcs_monitor_setup \
   --main-height 1080
 ```
 
-Install the ultrawide variant that stacks the three exported screens in the extra left strip and keeps a full 16:9 main view on the right:
+Install the ultrawide variant that solves the same normalized left-stack layout on an ultrawide screen:
 
 ```bash
 python -m tools.install_dcs_monitor_setup \
@@ -561,8 +561,8 @@ Relevant DCS-side scripts live under:
 
 1. Install the hook files with `python -m tools.install_dcs_hook`.
 2. If you are testing the viewport PoC, install the monitor setup with `python -m tools.install_dcs_monitor_setup --mode <extended-right|ultrawide-left-stack|single-monitor> --main-width <screen_width> --main-height <screen_height>`.
-3. The frozen v0.4 visual contract only uses the native `LEFT_MFCD`, `CENTER_MFCD`(`AMPCD`), and `RIGHT_MFCD` exports; all other evidence should come from DCS-BIOS.
-4. In DCS Options, select `SimTutor_FA18C_CompositePanel_v1` as the monitor setup and set the total resolution to the tool's printed recommended resolution. On `3440x1440` ultrawide, `ultrawide-left-stack` is the reference layout.
+3. The frozen v0.4 visual contract only uses the native `LEFT_MFCD`, `CENTER_MFCD` (`AMPCD`), and `RIGHT_MFCD` exports; all other evidence should come from DCS-BIOS.
+4. In DCS Options, select `SimTutor_FA18C_CompositePanel_v1` as the monitor setup and set the total resolution to the tool's printed recommended resolution. `single-monitor` and `ultrawide-left-stack` now resolve the same normalized left-stack layout against different screen sizes.
 5. Ensure DCS or DCS.openbeta loads the copied Lua files.
 6. Start `python live_dcs.py`.
 7. Trigger help with Enter on stdin or send `help` to the configured UDP help port.

--- a/README.md
+++ b/README.md
@@ -561,8 +561,8 @@ Relevant DCS-side scripts live under:
 
 1. Install the hook files with `python -m tools.install_dcs_hook`.
 2. If you are testing the viewport PoC, install the monitor setup with `python -m tools.install_dcs_monitor_setup --mode <extended-right|ultrawide-left-stack|single-monitor> --main-width <screen_width> --main-height <screen_height>`.
-3. For `extended-right`, ensure a right-side extended desktop region exists with at least `2560x1440` pixels.
-4. In DCS Options, select `SimTutor_FA18C_CompositePanel_v1` as the monitor setup and set the total resolution to the tool's printed recommended resolution.
+3. The frozen v0.4 visual contract only uses the native `LEFT_MFCD`, `CENTER_MFCD`(`AMPCD`), and `RIGHT_MFCD` exports; all other evidence should come from DCS-BIOS.
+4. In DCS Options, select `SimTutor_FA18C_CompositePanel_v1` as the monitor setup and set the total resolution to the tool's printed recommended resolution. On `3440x1440` ultrawide, `ultrawide-left-stack` is the reference layout.
 5. Ensure DCS or DCS.openbeta loads the copied Lua files.
 6. Start `python live_dcs.py`.
 7. Trigger help with Enter on stdin or send `help` to the configured UDP help port.

--- a/adapters/vision_prompting.py
+++ b/adapters/vision_prompting.py
@@ -1,0 +1,301 @@
+"""
+Utilities for frozen composite-panel layout loading, scaling, prompt snippets,
+and SVG sample generation.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+VISION_REGION_ORDER: tuple[str, ...] = (
+    "left_ddi",
+    "ampcd",
+    "right_ddi",
+    "warning_panel",
+    "ufc",
+    "ifei",
+    "standby_hud",
+)
+DEFAULT_LAYOUT_ID = "fa18c_composite_panel_v1"
+
+_REGION_FILL_BY_ID: dict[str, str] = {
+    "left_ddi": "#18272d",
+    "ampcd": "#1b3138",
+    "right_ddi": "#18272d",
+    "warning_panel": "#3d251e",
+    "ufc": "#2c2f34",
+    "ifei": "#202b24",
+    "standby_hud": "#203037",
+}
+_REGION_ACCENT_BY_ID: dict[str, str] = {
+    "left_ddi": "#74d1ff",
+    "ampcd": "#6ee7c8",
+    "right_ddi": "#74d1ff",
+    "warning_panel": "#ff8b6b",
+    "ufc": "#f6d365",
+    "ifei": "#b7f171",
+    "standby_hud": "#b9c7ff",
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def default_vision_layout_path() -> Path:
+    return _repo_root() / "packs" / "fa18c_startup" / "vision_layout.yaml"
+
+
+def _resolve_vision_layout_path(path: str | Path | None) -> Path:
+    return Path(path) if path is not None else default_vision_layout_path()
+
+
+def _require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def _require_positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return _require_mapping(data, f"vision layout YAML at {path}")
+
+
+def _validate_region(region: Mapping[str, Any], *, canvas_width: int, canvas_height: int) -> dict[str, Any]:
+    normalized = {
+        "region_id": region.get("region_id"),
+        "display_name_zh": region.get("display_name_zh"),
+        "display_name_en": region.get("display_name_en"),
+        "x": region.get("x"),
+        "y": region.get("y"),
+        "width": region.get("width"),
+        "height": region.get("height"),
+        "intended_contents": region.get("intended_contents"),
+        "background_style": region.get("background_style"),
+        "ocr_priority": region.get("ocr_priority"),
+    }
+    region_id = normalized["region_id"]
+    if not isinstance(region_id, str) or not region_id:
+        raise ValueError("vision layout region_id must be a non-empty string")
+    if not isinstance(normalized["display_name_zh"], str) or not normalized["display_name_zh"]:
+        raise ValueError(f"vision layout region {region_id} missing display_name_zh")
+    if not isinstance(normalized["display_name_en"], str) or not normalized["display_name_en"]:
+        raise ValueError(f"vision layout region {region_id} missing display_name_en")
+    for key in ("x", "y", "width", "height"):
+        normalized[key] = _require_positive_int(normalized[key], f"vision layout region {region_id}.{key}")
+    if not isinstance(normalized["intended_contents"], list) or not normalized["intended_contents"]:
+        raise ValueError(f"vision layout region {region_id} intended_contents must be a non-empty list")
+    if not all(isinstance(item, str) and item for item in normalized["intended_contents"]):
+        raise ValueError(f"vision layout region {region_id} intended_contents must contain non-empty strings")
+    if not isinstance(normalized["background_style"], str) or not normalized["background_style"]:
+        raise ValueError(f"vision layout region {region_id} missing background_style")
+    if normalized["ocr_priority"] not in {"high", "medium", "low"}:
+        raise ValueError(f"vision layout region {region_id} ocr_priority must be high/medium/low")
+    if normalized["x"] + normalized["width"] > canvas_width:
+        raise ValueError(f"vision layout region {region_id} exceeds canvas width")
+    if normalized["y"] + normalized["height"] > canvas_height:
+        raise ValueError(f"vision layout region {region_id} exceeds canvas height")
+    return normalized
+
+
+def _check_non_overlapping_regions(regions: list[dict[str, Any]]) -> None:
+    for idx, current in enumerate(regions):
+        left_a = current["x"]
+        top_a = current["y"]
+        right_a = left_a + current["width"]
+        bottom_a = top_a + current["height"]
+        for other in regions[idx + 1 :]:
+            left_b = other["x"]
+            top_b = other["y"]
+            right_b = left_b + other["width"]
+            bottom_b = top_b + other["height"]
+            overlaps = left_a < right_b and right_a > left_b and top_a < bottom_b and bottom_a > top_b
+            if overlaps:
+                raise ValueError(
+                    f"vision layout regions overlap: {current['region_id']} vs {other['region_id']}"
+                )
+
+
+def _normalize_layout(data: Mapping[str, Any]) -> dict[str, Any]:
+    layout_id = data.get("layout_id")
+    if not isinstance(layout_id, str) or not layout_id:
+        raise ValueError("vision layout missing layout_id")
+    if layout_id != DEFAULT_LAYOUT_ID:
+        raise ValueError(f"unsupported vision layout id: {layout_id}")
+
+    canvas = _require_mapping(data.get("canvas"), "vision layout canvas")
+    canvas_width = _require_positive_int(canvas.get("width"), "vision layout canvas.width")
+    canvas_height = _require_positive_int(canvas.get("height"), "vision layout canvas.height")
+
+    background = _require_mapping(data.get("background"), "vision layout background")
+    if not isinstance(background.get("style"), str) or not background["style"]:
+        raise ValueError("vision layout background.style must be a non-empty string")
+    if not isinstance(background.get("fill"), str) or not background["fill"]:
+        raise ValueError("vision layout background.fill must be a non-empty string")
+    if not isinstance(background.get("description"), str) or not background["description"]:
+        raise ValueError("vision layout background.description must be a non-empty string")
+
+    raw_regions = data.get("regions")
+    if not isinstance(raw_regions, list) or not raw_regions:
+        raise ValueError("vision layout regions must be a non-empty list")
+
+    normalized_regions = [
+        _validate_region(
+            _require_mapping(region, "vision layout region"),
+            canvas_width=canvas_width,
+            canvas_height=canvas_height,
+        )
+        for region in raw_regions
+    ]
+    region_order = tuple(region["region_id"] for region in normalized_regions)
+    if region_order != VISION_REGION_ORDER:
+        raise ValueError(f"vision layout region order must be {VISION_REGION_ORDER!r}")
+    _check_non_overlapping_regions(normalized_regions)
+
+    return {
+        "layout_id": layout_id,
+        "title": data.get("title") if isinstance(data.get("title"), str) else layout_id,
+        "description": data.get("description") if isinstance(data.get("description"), str) else "",
+        "canvas": {"width": canvas_width, "height": canvas_height},
+        "background": {
+            "style": background["style"],
+            "fill": background["fill"],
+            "description": background["description"],
+        },
+        "regions": normalized_regions,
+    }
+
+
+@lru_cache(maxsize=4)
+def _cached_layout(path_str: str) -> dict[str, Any]:
+    return _normalize_layout(_load_yaml(Path(path_str)))
+
+
+def load_vision_layout(path: str | Path | None = None) -> dict[str, Any]:
+    resolved = _resolve_vision_layout_path(path).resolve()
+    return _cached_layout(str(resolved))
+
+
+def scale_layout_regions(
+    layout: Mapping[str, Any],
+    *,
+    output_width: int,
+    output_height: int,
+) -> dict[str, Any]:
+    target_width = _require_positive_int(output_width, "output_width")
+    target_height = _require_positive_int(output_height, "output_height")
+    canvas = _require_mapping(layout.get("canvas"), "layout canvas")
+    base_width = _require_positive_int(canvas.get("width"), "layout canvas.width")
+    base_height = _require_positive_int(canvas.get("height"), "layout canvas.height")
+
+    scale = min(target_width / base_width, target_height / base_height)
+    offset_x = int(round((target_width - base_width * scale) / 2))
+    offset_y = int(round((target_height - base_height * scale) / 2))
+
+    scaled_regions: list[dict[str, Any]] = []
+    for region in layout.get("regions", []):
+        region_map = _require_mapping(region, "layout region")
+        scaled_regions.append(
+            {
+                "region_id": region_map["region_id"],
+                "display_name_zh": region_map["display_name_zh"],
+                "display_name_en": region_map["display_name_en"],
+                "x": offset_x + int(round(int(region_map["x"]) * scale)),
+                "y": offset_y + int(round(int(region_map["y"]) * scale)),
+                "width": int(round(int(region_map["width"]) * scale)),
+                "height": int(round(int(region_map["height"]) * scale)),
+            }
+        )
+
+    return {
+        "layout_id": layout.get("layout_id"),
+        "canvas": {"width": target_width, "height": target_height},
+        "scale": scale,
+        "offset_x": offset_x,
+        "offset_y": offset_y,
+        "regions": scaled_regions,
+    }
+
+
+def build_vlm_region_prompt(layout: Mapping[str, Any] | None = None, *, lang: str = "zh") -> str:
+    current_layout = layout or load_vision_layout()
+    segments: list[str] = []
+    for region in current_layout["regions"]:
+        region_id = region["region_id"]
+        label = region["display_name_zh"] if lang == "zh" else region["display_name_en"]
+        segments.append(f"{region_id}={label}")
+    if lang == "zh":
+        return (
+            "固定组合图区域命名（按顺序引用，禁止使用任何显示器别名）："
+            + "; ".join(segments)
+            + "。引用时必须使用 region_id。"
+        )
+    return (
+        "Frozen composite-panel region names (reference in order; do not use any display aliases): "
+        + "; ".join(segments)
+        + ". Always cite the region_id verbatim."
+    )
+
+
+def render_layout_svg(layout: Mapping[str, Any] | None = None) -> str:
+    current_layout = layout or load_vision_layout()
+    canvas = current_layout["canvas"]
+    width = canvas["width"]
+    height = canvas["height"]
+    background = current_layout["background"]
+    lines = [
+        '<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1440" viewBox="0 0 2560 1440" role="img" aria-labelledby="title desc">',
+        f"  <title id=\"title\">{current_layout['title']}</title>",
+        f"  <desc id=\"desc\">{background['description']}</desc>",
+        f"  <rect width=\"{width}\" height=\"{height}\" fill=\"{background['fill']}\" />",
+        "  <g font-family=\"DejaVu Sans Mono, monospace\">",
+    ]
+    for region in current_layout["regions"]:
+        region_id = region["region_id"]
+        fill = _REGION_FILL_BY_ID.get(region_id, "#22303a")
+        accent = _REGION_ACCENT_BY_ID.get(region_id, "#a5d6ff")
+        x = region["x"]
+        y = region["y"]
+        w = region["width"]
+        h = region["height"]
+        title_y = y + 62
+        subtitle_y = y + 112
+        content_y = y + h - 44
+        lines.extend(
+            [
+                f"    <g id=\"{region_id}\">",
+                f"      <rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" rx=\"26\" ry=\"26\" fill=\"{fill}\" stroke=\"{accent}\" stroke-width=\"6\" />",
+                f"      <text x=\"{x + 28}\" y=\"{title_y}\" fill=\"#f4f7fb\" font-size=\"40\" font-weight=\"700\">{region['display_name_en']}</text>",
+                f"      <text x=\"{x + 28}\" y=\"{subtitle_y}\" fill=\"{accent}\" font-size=\"28\">{region_id} · {region['display_name_zh']}</text>",
+                f"      <text x=\"{x + 28}\" y=\"{content_y}\" fill=\"#d0dae4\" font-size=\"24\">OCR priority: {region['ocr_priority']}</text>",
+                "    </g>",
+            ]
+        )
+    lines.extend(
+        [
+            "  </g>",
+            "</svg>",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "DEFAULT_LAYOUT_ID",
+    "VISION_REGION_ORDER",
+    "build_vlm_region_prompt",
+    "default_vision_layout_path",
+    "load_vision_layout",
+    "render_layout_svg",
+    "scale_layout_regions",
+]

--- a/adapters/vision_prompting.py
+++ b/adapters/vision_prompting.py
@@ -1,6 +1,6 @@
 """
-Utilities for frozen composite-panel layout loading, scaling, prompt snippets,
-and SVG sample generation.
+Utilities for the frozen native-viewport layout, scaling, prompt snippets, and
+SVG sample generation.
 """
 
 from __future__ import annotations
@@ -15,10 +15,6 @@ VISION_REGION_ORDER: tuple[str, ...] = (
     "left_ddi",
     "ampcd",
     "right_ddi",
-    "warning_panel",
-    "ufc",
-    "ifei",
-    "standby_hud",
 )
 DEFAULT_LAYOUT_ID = "fa18c_composite_panel_v1"
 
@@ -26,19 +22,11 @@ _REGION_FILL_BY_ID: dict[str, str] = {
     "left_ddi": "#18272d",
     "ampcd": "#1b3138",
     "right_ddi": "#18272d",
-    "warning_panel": "#3d251e",
-    "ufc": "#2c2f34",
-    "ifei": "#202b24",
-    "standby_hud": "#203037",
 }
 _REGION_ACCENT_BY_ID: dict[str, str] = {
     "left_ddi": "#74d1ff",
     "ampcd": "#6ee7c8",
     "right_ddi": "#74d1ff",
-    "warning_panel": "#ff8b6b",
-    "ufc": "#f6d365",
-    "ifei": "#b7f171",
-    "standby_hud": "#b9c7ff",
 }
 
 
@@ -236,12 +224,12 @@ def build_vlm_region_prompt(layout: Mapping[str, Any] | None = None, *, lang: st
         segments.append(f"{region_id}={label}")
     if lang == "zh":
         return (
-            "固定组合图区域命名（按顺序引用，禁止使用任何显示器别名）："
+            "固定原生视口区域命名（按顺序引用，禁止使用任何显示器别名）："
             + "; ".join(segments)
             + "。引用时必须使用 region_id。"
         )
     return (
-        "Frozen composite-panel region names (reference in order; do not use any display aliases): "
+        "Frozen native-viewport region names (reference in order; do not use any display aliases): "
         + "; ".join(segments)
         + ". Always cite the region_id verbatim."
     )
@@ -254,7 +242,7 @@ def render_layout_svg(layout: Mapping[str, Any] | None = None) -> str:
     height = canvas["height"]
     background = current_layout["background"]
     lines = [
-        '<svg xmlns="http://www.w3.org/2000/svg" width="2560" height="1440" viewBox="0 0 2560 1440" role="img" aria-labelledby="title desc">',
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
         f"  <title id=\"title\">{current_layout['title']}</title>",
         f"  <desc id=\"desc\">{background['description']}</desc>",
         f"  <rect width=\"{width}\" height=\"{height}\" fill=\"{background['fill']}\" />",

--- a/adapters/vision_prompting.py
+++ b/adapters/vision_prompting.py
@@ -320,6 +320,7 @@ def render_layout_svg(layout: Mapping[str, Any] | None = None) -> str:
         region_id = region["region_id"]
         fill = _REGION_FILL_BY_ID[region_id]
         accent = _REGION_ACCENT_BY_ID[region_id]
+        ocr_priority = region["ocr_priority"]
         x = int(round(width * float(region["x_norm"])))
         y = int(round(height * float(region["y_norm"])))
         w = int(round(width * float(region["width_norm"])))
@@ -330,7 +331,7 @@ def render_layout_svg(layout: Mapping[str, Any] | None = None) -> str:
                 f'      <rect x="{x}" y="{y}" width="{w}" height="{h}" rx="26" ry="26" fill="{fill}" stroke="{accent}" stroke-width="6" />',
                 f'      <text x="{x + 28}" y="{y + 62}" fill="#f4f7fb" font-size="40" font-weight="700">{region["display_name_en"]}</text>',
                 f'      <text x="{x + 28}" y="{y + 112}" fill="{accent}" font-size="28">{region_id}</text>',
-                f'      <text x="{x + 28}" y="{y + h - 44}" fill="#d0dae4" font-size="24">OCR priority: high</text>',
+                f'      <text x="{x + 28}" y="{y + h - 44}" fill="#d0dae4" font-size="24">OCR priority: {ocr_priority}</text>',
                 "    </g>",
             ]
         )

--- a/adapters/vision_prompting.py
+++ b/adapters/vision_prompting.py
@@ -1,6 +1,6 @@
 """
-Utilities for the frozen native-viewport layout, scaling, prompt snippets, and
-SVG sample generation.
+Utilities for the normalized native-viewport layout, geometry solving, prompt
+snippets, and SVG preview generation.
 """
 
 from __future__ import annotations
@@ -16,7 +16,9 @@ VISION_REGION_ORDER: tuple[str, ...] = (
     "ampcd",
     "right_ddi",
 )
-DEFAULT_LAYOUT_ID = "fa18c_composite_panel_v1"
+DEFAULT_LAYOUT_ID = "fa18c_composite_panel_v2"
+FULLSCREEN_PREVIEW_WIDTH = 1600
+FULLSCREEN_PREVIEW_HEIGHT = 900
 
 _REGION_FILL_BY_ID: dict[str, str] = {
     "left_ddi": "#18272d",
@@ -54,20 +56,77 @@ def _require_positive_int(value: Any, label: str) -> int:
     return value
 
 
+def _require_norm_float(value: Any, label: str, *, allow_zero: bool = True) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{label} must be a number")
+    normalized = float(value)
+    if allow_zero:
+        if normalized < 0.0 or normalized > 1.0:
+            raise ValueError(f"{label} must be within [0, 1]")
+    elif normalized <= 0.0 or normalized > 1.0:
+        raise ValueError(f"{label} must be within (0, 1]")
+    return normalized
+
+
+def _require_positive_float(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or float(value) <= 0.0:
+        raise ValueError(f"{label} must be a positive number")
+    return float(value)
+
+
 def _load_yaml(path: Path) -> dict[str, Any]:
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     return _require_mapping(data, f"vision layout YAML at {path}")
 
 
-def _validate_region(region: Mapping[str, Any], *, canvas_width: int, canvas_height: int) -> dict[str, Any]:
+def _validate_strip_norm(strip: Mapping[str, Any]) -> dict[str, Any]:
+    anchor = strip.get("anchor")
+    if anchor != "left":
+        raise ValueError("vision layout strip_norm.anchor must be 'left'")
+    normalized = {
+        "anchor": anchor,
+        "x_norm": _require_norm_float(strip.get("x_norm"), "vision layout strip_norm.x_norm"),
+        "y_norm": _require_norm_float(strip.get("y_norm"), "vision layout strip_norm.y_norm"),
+        "height_norm": _require_norm_float(
+            strip.get("height_norm"),
+            "vision layout strip_norm.height_norm",
+            allow_zero=False,
+        ),
+        "target_aspect_ratio": _require_positive_float(
+            strip.get("target_aspect_ratio"),
+            "vision layout strip_norm.target_aspect_ratio",
+        ),
+        "min_main_view_width_px": _require_positive_int(
+            strip.get("min_main_view_width_px"),
+            "vision layout strip_norm.min_main_view_width_px",
+        ),
+    }
+    if normalized["x_norm"] != 0.0:
+        raise ValueError("vision layout strip_norm.x_norm must currently be 0.0")
+    if normalized["y_norm"] != 0.0:
+        raise ValueError("vision layout strip_norm.y_norm must currently be 0.0")
+    if normalized["height_norm"] != 1.0:
+        raise ValueError("vision layout strip_norm.height_norm must currently be 1.0")
+    return normalized
+
+
+def _validate_region(region: Mapping[str, Any]) -> dict[str, Any]:
     normalized = {
         "region_id": region.get("region_id"),
         "display_name_zh": region.get("display_name_zh"),
         "display_name_en": region.get("display_name_en"),
-        "x": region.get("x"),
-        "y": region.get("y"),
-        "width": region.get("width"),
-        "height": region.get("height"),
+        "x_norm": _require_norm_float(region.get("x_norm"), "vision layout region.x_norm"),
+        "y_norm": _require_norm_float(region.get("y_norm"), "vision layout region.y_norm"),
+        "width_norm": _require_norm_float(
+            region.get("width_norm"),
+            "vision layout region.width_norm",
+            allow_zero=False,
+        ),
+        "height_norm": _require_norm_float(
+            region.get("height_norm"),
+            "vision layout region.height_norm",
+            allow_zero=False,
+        ),
         "intended_contents": region.get("intended_contents"),
         "background_style": region.get("background_style"),
         "ocr_priority": region.get("ocr_priority"),
@@ -79,8 +138,10 @@ def _validate_region(region: Mapping[str, Any], *, canvas_width: int, canvas_hei
         raise ValueError(f"vision layout region {region_id} missing display_name_zh")
     if not isinstance(normalized["display_name_en"], str) or not normalized["display_name_en"]:
         raise ValueError(f"vision layout region {region_id} missing display_name_en")
-    for key in ("x", "y", "width", "height"):
-        normalized[key] = _require_positive_int(normalized[key], f"vision layout region {region_id}.{key}")
+    if normalized["x_norm"] + normalized["width_norm"] > 1.0:
+        raise ValueError(f"vision layout region {region_id} exceeds strip width")
+    if normalized["y_norm"] + normalized["height_norm"] > 1.0:
+        raise ValueError(f"vision layout region {region_id} exceeds strip height")
     if not isinstance(normalized["intended_contents"], list) or not normalized["intended_contents"]:
         raise ValueError(f"vision layout region {region_id} intended_contents must be a non-empty list")
     if not all(isinstance(item, str) and item for item in normalized["intended_contents"]):
@@ -89,24 +150,20 @@ def _validate_region(region: Mapping[str, Any], *, canvas_width: int, canvas_hei
         raise ValueError(f"vision layout region {region_id} missing background_style")
     if normalized["ocr_priority"] not in {"high", "medium", "low"}:
         raise ValueError(f"vision layout region {region_id} ocr_priority must be high/medium/low")
-    if normalized["x"] + normalized["width"] > canvas_width:
-        raise ValueError(f"vision layout region {region_id} exceeds canvas width")
-    if normalized["y"] + normalized["height"] > canvas_height:
-        raise ValueError(f"vision layout region {region_id} exceeds canvas height")
     return normalized
 
 
 def _check_non_overlapping_regions(regions: list[dict[str, Any]]) -> None:
     for idx, current in enumerate(regions):
-        left_a = current["x"]
-        top_a = current["y"]
-        right_a = left_a + current["width"]
-        bottom_a = top_a + current["height"]
+        left_a = current["x_norm"]
+        top_a = current["y_norm"]
+        right_a = left_a + current["width_norm"]
+        bottom_a = top_a + current["height_norm"]
         for other in regions[idx + 1 :]:
-            left_b = other["x"]
-            top_b = other["y"]
-            right_b = left_b + other["width"]
-            bottom_b = top_b + other["height"]
+            left_b = other["x_norm"]
+            top_b = other["y_norm"]
+            right_b = left_b + other["width_norm"]
+            bottom_b = top_b + other["height_norm"]
             overlaps = left_a < right_b and right_a > left_b and top_a < bottom_b and bottom_a > top_b
             if overlaps:
                 raise ValueError(
@@ -121,9 +178,9 @@ def _normalize_layout(data: Mapping[str, Any]) -> dict[str, Any]:
     if layout_id != DEFAULT_LAYOUT_ID:
         raise ValueError(f"unsupported vision layout id: {layout_id}")
 
-    canvas = _require_mapping(data.get("canvas"), "vision layout canvas")
-    canvas_width = _require_positive_int(canvas.get("width"), "vision layout canvas.width")
-    canvas_height = _require_positive_int(canvas.get("height"), "vision layout canvas.height")
+    logical_canvas = _require_mapping(data.get("logical_canvas"), "vision layout logical_canvas")
+    logical_width = _require_positive_int(logical_canvas.get("width"), "vision layout logical_canvas.width")
+    logical_height = _require_positive_int(logical_canvas.get("height"), "vision layout logical_canvas.height")
 
     background = _require_mapping(data.get("background"), "vision layout background")
     if not isinstance(background.get("style"), str) or not background["style"]:
@@ -133,20 +190,12 @@ def _normalize_layout(data: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(background.get("description"), str) or not background["description"]:
         raise ValueError("vision layout background.description must be a non-empty string")
 
+    strip_norm = _validate_strip_norm(_require_mapping(data.get("strip_norm"), "vision layout strip_norm"))
     raw_regions = data.get("regions")
     if not isinstance(raw_regions, list) or not raw_regions:
         raise ValueError("vision layout regions must be a non-empty list")
-
-    normalized_regions = [
-        _validate_region(
-            _require_mapping(region, "vision layout region"),
-            canvas_width=canvas_width,
-            canvas_height=canvas_height,
-        )
-        for region in raw_regions
-    ]
-    region_order = tuple(region["region_id"] for region in normalized_regions)
-    if region_order != VISION_REGION_ORDER:
+    normalized_regions = [_validate_region(_require_mapping(region, "vision layout region")) for region in raw_regions]
+    if tuple(region["region_id"] for region in normalized_regions) != VISION_REGION_ORDER:
         raise ValueError(f"vision layout region order must be {VISION_REGION_ORDER!r}")
     _check_non_overlapping_regions(normalized_regions)
 
@@ -154,12 +203,13 @@ def _normalize_layout(data: Mapping[str, Any]) -> dict[str, Any]:
         "layout_id": layout_id,
         "title": data.get("title") if isinstance(data.get("title"), str) else layout_id,
         "description": data.get("description") if isinstance(data.get("description"), str) else "",
-        "canvas": {"width": canvas_width, "height": canvas_height},
+        "logical_canvas": {"width": logical_width, "height": logical_height},
         "background": {
             "style": background["style"],
             "fill": background["fill"],
             "description": background["description"],
         },
+        "strip_norm": strip_norm,
         "regions": normalized_regions,
     }
 
@@ -174,7 +224,7 @@ def load_vision_layout(path: str | Path | None = None) -> dict[str, Any]:
     return _cached_layout(str(resolved))
 
 
-def scale_layout_regions(
+def solve_layout_geometry(
     layout: Mapping[str, Any],
     *,
     output_width: int,
@@ -182,37 +232,57 @@ def scale_layout_regions(
 ) -> dict[str, Any]:
     target_width = _require_positive_int(output_width, "output_width")
     target_height = _require_positive_int(output_height, "output_height")
-    canvas = _require_mapping(layout.get("canvas"), "layout canvas")
-    base_width = _require_positive_int(canvas.get("width"), "layout canvas.width")
-    base_height = _require_positive_int(canvas.get("height"), "layout canvas.height")
+    strip_norm = _require_mapping(layout.get("strip_norm"), "layout strip_norm")
+    strip_x = int(round(target_width * float(strip_norm["x_norm"])))
+    strip_y = int(round(target_height * float(strip_norm["y_norm"])))
+    strip_height = int(round(target_height * float(strip_norm["height_norm"])))
+    strip_width = int(round(strip_height * float(strip_norm["target_aspect_ratio"])))
+    min_main_view_width = int(strip_norm["min_main_view_width_px"])
+    max_strip_width = target_width - min_main_view_width
+    if max_strip_width <= 0:
+        raise ValueError("screen width is too small for the normalized left-stack layout")
+    if strip_width > max_strip_width:
+        strip_width = max_strip_width
+    if strip_x + strip_width > target_width:
+        raise ValueError("resolved strip exceeds output width")
+    if strip_y + strip_height > target_height:
+        raise ValueError("resolved strip exceeds output height")
+    main_view_x = strip_x + strip_width
+    main_view_width = target_width - main_view_x
+    if main_view_width < min_main_view_width:
+        raise ValueError("resolved main view width is below the configured minimum")
 
-    scale = min(target_width / base_width, target_height / base_height)
-    offset_x = int(round((target_width - base_width * scale) / 2))
-    offset_y = int(round((target_height - base_height * scale) / 2))
-
-    scaled_regions: list[dict[str, Any]] = []
+    resolved_regions: list[dict[str, Any]] = []
     for region in layout.get("regions", []):
         region_map = _require_mapping(region, "layout region")
-        scaled_regions.append(
+        resolved_regions.append(
             {
                 "region_id": region_map["region_id"],
                 "display_name_zh": region_map["display_name_zh"],
                 "display_name_en": region_map["display_name_en"],
-                "x": offset_x + int(round(int(region_map["x"]) * scale)),
-                "y": offset_y + int(round(int(region_map["y"]) * scale)),
-                "width": int(round(int(region_map["width"]) * scale)),
-                "height": int(round(int(region_map["height"]) * scale)),
+                "x": strip_x + int(round(strip_width * float(region_map["x_norm"]))),
+                "y": strip_y + int(round(strip_height * float(region_map["y_norm"]))),
+                "width": int(round(strip_width * float(region_map["width_norm"]))),
+                "height": int(round(strip_height * float(region_map["height_norm"]))),
             }
         )
 
     return {
         "layout_id": layout.get("layout_id"),
         "canvas": {"width": target_width, "height": target_height},
-        "scale": scale,
-        "offset_x": offset_x,
-        "offset_y": offset_y,
-        "regions": scaled_regions,
+        "strip_rect": {"x": strip_x, "y": strip_y, "width": strip_width, "height": strip_height},
+        "main_view_rect": {"x": main_view_x, "y": 0, "width": main_view_width, "height": target_height},
+        "regions": resolved_regions,
     }
+
+
+def scale_layout_regions(
+    layout: Mapping[str, Any],
+    *,
+    output_width: int,
+    output_height: int,
+) -> dict[str, Any]:
+    return solve_layout_geometry(layout, output_width=output_width, output_height=output_height)
 
 
 def build_vlm_region_prompt(layout: Mapping[str, Any] | None = None, *, lang: str = "zh") -> str:
@@ -223,11 +293,7 @@ def build_vlm_region_prompt(layout: Mapping[str, Any] | None = None, *, lang: st
         label = region["display_name_zh"] if lang == "zh" else region["display_name_en"]
         segments.append(f"{region_id}={label}")
     if lang == "zh":
-        return (
-            "固定原生视口区域命名（按顺序引用，禁止使用任何显示器别名）："
-            + "; ".join(segments)
-            + "。引用时必须使用 region_id。"
-        )
+        return "固定原生视口区域命名（按顺序引用，禁止使用任何显示器别名）：" + "; ".join(segments) + "。引用时必须使用 region_id。"
     return (
         "Frozen native-viewport region names (reference in order; do not use any display aliases): "
         + "; ".join(segments)
@@ -237,53 +303,97 @@ def build_vlm_region_prompt(layout: Mapping[str, Any] | None = None, *, lang: st
 
 def render_layout_svg(layout: Mapping[str, Any] | None = None) -> str:
     current_layout = layout or load_vision_layout()
-    canvas = current_layout["canvas"]
-    width = canvas["width"]
-    height = canvas["height"]
+    logical_canvas = current_layout["logical_canvas"]
+    width = logical_canvas["width"]
+    height = logical_canvas["height"]
     background = current_layout["background"]
     lines = [
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-labelledby="title desc">',
-        f"  <title id=\"title\">{current_layout['title']}</title>",
-        f"  <desc id=\"desc\">{background['description']}</desc>",
-        f"  <rect width=\"{width}\" height=\"{height}\" fill=\"{background['fill']}\" />",
-        "  <g font-family=\"DejaVu Sans Mono, monospace\">",
+        f'  <title id="title">{current_layout["title"]} Strip Preview</title>',
+        f'  <desc id="desc">{background["description"]}</desc>',
+        f'  <rect width="{width}" height="{height}" fill="{background["fill"]}" />',
+        '  <g font-family="DejaVu Sans Mono, monospace">',
+        '    <text x="28" y="48" fill="#d9e2ea" font-size="24" font-weight="700">Normalized Export Strip</text>',
+        '    <text x="28" y="80" fill="#8ba1b3" font-size="18">Three native display exports resolved inside the left stack.</text>',
     ]
     for region in current_layout["regions"]:
         region_id = region["region_id"]
-        fill = _REGION_FILL_BY_ID.get(region_id, "#22303a")
-        accent = _REGION_ACCENT_BY_ID.get(region_id, "#a5d6ff")
+        fill = _REGION_FILL_BY_ID[region_id]
+        accent = _REGION_ACCENT_BY_ID[region_id]
+        x = int(round(width * float(region["x_norm"])))
+        y = int(round(height * float(region["y_norm"])))
+        w = int(round(width * float(region["width_norm"])))
+        h = int(round(height * float(region["height_norm"])))
+        lines.extend(
+            [
+                f'    <g id="{region_id}">',
+                f'      <rect x="{x}" y="{y}" width="{w}" height="{h}" rx="26" ry="26" fill="{fill}" stroke="{accent}" stroke-width="6" />',
+                f'      <text x="{x + 28}" y="{y + 62}" fill="#f4f7fb" font-size="40" font-weight="700">{region["display_name_en"]}</text>',
+                f'      <text x="{x + 28}" y="{y + 112}" fill="{accent}" font-size="28">{region_id}</text>',
+                f'      <text x="{x + 28}" y="{y + h - 44}" fill="#d0dae4" font-size="24">OCR priority: high</text>',
+                "    </g>",
+            ]
+        )
+    lines.extend(["  </g>", "</svg>"])
+    return "\n".join(lines) + "\n"
+
+
+def render_fullscreen_layout_svg(
+    layout: Mapping[str, Any] | None = None,
+    *,
+    output_width: int = FULLSCREEN_PREVIEW_WIDTH,
+    output_height: int = FULLSCREEN_PREVIEW_HEIGHT,
+) -> str:
+    current_layout = layout or load_vision_layout()
+    solved = solve_layout_geometry(current_layout, output_width=output_width, output_height=output_height)
+    strip_rect = solved["strip_rect"]
+    main_rect = solved["main_view_rect"]
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{output_width}" height="{output_height}" viewBox="0 0 {output_width} {output_height}" role="img" aria-labelledby="title desc">',
+        '  <title id="title">F/A-18C Normalized Full-Screen Layout Diagram</title>',
+        '  <desc id="desc">Generic full-screen diagram showing the normalized export strip on the left and the main simulator view on the right.</desc>',
+        '  <rect width="100%" height="100%" fill="#0d1216" />',
+        f'  <rect x="{main_rect["x"]}" y="{main_rect["y"]}" width="{main_rect["width"]}" height="{main_rect["height"]}" fill="#101d28" stroke="#415564" stroke-width="2" />',
+        f'  <rect x="{strip_rect["x"]}" y="{strip_rect["y"]}" width="{strip_rect["width"]}" height="{strip_rect["height"]}" fill="#101416" stroke="#8ca4b8" stroke-width="3" />',
+        '  <g font-family="DejaVu Sans Mono, monospace">',
+        f'    <text x="{main_rect["x"] + 28}" y="46" fill="#f0f4f8" font-size="24" font-weight="700">Main Simulator View</text>',
+        f'    <text x="{main_rect["x"] + 28}" y="76" fill="#8aa0b2" font-size="18">The playable camera occupies the remaining screen space.</text>',
+        f'    <text x="{strip_rect["x"] + 24}" y="46" fill="#f0f4f8" font-size="24" font-weight="700">Export Strip</text>',
+        f'    <text x="{strip_rect["x"] + 24}" y="76" fill="#8aa0b2" font-size="18">VLM input is cut from this strip first, then split into three regions.</text>',
+        f'    <line x1="{main_rect["x"] + 40}" y1="{int(output_height * 0.55)}" x2="{output_width - 60}" y2="{int(output_height * 0.55)}" stroke="#4f6676" stroke-width="2" stroke-dasharray="8 8" />',
+        f'    <line x1="{main_rect["x"] + 40}" y1="{int(output_height * 0.70)}" x2="{output_width - 60}" y2="{int(output_height * 0.52)}" stroke="#38515e" stroke-width="2" />',
+    ]
+    for region in solved["regions"]:
+        region_id = region["region_id"]
+        fill = _REGION_FILL_BY_ID[region_id]
+        accent = _REGION_ACCENT_BY_ID[region_id]
         x = region["x"]
         y = region["y"]
         w = region["width"]
         h = region["height"]
-        title_y = y + 62
-        subtitle_y = y + 112
-        content_y = y + h - 44
         lines.extend(
             [
-                f"    <g id=\"{region_id}\">",
-                f"      <rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" rx=\"26\" ry=\"26\" fill=\"{fill}\" stroke=\"{accent}\" stroke-width=\"6\" />",
-                f"      <text x=\"{x + 28}\" y=\"{title_y}\" fill=\"#f4f7fb\" font-size=\"40\" font-weight=\"700\">{region['display_name_en']}</text>",
-                f"      <text x=\"{x + 28}\" y=\"{subtitle_y}\" fill=\"{accent}\" font-size=\"28\">{region_id} · {region['display_name_zh']}</text>",
-                f"      <text x=\"{x + 28}\" y=\"{content_y}\" fill=\"#d0dae4\" font-size=\"24\">OCR priority: {region['ocr_priority']}</text>",
+                f'    <g id="fullscreen_{region_id}">',
+                f'      <rect x="{x}" y="{y}" width="{w}" height="{h}" rx="20" ry="20" fill="{fill}" stroke="{accent}" stroke-width="4" />',
+                f'      <text x="{x + 18}" y="{y + 42}" fill="#f4f7fb" font-size="22" font-weight="700">{region["display_name_en"]}</text>',
+                f'      <text x="{x + 18}" y="{y + 70}" fill="{accent}" font-size="16">{region_id}</text>',
                 "    </g>",
             ]
         )
-    lines.extend(
-        [
-            "  </g>",
-            "</svg>",
-        ]
-    )
+    lines.extend(["  </g>", "</svg>"])
     return "\n".join(lines) + "\n"
 
 
 __all__ = [
     "DEFAULT_LAYOUT_ID",
+    "FULLSCREEN_PREVIEW_HEIGHT",
+    "FULLSCREEN_PREVIEW_WIDTH",
     "VISION_REGION_ORDER",
     "build_vlm_region_prompt",
     "default_vision_layout_path",
     "load_vision_layout",
+    "render_fullscreen_layout_svg",
     "render_layout_svg",
     "scale_layout_regions",
+    "solve_layout_geometry",
 ]

--- a/core/types_v2.py
+++ b/core/types_v2.py
@@ -61,6 +61,7 @@ class VisionObservation:
     session_id: Optional[str] = None
     observation_ref: Optional[str] = None
     channel: Optional[str] = None
+    layout_id: Optional[str] = None
     image_uri: Optional[str] = None
     mime_type: Optional[str] = None
     metadata: Dict[str, Any] = field(default_factory=dict)

--- a/packs/fa18c_startup/pack.yaml
+++ b/packs/fa18c_startup/pack.yaml
@@ -6,6 +6,35 @@ description: >
   Doc/Evaluation/fa18c_startup_master.md and Appendix - Training Task Syllabus.md.
 metadata:
   step_registry_path: step_registry.yaml
+  vision_layout_id: fa18c_composite_panel_v1
+  vision_priority_steps:
+    - S02
+    - S07
+    - S08
+    - S09
+    - S15
+    - S18
+    - S21
+    - S22
+    - S23
+    - S24
+    - S25
+  bios_priority_steps:
+    - S01
+    - S03
+    - S04
+    - S06
+    - S10
+    - S12
+    - S13
+  manual_or_out_of_layout_steps:
+    - S05
+    - S11
+    - S14
+    - S16
+    - S17
+    - S19
+    - S20
   source_documents:
     - Doc/Evaluation/fa18c_startup_master.md
     - Doc/Evaluation/Appendix - Training Task Syllabus.md

--- a/packs/fa18c_startup/pack.yaml
+++ b/packs/fa18c_startup/pack.yaml
@@ -6,7 +6,7 @@ description: >
   Doc/Evaluation/fa18c_startup_master.md and Appendix - Training Task Syllabus.md.
 metadata:
   step_registry_path: step_registry.yaml
-  vision_layout_id: fa18c_composite_panel_v1
+  vision_layout_id: fa18c_composite_panel_v2
   vision_priority_steps:
     - S08
     - S15

--- a/packs/fa18c_startup/pack.yaml
+++ b/packs/fa18c_startup/pack.yaml
@@ -8,40 +8,40 @@ metadata:
   step_registry_path: step_registry.yaml
   vision_layout_id: fa18c_composite_panel_v1
   vision_priority_steps:
-    - S02
-    - S07
     - S08
-    - S09
     - S15
     - S18
-    - S21
-    - S22
-    - S23
-    - S24
-    - S25
   bios_priority_steps:
     - S01
     - S03
     - S04
+    - S05
     - S06
+    - S07
+    - S09
     - S10
+    - S11
     - S12
     - S13
+    - S21
   manual_or_out_of_layout_steps:
-    - S05
-    - S11
+    - S02
     - S14
     - S16
     - S17
     - S19
     - S20
+    - S22
+    - S23
+    - S24
+    - S25
   source_documents:
     - Doc/Evaluation/fa18c_startup_master.md
     - Doc/Evaluation/Appendix - Training Task Syllabus.md
   notes: >
     Full cold-start procedure coverage for steps S01-S25 (phases P1-P6).
-    Pack-level gate maps prioritize observable signals and keep unknown steps
-    extensible for future VLM-assisted confirmation.
+    The frozen v0.4 visual contract only uses native left/right DDI plus AMPCD
+    exports; UFC, IFEI, and warning/advisory evidence should come from DCS-BIOS.
 
 prerequisites:
   - "Aircraft cold and dark at ramp or carrier; parking brake set."

--- a/packs/fa18c_startup/vision_layout.yaml
+++ b/packs/fa18c_startup/vision_layout.yaml
@@ -1,0 +1,97 @@
+layout_id: fa18c_composite_panel_v1
+title: "F/A-18C Composite Panel Layout v1"
+description: >
+  Fixed composite panel layout for v0.4 visual grounding. The goal is stable OCR
+  and annunciator recognition, not photoreal cockpit recreation.
+canvas:
+  width: 2560
+  height: 1440
+background:
+  style: matte_neutral_dark
+  fill: "#101416"
+  description: "Dark neutral matte background with no cockpit scenery or decorative texture."
+regions:
+  - region_id: left_ddi
+    display_name_zh: 左 DDI
+    display_name_en: Left DDI
+    x: 32
+    y: 32
+    width: 768
+    height: 768
+    intended_contents:
+      - "Left DDI pages such as FCS/HSI/ENG."
+      - "Display text and page-level annunciation."
+    background_style: display_cutout_dark
+    ocr_priority: high
+  - region_id: ampcd
+    display_name_zh: AMPCD
+    display_name_en: AMPCD
+    x: 896
+    y: 32
+    width: 768
+    height: 768
+    intended_contents:
+      - "AMPCD page state and center display text."
+      - "Page labels and display symbology."
+    background_style: display_cutout_dark
+    ocr_priority: high
+  - region_id: right_ddi
+    display_name_zh: 右 DDI
+    display_name_en: Right DDI
+    x: 1760
+    y: 32
+    width: 768
+    height: 768
+    intended_contents:
+      - "Right DDI pages such as BIT/FCS."
+      - "Display text and BIT result review."
+    background_style: display_cutout_dark
+    ocr_priority: high
+  - region_id: warning_panel
+    display_name_zh: 告警灯区
+    display_name_en: Warning Panel
+    x: 32
+    y: 832
+    width: 848
+    height: 248
+    intended_contents:
+      - "MASTER CAUTION and caution/warning/advisory lamps."
+      - "Engine fire and extinguisher related annunciators."
+    background_style: annunciator_panel_dark
+    ocr_priority: high
+  - region_id: ufc
+    display_name_zh: UFC
+    display_name_en: UFC
+    x: 912
+    y: 832
+    width: 736
+    height: 248
+    intended_contents:
+      - "UFC readouts, COMM channel state, and keypad area."
+      - "Mission radio frequency or preset confirmation."
+    background_style: keypad_panel_dark
+    ocr_priority: high
+  - region_id: ifei
+    display_name_zh: IFEI
+    display_name_en: IFEI
+    x: 1680
+    y: 832
+    width: 848
+    height: 248
+    intended_contents:
+      - "Integrated Fuel/Engine Indicator text and numeric values."
+      - "BINGO fuel confirmation and engine status references."
+    background_style: engine_indicator_dark
+    ocr_priority: high
+  - region_id: standby_hud
+    display_name_zh: 备用仪表/HUD
+    display_name_en: Standby / HUD
+    x: 912
+    y: 1112
+    width: 736
+    height: 296
+    intended_contents:
+      - "Standby attitude/altimeter area and any small HUD crop needed by the pack."
+      - "Visual-only standby instrument confirmation."
+    background_style: standby_cluster_dark
+    ocr_priority: medium

--- a/packs/fa18c_startup/vision_layout.yaml
+++ b/packs/fa18c_startup/vision_layout.yaml
@@ -1,97 +1,50 @@
 layout_id: fa18c_composite_panel_v1
-title: "F/A-18C Composite Panel Layout v1"
+title: "F/A-18C Native Viewport Layout v1"
 description: >
-  Fixed composite panel layout for v0.4 visual grounding. The goal is stable OCR
-  and annunciator recognition, not photoreal cockpit recreation.
+  Fixed native-viewport layout for v0.4 visual grounding. Only the three DCS
+  native display exports remain in the visual contract; UFC, IFEI, and warning
+  blocks are expected from DCS-BIOS instead of image crops.
 canvas:
-  width: 2560
+  width: 880
   height: 1440
 background:
   style: matte_neutral_dark
   fill: "#101416"
-  description: "Dark neutral matte background with no cockpit scenery or decorative texture."
+  description: "Dark neutral matte background for the three stacked native display exports, with no main camera view."
 regions:
   - region_id: left_ddi
     display_name_zh: 左 DDI
     display_name_en: Left DDI
-    x: 32
-    y: 32
-    width: 768
-    height: 768
+    x: 216
+    y: 24
+    width: 448
+    height: 448
     intended_contents:
-      - "Left DDI pages such as FCS/HSI/ENG."
-      - "Display text and page-level annunciation."
+      - "Native LEFT_MFCD export showing left DDI pages such as FCS or HSI."
+      - "Page text, page labels, and display-only step evidence."
     background_style: display_cutout_dark
     ocr_priority: high
   - region_id: ampcd
     display_name_zh: AMPCD
     display_name_en: AMPCD
-    x: 896
-    y: 32
-    width: 768
-    height: 768
+    x: 216
+    y: 496
+    width: 448
+    height: 448
     intended_contents:
-      - "AMPCD page state and center display text."
-      - "Page labels and display symbology."
+      - "Native CENTER_MFCD export showing AMPCD page state and center display text."
+      - "Page labels and display symbology required by pack steps."
     background_style: display_cutout_dark
     ocr_priority: high
   - region_id: right_ddi
     display_name_zh: 右 DDI
     display_name_en: Right DDI
-    x: 1760
-    y: 32
-    width: 768
-    height: 768
+    x: 216
+    y: 968
+    width: 448
+    height: 448
     intended_contents:
-      - "Right DDI pages such as BIT/FCS."
-      - "Display text and BIT result review."
+      - "Native RIGHT_MFCD export showing right DDI pages such as BIT or FCS."
+      - "Display text and BIT-result review."
     background_style: display_cutout_dark
     ocr_priority: high
-  - region_id: warning_panel
-    display_name_zh: 告警灯区
-    display_name_en: Warning Panel
-    x: 32
-    y: 832
-    width: 848
-    height: 248
-    intended_contents:
-      - "MASTER CAUTION and caution/warning/advisory lamps."
-      - "Engine fire and extinguisher related annunciators."
-    background_style: annunciator_panel_dark
-    ocr_priority: high
-  - region_id: ufc
-    display_name_zh: UFC
-    display_name_en: UFC
-    x: 912
-    y: 832
-    width: 736
-    height: 248
-    intended_contents:
-      - "UFC readouts, COMM channel state, and keypad area."
-      - "Mission radio frequency or preset confirmation."
-    background_style: keypad_panel_dark
-    ocr_priority: high
-  - region_id: ifei
-    display_name_zh: IFEI
-    display_name_en: IFEI
-    x: 1680
-    y: 832
-    width: 848
-    height: 248
-    intended_contents:
-      - "Integrated Fuel/Engine Indicator text and numeric values."
-      - "BINGO fuel confirmation and engine status references."
-    background_style: engine_indicator_dark
-    ocr_priority: high
-  - region_id: standby_hud
-    display_name_zh: 备用仪表/HUD
-    display_name_en: Standby / HUD
-    x: 912
-    y: 1112
-    width: 736
-    height: 296
-    intended_contents:
-      - "Standby attitude/altimeter area and any small HUD crop needed by the pack."
-      - "Visual-only standby instrument confirmation."
-    background_style: standby_cluster_dark
-    ocr_priority: medium

--- a/packs/fa18c_startup/vision_layout.yaml
+++ b/packs/fa18c_startup/vision_layout.yaml
@@ -1,24 +1,31 @@
-layout_id: fa18c_composite_panel_v1
-title: "F/A-18C Native Viewport Layout v1"
+layout_id: fa18c_composite_panel_v2
+title: "F/A-18C Native Viewport Layout v2"
 description: >
-  Fixed native-viewport layout for v0.4 visual grounding. Only the three DCS
-  native display exports remain in the visual contract; UFC, IFEI, and warning
-  blocks are expected from DCS-BIOS instead of image crops.
-canvas:
+  Normalized left-stack native viewport layout for v0.4 visual grounding. The
+  strip is resolved relative to the full screen first, then the three display
+  regions are resolved relative to that strip.
+logical_canvas:
   width: 880
   height: 1440
 background:
   style: matte_neutral_dark
   fill: "#101416"
-  description: "Dark neutral matte background for the three stacked native display exports, with no main camera view."
+  description: "Dark neutral matte preview background for the native export strip."
+strip_norm:
+  anchor: left
+  x_norm: 0.0
+  y_norm: 0.0
+  height_norm: 1.0
+  target_aspect_ratio: 0.6111111111
+  min_main_view_width_px: 640
 regions:
   - region_id: left_ddi
     display_name_zh: 左 DDI
     display_name_en: Left DDI
-    x: 216
-    y: 24
-    width: 448
-    height: 448
+    x_norm: 0.2454545455
+    y_norm: 0.0166666667
+    width_norm: 0.5090909091
+    height_norm: 0.3111111111
     intended_contents:
       - "Native LEFT_MFCD export showing left DDI pages such as FCS or HSI."
       - "Page text, page labels, and display-only step evidence."
@@ -27,10 +34,10 @@ regions:
   - region_id: ampcd
     display_name_zh: AMPCD
     display_name_en: AMPCD
-    x: 216
-    y: 496
-    width: 448
-    height: 448
+    x_norm: 0.2454545455
+    y_norm: 0.3444444444
+    width_norm: 0.5090909091
+    height_norm: 0.3111111111
     intended_contents:
       - "Native CENTER_MFCD export showing AMPCD page state and center display text."
       - "Page labels and display symbology required by pack steps."
@@ -39,10 +46,10 @@ regions:
   - region_id: right_ddi
     display_name_zh: 右 DDI
     display_name_en: Right DDI
-    x: 216
-    y: 968
-    width: 448
-    height: 448
+    x_norm: 0.2454545455
+    y_norm: 0.6722222222
+    width_norm: 0.5090909091
+    height_norm: 0.3111111111
     intended_contents:
       - "Native RIGHT_MFCD export showing right DDI pages such as BIT or FCS."
       - "Display text and BIT-result review."

--- a/simtutor/schemas/v2/vision_observation.json
+++ b/simtutor/schemas/v2/vision_observation.json
@@ -20,6 +20,10 @@
       "type": ["string", "null"],
       "description": "Stable logical camera or display channel, e.g. center_mfd."
     },
+    "layout_id": {
+      "type": ["string", "null"],
+      "description": "Stable composite layout identifier, resolved to canonical geometry via pack vision_layout.yaml."
+    },
     "image_uri": {
       "type": ["string", "null"],
       "format": "uri",

--- a/simtutor/schemas/v2/vision_observation.json
+++ b/simtutor/schemas/v2/vision_observation.json
@@ -22,7 +22,7 @@
     },
     "layout_id": {
       "type": ["string", "null"],
-      "description": "Stable visual-layout identifier, resolved to canonical native-viewport geometry via pack vision_layout.yaml."
+      "description": "Stable visual-layout identifier, resolved to canonical normalized native-viewport geometry via pack vision_layout.yaml."
     },
     "image_uri": {
       "type": ["string", "null"],

--- a/simtutor/schemas/v2/vision_observation.json
+++ b/simtutor/schemas/v2/vision_observation.json
@@ -22,7 +22,7 @@
     },
     "layout_id": {
       "type": ["string", "null"],
-      "description": "Stable composite layout identifier, resolved to canonical geometry via pack vision_layout.yaml."
+      "description": "Stable visual-layout identifier, resolved to canonical native-viewport geometry via pack vision_layout.yaml."
     },
     "image_uri": {
       "type": ["string", "null"],

--- a/tests/test_install_dcs_monitor_setup.py
+++ b/tests/test_install_dcs_monitor_setup.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.install_dcs_monitor_setup import (
+    COMPOSITE_CANVAS_HEIGHT,
+    COMPOSITE_CANVAS_WIDTH,
+    MODE_EXTENDED_RIGHT,
+    MODE_SINGLE_MONITOR,
+    MODE_ULTRAWIDE_LEFT_STACK,
+    MONITOR_SETUP_BASENAME,
+    build_monitor_setup_plan,
+    install_monitor_setup,
+)
+
+
+def test_build_monitor_setup_plan_uses_frozen_top_row_coordinates() -> None:
+    plan = build_monitor_setup_plan(main_width=1920, main_height=1080, mode=MODE_EXTENDED_RIGHT)
+
+    assert plan.setup_name == MONITOR_SETUP_BASENAME
+    assert plan.mode == MODE_EXTENDED_RIGHT
+    assert plan.canvas_width == COMPOSITE_CANVAS_WIDTH
+    assert plan.canvas_height == COMPOSITE_CANVAS_HEIGHT
+    assert plan.total_width == 1920 + 2560
+    assert plan.total_height == 1440
+
+    assert [(viewport.name, viewport.x, viewport.y, viewport.width, viewport.height) for viewport in plan.viewports] == [
+        ("LEFT_MFCD", 1952, 32, 768, 768),
+        ("CENTER_MFCD", 2816, 32, 768, 768),
+        ("RIGHT_MFCD", 3680, 32, 768, 768),
+    ]
+
+
+def test_monitor_setup_lua_contains_center_and_three_viewports() -> None:
+    plan = build_monitor_setup_plan(main_width=2560, main_height=1440, mode=MODE_EXTENDED_RIGHT)
+    lua_text = plan.lua_text
+
+    assert "Viewports.Center =" in lua_text
+    assert "_  = function(p) return p; end;" in lua_text
+    assert "UIMainView = Viewports.Center" in lua_text
+    assert "GU_MAIN_VIEWPORT = UIMainView" in lua_text
+    assert "-- Recommended DCS resolution: 5120x1440" in lua_text
+    assert "LEFT_MFCD =" in lua_text
+    assert "CENTER_MFCD =" in lua_text
+    assert "RIGHT_MFCD =" in lua_text
+    assert "x = 2592;" in lua_text
+    assert "x = 3456;" in lua_text
+    assert "x = 4320;" in lua_text
+
+
+def test_build_monitor_setup_plan_supports_single_monitor_mode() -> None:
+    plan = build_monitor_setup_plan(main_width=1920, main_height=1080, mode=MODE_SINGLE_MONITOR)
+
+    assert plan.mode == MODE_SINGLE_MONITOR
+    assert plan.total_width == 1920
+    assert plan.total_height == 1080
+    assert plan.canvas_width == 1920
+    assert plan.canvas_height < 1080
+    assert plan.main_width == 1920
+    assert plan.main_height == 480
+    assert [(viewport.name, viewport.x, viewport.y, viewport.width, viewport.height) for viewport in plan.viewports] == [
+        ("LEFT_MFCD", 24, 24, 576, 576),
+        ("CENTER_MFCD", 672, 24, 576, 576),
+        ("RIGHT_MFCD", 1320, 24, 576, 576),
+    ]
+
+
+def test_single_monitor_lua_places_main_view_below_top_row() -> None:
+    plan = build_monitor_setup_plan(main_width=1920, main_height=1080, mode=MODE_SINGLE_MONITOR)
+    lua_text = plan.lua_text
+
+    assert "-- Recommended DCS resolution: 1920x1080" in lua_text
+    assert "Description = 'SimTutor F/A-18C composite panel viewport PoC (single monitor top-row layout)'" in lua_text
+    assert "    y = 600;" in lua_text
+    assert "    width = 1920;" in lua_text
+    assert "    height = 480;" in lua_text
+    assert "CENTER_MFCD =" in lua_text
+
+
+def test_build_monitor_setup_plan_supports_ultrawide_left_stack_mode() -> None:
+    plan = build_monitor_setup_plan(main_width=3440, main_height=1440, mode=MODE_ULTRAWIDE_LEFT_STACK)
+
+    assert plan.mode == MODE_ULTRAWIDE_LEFT_STACK
+    assert plan.total_width == 3440
+    assert plan.total_height == 1440
+    assert plan.canvas_width == 880
+    assert plan.canvas_height == 1440
+    assert plan.main_width == 2560
+    assert plan.main_height == 1440
+    assert [(viewport.name, viewport.x, viewport.y, viewport.width, viewport.height) for viewport in plan.viewports] == [
+        ("LEFT_MFCD", 216, 24, 448, 448),
+        ("CENTER_MFCD", 216, 496, 448, 448),
+        ("RIGHT_MFCD", 216, 968, 448, 448),
+    ]
+
+
+def test_ultrawide_left_stack_lua_places_main_view_on_right() -> None:
+    plan = build_monitor_setup_plan(main_width=3440, main_height=1440, mode=MODE_ULTRAWIDE_LEFT_STACK)
+    lua_text = plan.lua_text
+
+    assert "-- Recommended DCS resolution: 3440x1440" in lua_text
+    assert "Description = 'SimTutor F/A-18C composite panel viewport PoC (ultrawide left-stack layout)'" in lua_text
+    assert "    x = 880;" in lua_text
+    assert "    y = 0;" in lua_text
+    assert "    width = 2560;" in lua_text
+    assert "    height = 1440;" in lua_text
+    assert "CENTER_MFCD =" in lua_text
+
+
+def test_install_monitor_setup_writes_saved_games_config_path(tmp_path: Path) -> None:
+    saved_games_dir = tmp_path / "Saved Games" / "DCS"
+
+    result = install_monitor_setup(
+        saved_games_dir=saved_games_dir,
+        main_width=1920,
+        main_height=1080,
+        mode=MODE_EXTENDED_RIGHT,
+    )
+
+    expected_path = saved_games_dir / "Config" / "MonitorSetup" / f"{MONITOR_SETUP_BASENAME}.lua"
+    assert result.monitor_setup_path == expected_path
+    assert result.changed is True
+    assert result.mode == MODE_EXTENDED_RIGHT
+    assert expected_path.exists()
+    assert "LEFT_MFCD" in expected_path.read_text(encoding="utf-8")
+
+
+def test_install_monitor_setup_is_idempotent(tmp_path: Path) -> None:
+    saved_games_dir = tmp_path / "Saved Games" / "DCS"
+
+    first = install_monitor_setup(
+        saved_games_dir=saved_games_dir,
+        main_width=1920,
+        main_height=1080,
+        mode=MODE_EXTENDED_RIGHT,
+    )
+    second = install_monitor_setup(
+        saved_games_dir=saved_games_dir,
+        main_width=1920,
+        main_height=1080,
+        mode=MODE_EXTENDED_RIGHT,
+    )
+
+    assert first.changed is True
+    assert second.changed is False
+
+
+@pytest.mark.parametrize(
+    ("main_width", "main_height"),
+    [
+        (0, 1080),
+        (1920, 0),
+        (-1, 1080),
+    ],
+)
+def test_build_monitor_setup_plan_rejects_non_positive_dimensions(main_width: int, main_height: int) -> None:
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        build_monitor_setup_plan(main_width=main_width, main_height=main_height)
+
+
+def test_build_monitor_setup_plan_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="unsupported mode"):
+        build_monitor_setup_plan(main_width=1920, main_height=1080, mode="unknown")
+
+
+def test_ultrawide_left_stack_rejects_non_ultrawide_screen() -> None:
+    with pytest.raises(ValueError, match="not wide enough"):
+        build_monitor_setup_plan(main_width=2560, main_height=1440, mode=MODE_ULTRAWIDE_LEFT_STACK)

--- a/tests/test_install_dcs_monitor_setup.py
+++ b/tests/test_install_dcs_monitor_setup.py
@@ -16,24 +16,23 @@ from tools.install_dcs_monitor_setup import (
 )
 
 
-def test_build_monitor_setup_plan_uses_frozen_top_row_coordinates() -> None:
+def test_build_monitor_setup_plan_uses_normalized_strip_inside_extended_canvas() -> None:
     plan = build_monitor_setup_plan(main_width=1920, main_height=1080, mode=MODE_EXTENDED_RIGHT)
 
     assert plan.setup_name == MONITOR_SETUP_BASENAME
     assert plan.mode == MODE_EXTENDED_RIGHT
     assert plan.canvas_width == COMPOSITE_CANVAS_WIDTH
     assert plan.canvas_height == COMPOSITE_CANVAS_HEIGHT
-    assert plan.total_width == 1920 + 2560
+    assert plan.total_width == 4480
     assert plan.total_height == 1440
-
     assert [(viewport.name, viewport.x, viewport.y, viewport.width, viewport.height) for viewport in plan.viewports] == [
-        ("LEFT_MFCD", 1952, 32, 768, 768),
-        ("CENTER_MFCD", 2816, 32, 768, 768),
-        ("RIGHT_MFCD", 3680, 32, 768, 768),
+        ("LEFT_MFCD", 2136, 24, 448, 448),
+        ("CENTER_MFCD", 2136, 496, 448, 448),
+        ("RIGHT_MFCD", 2136, 968, 448, 448),
     ]
 
 
-def test_monitor_setup_lua_contains_center_and_three_viewports() -> None:
+def test_monitor_setup_lua_contains_extended_canvas_viewports() -> None:
     plan = build_monitor_setup_plan(main_width=2560, main_height=1440, mode=MODE_EXTENDED_RIGHT)
     lua_text = plan.lua_text
 
@@ -45,9 +44,8 @@ def test_monitor_setup_lua_contains_center_and_three_viewports() -> None:
     assert "LEFT_MFCD =" in lua_text
     assert "CENTER_MFCD =" in lua_text
     assert "RIGHT_MFCD =" in lua_text
-    assert "x = 2592;" in lua_text
-    assert "x = 3456;" in lua_text
-    assert "x = 4320;" in lua_text
+    assert "x = 2776;" in lua_text
+    assert "y = 968;" in lua_text
 
 
 def test_build_monitor_setup_plan_supports_single_monitor_mode() -> None:
@@ -56,27 +54,27 @@ def test_build_monitor_setup_plan_supports_single_monitor_mode() -> None:
     assert plan.mode == MODE_SINGLE_MONITOR
     assert plan.total_width == 1920
     assert plan.total_height == 1080
-    assert plan.canvas_width == 1920
-    assert plan.canvas_height < 1080
-    assert plan.main_width == 1920
-    assert plan.main_height == 480
+    assert plan.canvas_width == 660
+    assert plan.canvas_height == 1080
+    assert plan.main_width == 1260
+    assert plan.main_height == 1080
     assert [(viewport.name, viewport.x, viewport.y, viewport.width, viewport.height) for viewport in plan.viewports] == [
-        ("LEFT_MFCD", 24, 24, 576, 576),
-        ("CENTER_MFCD", 672, 24, 576, 576),
-        ("RIGHT_MFCD", 1320, 24, 576, 576),
+        ("LEFT_MFCD", 162, 18, 336, 336),
+        ("CENTER_MFCD", 162, 372, 336, 336),
+        ("RIGHT_MFCD", 162, 726, 336, 336),
     ]
 
 
-def test_single_monitor_lua_places_main_view_below_top_row() -> None:
+def test_single_monitor_lua_places_main_view_on_right_of_left_stack() -> None:
     plan = build_monitor_setup_plan(main_width=1920, main_height=1080, mode=MODE_SINGLE_MONITOR)
     lua_text = plan.lua_text
 
     assert "-- Recommended DCS resolution: 1920x1080" in lua_text
-    assert "Description = 'SimTutor F/A-18C composite panel viewport PoC (single monitor top-row layout)'" in lua_text
-    assert "    y = 600;" in lua_text
-    assert "    width = 1920;" in lua_text
-    assert "    height = 480;" in lua_text
-    assert "CENTER_MFCD =" in lua_text
+    assert "Description = 'SimTutor F/A-18C composite panel viewport PoC (single monitor normalized left-stack layout)'" in lua_text
+    assert "    x = 660;" in lua_text
+    assert "    y = 0;" in lua_text
+    assert "    width = 1260;" in lua_text
+    assert "    height = 1080;" in lua_text
 
 
 def test_build_monitor_setup_plan_supports_ultrawide_left_stack_mode() -> None:
@@ -101,12 +99,17 @@ def test_ultrawide_left_stack_lua_places_main_view_on_right() -> None:
     lua_text = plan.lua_text
 
     assert "-- Recommended DCS resolution: 3440x1440" in lua_text
-    assert "Description = 'SimTutor F/A-18C composite panel viewport PoC (ultrawide left-stack layout)'" in lua_text
+    assert "Description = 'SimTutor F/A-18C composite panel viewport PoC (ultrawide normalized left-stack layout)'" in lua_text
     assert "    x = 880;" in lua_text
-    assert "    y = 0;" in lua_text
     assert "    width = 2560;" in lua_text
-    assert "    height = 1440;" in lua_text
     assert "CENTER_MFCD =" in lua_text
+
+
+def test_ultrawide_and_single_monitor_share_same_normalized_solver_family() -> None:
+    single = build_monitor_setup_plan(main_width=2560, main_height=1440, mode=MODE_SINGLE_MONITOR)
+    ultrawide = build_monitor_setup_plan(main_width=2560, main_height=1440, mode=MODE_ULTRAWIDE_LEFT_STACK)
+    assert single.viewports == ultrawide.viewports
+    assert single.main_width == ultrawide.main_width
 
 
 def test_install_monitor_setup_writes_saved_games_config_path(tmp_path: Path) -> None:
@@ -165,6 +168,6 @@ def test_build_monitor_setup_plan_rejects_unknown_mode() -> None:
         build_monitor_setup_plan(main_width=1920, main_height=1080, mode="unknown")
 
 
-def test_ultrawide_left_stack_rejects_non_ultrawide_screen() -> None:
-    with pytest.raises(ValueError, match="not wide enough"):
-        build_monitor_setup_plan(main_width=2560, main_height=1440, mode=MODE_ULTRAWIDE_LEFT_STACK)
+def test_single_monitor_rejects_too_narrow_screen() -> None:
+    with pytest.raises(ValueError, match="too small"):
+        build_monitor_setup_plan(main_width=639, main_height=1080, mode=MODE_SINGLE_MONITOR)

--- a/tests/test_vision_contracts.py
+++ b/tests/test_vision_contracts.py
@@ -20,6 +20,15 @@ def test_vision_observation_schema_accepts_defaults() -> None:
     validate_instance(obs, "vision_observation")
 
 
+def test_vision_observation_schema_accepts_layout_id() -> None:
+    obs = VisionObservation(
+        source="vision_stub",
+        channel="composite_panel",
+        layout_id="fa18c_composite_panel_v1",
+    ).to_dict()
+    validate_instance(obs, "vision_observation")
+
+
 def test_vision_port_protocol_shape() -> None:
     class DummyVisionAdapter:
         def start(self, session_id: str) -> None:

--- a/tests/test_vision_contracts.py
+++ b/tests/test_vision_contracts.py
@@ -24,7 +24,7 @@ def test_vision_observation_schema_accepts_layout_id() -> None:
     obs = VisionObservation(
         source="vision_stub",
         channel="native_viewports_strip",
-        layout_id="fa18c_composite_panel_v1",
+        layout_id="fa18c_composite_panel_v2",
     ).to_dict()
     validate_instance(obs, "vision_observation")
 

--- a/tests/test_vision_contracts.py
+++ b/tests/test_vision_contracts.py
@@ -23,7 +23,7 @@ def test_vision_observation_schema_accepts_defaults() -> None:
 def test_vision_observation_schema_accepts_layout_id() -> None:
     obs = VisionObservation(
         source="vision_stub",
-        channel="composite_panel",
+        channel="native_viewports_strip",
         layout_id="fa18c_composite_panel_v1",
     ).to_dict()
     validate_instance(obs, "vision_observation")

--- a/tests/test_vision_prompting.py
+++ b/tests/test_vision_prompting.py
@@ -30,8 +30,16 @@ def test_load_vision_layout_returns_frozen_contract() -> None:
     layout = load_vision_layout()
 
     assert layout["layout_id"] == DEFAULT_LAYOUT_ID
-    assert layout["canvas"] == {"width": 2560, "height": 1440}
+    assert layout["canvas"] == {"width": 880, "height": 1440}
     assert [region["region_id"] for region in layout["regions"]] == list(VISION_REGION_ORDER)
+    assert [
+        (region["x"], region["y"], region["width"], region["height"])
+        for region in layout["regions"]
+    ] == [
+        (216, 24, 448, 448),
+        (216, 496, 448, 448),
+        (216, 968, 448, 448),
+    ]
 
 
 def test_layout_regions_fit_canvas_and_do_not_overlap() -> None:
@@ -104,15 +112,11 @@ def test_svg_asset_matches_rendered_layout() -> None:
 def test_svg_contains_viewbox_and_all_region_labels() -> None:
     svg = _asset_path().read_text(encoding="utf-8")
 
-    assert 'viewBox="0 0 2560 1440"' in svg
+    assert 'viewBox="0 0 880 1440"' in svg
     for expected in (
         "Left DDI",
         "AMPCD",
         "Right DDI",
-        "Warning Panel",
-        "UFC",
-        "IFEI",
-        "Standby / HUD",
     ):
         assert expected in svg
 
@@ -136,7 +140,7 @@ def test_layout_yaml_declares_required_region_fields() -> None:
     data = yaml.safe_load(_layout_path().read_text(encoding="utf-8"))
     regions = data["regions"]
 
-    assert len(regions) == 7
+    assert len(regions) == 3
     for region in regions:
         assert set(region) >= {
             "region_id",

--- a/tests/test_vision_prompting.py
+++ b/tests/test_vision_prompting.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from adapters.vision_prompting import (
+    DEFAULT_LAYOUT_ID,
+    VISION_REGION_ORDER,
+    build_vlm_region_prompt,
+    load_vision_layout,
+    render_layout_svg,
+    scale_layout_regions,
+)
+
+
+def _layout_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "packs" / "fa18c_startup" / "vision_layout.yaml"
+
+
+def _doc_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "Doc" / "Vision" / "fa18c_composite_panel_ZH_v1.md"
+
+
+def _asset_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "Doc" / "Vision" / "assets" / "fa18c_composite_panel_v1.svg"
+
+
+def test_load_vision_layout_returns_frozen_contract() -> None:
+    layout = load_vision_layout()
+
+    assert layout["layout_id"] == DEFAULT_LAYOUT_ID
+    assert layout["canvas"] == {"width": 2560, "height": 1440}
+    assert [region["region_id"] for region in layout["regions"]] == list(VISION_REGION_ORDER)
+
+
+def test_layout_regions_fit_canvas_and_do_not_overlap() -> None:
+    layout = load_vision_layout()
+    canvas_width = layout["canvas"]["width"]
+    canvas_height = layout["canvas"]["height"]
+    regions = layout["regions"]
+
+    for region in regions:
+        assert region["x"] >= 0
+        assert region["y"] >= 0
+        assert region["x"] + region["width"] <= canvas_width
+        assert region["y"] + region["height"] <= canvas_height
+
+    for idx, current in enumerate(regions):
+        for other in regions[idx + 1 :]:
+            overlaps = (
+                current["x"] < other["x"] + other["width"]
+                and current["x"] + current["width"] > other["x"]
+                and current["y"] < other["y"] + other["height"]
+                and current["y"] + current["height"] > other["y"]
+            )
+            assert overlaps is False, (current["region_id"], other["region_id"])
+
+
+def test_scale_layout_regions_preserves_order_and_bounds() -> None:
+    layout = load_vision_layout()
+
+    for output_width, output_height in ((1920, 1080), (3840, 2160)):
+        scaled = scale_layout_regions(layout, output_width=output_width, output_height=output_height)
+        assert scaled["canvas"] == {"width": output_width, "height": output_height}
+        assert [region["region_id"] for region in scaled["regions"]] == list(VISION_REGION_ORDER)
+        for region in scaled["regions"]:
+            assert region["x"] >= 0
+            assert region["y"] >= 0
+            assert region["x"] + region["width"] <= output_width
+            assert region["y"] + region["height"] <= output_height
+        for idx, current in enumerate(scaled["regions"]):
+            for other in scaled["regions"][idx + 1 :]:
+                overlaps = (
+                    current["x"] < other["x"] + other["width"]
+                    and current["x"] + current["width"] > other["x"]
+                    and current["y"] < other["y"] + other["height"]
+                    and current["y"] + current["height"] > other["y"]
+                )
+                assert overlaps is False, (output_width, output_height, current["region_id"], other["region_id"])
+
+
+def test_vlm_region_prompt_uses_frozen_region_ids_and_order() -> None:
+    zh_prompt = build_vlm_region_prompt(lang="zh")
+    en_prompt = build_vlm_region_prompt(lang="en")
+
+    zh_positions = [zh_prompt.index(region_id) for region_id in VISION_REGION_ORDER]
+    en_positions = [en_prompt.index(region_id) for region_id in VISION_REGION_ORDER]
+    assert zh_positions == sorted(zh_positions)
+    assert en_positions == sorted(en_positions)
+    assert [segment.split("=")[0] for segment in zh_prompt.split("：", 1)[1].split("。", 1)[0].split("; ")] == list(
+        VISION_REGION_ORDER
+    )
+    assert [segment.split("=")[0] for segment in en_prompt.split(": ", 1)[1].split(". ", 1)[0].split("; ")] == list(
+        VISION_REGION_ORDER
+    )
+
+
+def test_svg_asset_matches_rendered_layout() -> None:
+    svg = render_layout_svg(load_vision_layout())
+    assert _asset_path().read_text(encoding="utf-8") == svg
+
+
+def test_svg_contains_viewbox_and_all_region_labels() -> None:
+    svg = _asset_path().read_text(encoding="utf-8")
+
+    assert 'viewBox="0 0 2560 1440"' in svg
+    for expected in (
+        "Left DDI",
+        "AMPCD",
+        "Right DDI",
+        "Warning Panel",
+        "UFC",
+        "IFEI",
+        "Standby / HUD",
+    ):
+        assert expected in svg
+
+
+def test_pack_metadata_and_doc_share_same_priority_step_lists() -> None:
+    pack_path = Path(__file__).resolve().parent.parent / "packs" / "fa18c_startup" / "pack.yaml"
+    pack = yaml.safe_load(pack_path.read_text(encoding="utf-8"))
+    metadata = pack["metadata"]
+    doc = _doc_path().read_text(encoding="utf-8")
+
+    assert metadata["vision_layout_id"] == DEFAULT_LAYOUT_ID
+    for step_id in metadata["vision_priority_steps"]:
+        assert f"`{step_id}`" in doc
+    for step_id in metadata["bios_priority_steps"]:
+        assert f"`{step_id}`" in doc
+    for step_id in metadata["manual_or_out_of_layout_steps"]:
+        assert f"`{step_id}`" in doc
+
+
+def test_layout_yaml_declares_required_region_fields() -> None:
+    data = yaml.safe_load(_layout_path().read_text(encoding="utf-8"))
+    regions = data["regions"]
+
+    assert len(regions) == 7
+    for region in regions:
+        assert set(region) >= {
+            "region_id",
+            "display_name_zh",
+            "display_name_en",
+            "x",
+            "y",
+            "width",
+            "height",
+            "intended_contents",
+            "background_style",
+            "ocr_priority",
+        }

--- a/tests/test_vision_prompting.py
+++ b/tests/test_vision_prompting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from adapters.vision_prompting import (
@@ -9,8 +10,9 @@ from adapters.vision_prompting import (
     VISION_REGION_ORDER,
     build_vlm_region_prompt,
     load_vision_layout,
+    render_fullscreen_layout_svg,
     render_layout_svg,
-    scale_layout_regions,
+    solve_layout_geometry,
 )
 
 
@@ -19,73 +21,87 @@ def _layout_path() -> Path:
 
 
 def _doc_path() -> Path:
-    return Path(__file__).resolve().parent.parent / "Doc" / "Vision" / "fa18c_composite_panel_ZH_v1.md"
+    return Path(__file__).resolve().parent.parent / "Doc" / "Vision" / "fa18c_composite_panel_ZH_v2.md"
 
 
-def _asset_path() -> Path:
-    return Path(__file__).resolve().parent.parent / "Doc" / "Vision" / "assets" / "fa18c_composite_panel_v1.svg"
+def _strip_asset_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "Doc" / "Vision" / "assets" / "fa18c_composite_panel_v2.svg"
 
 
-def test_load_vision_layout_returns_frozen_contract() -> None:
+def _fullscreen_asset_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "Doc" / "Vision" / "assets" / "fa18c_composite_panel_fullscreen_v2.svg"
+
+
+def test_load_vision_layout_returns_normalized_v2_contract() -> None:
     layout = load_vision_layout()
 
     assert layout["layout_id"] == DEFAULT_LAYOUT_ID
-    assert layout["canvas"] == {"width": 880, "height": 1440}
+    assert layout["logical_canvas"] == {"width": 880, "height": 1440}
+    assert layout["strip_norm"] == {
+        "anchor": "left",
+        "x_norm": 0.0,
+        "y_norm": 0.0,
+        "height_norm": 1.0,
+        "target_aspect_ratio": 0.6111111111,
+        "min_main_view_width_px": 640,
+    }
     assert [region["region_id"] for region in layout["regions"]] == list(VISION_REGION_ORDER)
-    assert [
-        (region["x"], region["y"], region["width"], region["height"])
-        for region in layout["regions"]
-    ] == [
-        (216, 24, 448, 448),
-        (216, 496, 448, 448),
-        (216, 968, 448, 448),
-    ]
 
 
-def test_layout_regions_fit_canvas_and_do_not_overlap() -> None:
+def test_normalized_regions_fit_strip_and_do_not_overlap() -> None:
     layout = load_vision_layout()
-    canvas_width = layout["canvas"]["width"]
-    canvas_height = layout["canvas"]["height"]
     regions = layout["regions"]
 
     for region in regions:
-        assert region["x"] >= 0
-        assert region["y"] >= 0
-        assert region["x"] + region["width"] <= canvas_width
-        assert region["y"] + region["height"] <= canvas_height
+        assert 0.0 <= region["x_norm"] <= 1.0
+        assert 0.0 <= region["y_norm"] <= 1.0
+        assert region["x_norm"] + region["width_norm"] <= 1.0
+        assert region["y_norm"] + region["height_norm"] <= 1.0
 
     for idx, current in enumerate(regions):
         for other in regions[idx + 1 :]:
             overlaps = (
-                current["x"] < other["x"] + other["width"]
-                and current["x"] + current["width"] > other["x"]
-                and current["y"] < other["y"] + other["height"]
-                and current["y"] + current["height"] > other["y"]
+                current["x_norm"] < other["x_norm"] + other["width_norm"]
+                and current["x_norm"] + current["width_norm"] > other["x_norm"]
+                and current["y_norm"] < other["y_norm"] + other["height_norm"]
+                and current["y_norm"] + current["height_norm"] > other["y_norm"]
             )
             assert overlaps is False, (current["region_id"], other["region_id"])
 
 
-def test_scale_layout_regions_preserves_order_and_bounds() -> None:
-    layout = load_vision_layout()
+@pytest.mark.parametrize(
+    ("output_width", "output_height", "expected_strip", "expected_main"),
+    [
+        (1920, 1080, {"x": 0, "y": 0, "width": 660, "height": 1080}, {"x": 660, "y": 0, "width": 1260, "height": 1080}),
+        (2560, 1440, {"x": 0, "y": 0, "width": 880, "height": 1440}, {"x": 880, "y": 0, "width": 1680, "height": 1440}),
+        (3440, 1440, {"x": 0, "y": 0, "width": 880, "height": 1440}, {"x": 880, "y": 0, "width": 2560, "height": 1440}),
+        (3840, 1600, {"x": 0, "y": 0, "width": 978, "height": 1600}, {"x": 978, "y": 0, "width": 2862, "height": 1600}),
+        (3840, 1080, {"x": 0, "y": 0, "width": 660, "height": 1080}, {"x": 660, "y": 0, "width": 3180, "height": 1080}),
+        (2160, 1440, {"x": 0, "y": 0, "width": 880, "height": 1440}, {"x": 880, "y": 0, "width": 1280, "height": 1440}),
+    ],
+)
+def test_solve_layout_geometry_handles_reference_screen_sizes(
+    output_width: int,
+    output_height: int,
+    expected_strip: dict[str, int],
+    expected_main: dict[str, int],
+) -> None:
+    solved = solve_layout_geometry(load_vision_layout(), output_width=output_width, output_height=output_height)
 
-    for output_width, output_height in ((1920, 1080), (3840, 2160)):
-        scaled = scale_layout_regions(layout, output_width=output_width, output_height=output_height)
-        assert scaled["canvas"] == {"width": output_width, "height": output_height}
-        assert [region["region_id"] for region in scaled["regions"]] == list(VISION_REGION_ORDER)
-        for region in scaled["regions"]:
-            assert region["x"] >= 0
-            assert region["y"] >= 0
-            assert region["x"] + region["width"] <= output_width
-            assert region["y"] + region["height"] <= output_height
-        for idx, current in enumerate(scaled["regions"]):
-            for other in scaled["regions"][idx + 1 :]:
-                overlaps = (
-                    current["x"] < other["x"] + other["width"]
-                    and current["x"] + current["width"] > other["x"]
-                    and current["y"] < other["y"] + other["height"]
-                    and current["y"] + current["height"] > other["y"]
-                )
-                assert overlaps is False, (output_width, output_height, current["region_id"], other["region_id"])
+    assert solved["canvas"] == {"width": output_width, "height": output_height}
+    assert solved["strip_rect"] == expected_strip
+    assert solved["main_view_rect"] == expected_main
+    assert [region["region_id"] for region in solved["regions"]] == list(VISION_REGION_ORDER)
+    for region in solved["regions"]:
+        assert region["x"] >= expected_strip["x"]
+        assert region["y"] >= expected_strip["y"]
+        assert region["x"] + region["width"] <= expected_strip["x"] + expected_strip["width"]
+        assert region["y"] + region["height"] <= expected_strip["y"] + expected_strip["height"]
+
+
+def test_solve_layout_geometry_rejects_too_narrow_screen() -> None:
+    with pytest.raises(ValueError, match="too small"):
+        solve_layout_geometry(load_vision_layout(), output_width=639, output_height=1080)
 
 
 def test_vlm_region_prompt_uses_frozen_region_ids_and_order() -> None:
@@ -96,29 +112,25 @@ def test_vlm_region_prompt_uses_frozen_region_ids_and_order() -> None:
     en_positions = [en_prompt.index(region_id) for region_id in VISION_REGION_ORDER]
     assert zh_positions == sorted(zh_positions)
     assert en_positions == sorted(en_positions)
-    assert [segment.split("=")[0] for segment in zh_prompt.split("：", 1)[1].split("。", 1)[0].split("; ")] == list(
-        VISION_REGION_ORDER
-    )
-    assert [segment.split("=")[0] for segment in en_prompt.split(": ", 1)[1].split(". ", 1)[0].split("; ")] == list(
-        VISION_REGION_ORDER
-    )
 
 
-def test_svg_asset_matches_rendered_layout() -> None:
-    svg = render_layout_svg(load_vision_layout())
-    assert _asset_path().read_text(encoding="utf-8") == svg
+def test_strip_svg_asset_matches_rendered_layout() -> None:
+    assert _strip_asset_path().read_text(encoding="utf-8") == render_layout_svg(load_vision_layout())
 
 
-def test_svg_contains_viewbox_and_all_region_labels() -> None:
-    svg = _asset_path().read_text(encoding="utf-8")
+def test_fullscreen_svg_asset_matches_rendered_layout() -> None:
+    assert _fullscreen_asset_path().read_text(encoding="utf-8") == render_fullscreen_layout_svg(load_vision_layout())
 
-    assert 'viewBox="0 0 880 1440"' in svg
-    for expected in (
-        "Left DDI",
-        "AMPCD",
-        "Right DDI",
-    ):
-        assert expected in svg
+
+def test_svg_assets_are_english_and_have_expected_labels() -> None:
+    strip_svg = _strip_asset_path().read_text(encoding="utf-8")
+    fullscreen_svg = _fullscreen_asset_path().read_text(encoding="utf-8")
+
+    assert "Left DDI" in strip_svg
+    assert "left_ddi" in strip_svg
+    assert "左 DDI" not in strip_svg
+    assert "Main Simulator View" in fullscreen_svg
+    assert "Export Strip" in fullscreen_svg
 
 
 def test_pack_metadata_and_doc_share_same_priority_step_lists() -> None:
@@ -136,20 +148,28 @@ def test_pack_metadata_and_doc_share_same_priority_step_lists() -> None:
         assert f"`{step_id}`" in doc
 
 
-def test_layout_yaml_declares_required_region_fields() -> None:
+def test_layout_yaml_declares_required_v2_fields() -> None:
     data = yaml.safe_load(_layout_path().read_text(encoding="utf-8"))
-    regions = data["regions"]
 
-    assert len(regions) == 3
-    for region in regions:
+    assert data["layout_id"] == DEFAULT_LAYOUT_ID
+    assert set(data["strip_norm"]) >= {
+        "anchor",
+        "x_norm",
+        "y_norm",
+        "height_norm",
+        "target_aspect_ratio",
+        "min_main_view_width_px",
+    }
+    assert len(data["regions"]) == 3
+    for region in data["regions"]:
         assert set(region) >= {
             "region_id",
             "display_name_zh",
             "display_name_en",
-            "x",
-            "y",
-            "width",
-            "height",
+            "x_norm",
+            "y_norm",
+            "width_norm",
+            "height_norm",
             "intended_contents",
             "background_style",
             "ocr_priority",

--- a/tools/install_dcs_monitor_setup.py
+++ b/tools/install_dcs_monitor_setup.py
@@ -16,6 +16,9 @@ from pathlib import Path
 from adapters.vision_prompting import load_vision_layout, solve_layout_geometry
 from tools.install_dcs_hook import resolve_saved_games_dir
 
+# Keep the Saved Games monitor-setup filename stable for DCS Options/backward
+# compatibility; the active visual contract version is tracked by layout_id in
+# packs/fa18c_startup/vision_layout.yaml.
 MONITOR_SETUP_BASENAME = "SimTutor_FA18C_CompositePanel_v1"
 COMPOSITE_CANVAS_WIDTH = 2560
 COMPOSITE_CANVAS_HEIGHT = 1440

--- a/tools/install_dcs_monitor_setup.py
+++ b/tools/install_dcs_monitor_setup.py
@@ -98,6 +98,10 @@ def build_monitor_setup_plan(*, main_width: int, main_height: int, mode: str = M
     layout = load_vision_layout()
 
     if mode == MODE_EXTENDED_RIGHT:
+        # The debug canvas stays fixed at 2560x1440, but the three native
+        # viewports inside that canvas are still solved from the normalized
+        # left-strip contract so DCS export geometry and VLM crop geometry do
+        # not drift apart.
         export_solution = solve_layout_geometry(
             layout,
             output_width=COMPOSITE_CANVAS_WIDTH,
@@ -113,6 +117,8 @@ def build_monitor_setup_plan(*, main_width: int, main_height: int, mode: str = M
         canvas_height = COMPOSITE_CANVAS_HEIGHT
         viewports = _region_viewports(export_solution, x_offset=width)
     elif mode in {MODE_SINGLE_MONITOR, MODE_ULTRAWIDE_LEFT_STACK}:
+        # Both single-monitor and ultrawide-left-stack intentionally share the
+        # same normalized solver family; only the target screen size changes.
         solution = solve_layout_geometry(layout, output_width=width, output_height=height)
         main_rect = solution["main_view_rect"]
         strip_rect = solution["strip_rect"]

--- a/tools/install_dcs_monitor_setup.py
+++ b/tools/install_dcs_monitor_setup.py
@@ -2,9 +2,9 @@
 Install a Saved Games monitor-setup Lua for the F/A-18C viewport PoC.
 
 Supported modes:
-- extended-right: place the 2560x1440 composite canvas to the right of the main viewport
-- single-monitor: place LEFT_MFCD/CENTER_MFCD/RIGHT_MFCD on the top band of one screen
-- ultrawide-left-stack: stack LEFT_MFCD/CENTER_MFCD/RIGHT_MFCD vertically in the extra left strip of an ultrawide screen
+- extended-right: place a fixed 2560x1440 debug canvas to the right of the main viewport
+- single-monitor: solve the normalized left-stack layout against one screen
+- ultrawide-left-stack: solve the same normalized left-stack layout against an ultrawide screen
 """
 
 from __future__ import annotations
@@ -13,23 +13,15 @@ import argparse
 from dataclasses import dataclass
 from pathlib import Path
 
-from adapters.vision_prompting import load_vision_layout
+from adapters.vision_prompting import load_vision_layout, solve_layout_geometry
 from tools.install_dcs_hook import resolve_saved_games_dir
 
 MONITOR_SETUP_BASENAME = "SimTutor_FA18C_CompositePanel_v1"
 COMPOSITE_CANVAS_WIDTH = 2560
 COMPOSITE_CANVAS_HEIGHT = 1440
-TOP_ROW_CANONICAL_HEIGHT = 800
-MIN_SINGLE_MONITOR_MAIN_HEIGHT = 280
 MODE_EXTENDED_RIGHT = "extended-right"
 MODE_SINGLE_MONITOR = "single-monitor"
 MODE_ULTRAWIDE_LEFT_STACK = "ultrawide-left-stack"
-ULTRAWIDE_STACK_MARGIN = 24
-_VIEWPORT_REGION_TO_DCS_NAME = {
-    "left_ddi": "LEFT_MFCD",
-    "ampcd": "CENTER_MFCD",
-    "right_ddi": "RIGHT_MFCD",
-}
 
 
 @dataclass(frozen=True)
@@ -70,131 +62,76 @@ def _require_positive_int(value: int, label: str) -> int:
     return value
 
 
-def _expected_viewport_names() -> tuple[str, ...]:
-    return tuple(_VIEWPORT_REGION_TO_DCS_NAME.values())
+def _region_id_to_dcs_name(region_id: str) -> str:
+    mapping = {
+        "left_ddi": "LEFT_MFCD",
+        "ampcd": "CENTER_MFCD",
+        "right_ddi": "RIGHT_MFCD",
+    }
+    try:
+        return mapping[region_id]
+    except KeyError as exc:
+        raise ValueError(f"unsupported region id for DCS viewport export: {region_id}") from exc
 
 
-def _build_monitor_viewports_extended(main_width: int) -> tuple[MonitorViewport, ...]:
-    layout = load_vision_layout()
-    viewports: list[MonitorViewport] = []
-    for region in layout["regions"]:
-        region_id = region["region_id"]
-        dcs_name = _VIEWPORT_REGION_TO_DCS_NAME.get(region_id)
-        if dcs_name is None:
-            continue
-        viewports.append(
-            MonitorViewport(
-                name=dcs_name,
-                x=main_width + int(region["x"]),
-                y=int(region["y"]),
-                width=int(region["width"]),
-                height=int(region["height"]),
-            )
-        )
-    expected_names = _expected_viewport_names()
-    actual_names = tuple(viewport.name for viewport in viewports)
-    if actual_names != expected_names:
-        raise ValueError(f"unexpected viewport order: {actual_names!r}")
-    return tuple(viewports)
-
-
-def _single_monitor_scale(screen_width: int, screen_height: int) -> float:
-    width_scale = screen_width / COMPOSITE_CANVAS_WIDTH
-    height_scale = max(0.1, (screen_height - MIN_SINGLE_MONITOR_MAIN_HEIGHT) / TOP_ROW_CANONICAL_HEIGHT)
-    return min(width_scale, height_scale)
-
-
-def _build_monitor_viewports_single(screen_width: int, screen_height: int) -> tuple[MonitorViewport, ...]:
-    layout = load_vision_layout()
-    scale = _single_monitor_scale(screen_width, screen_height)
-    top_band_height = int(round(TOP_ROW_CANONICAL_HEIGHT * scale))
-    if screen_height - top_band_height < MIN_SINGLE_MONITOR_MAIN_HEIGHT:
-        raise ValueError("screen height is too small for single-monitor viewport layout")
-    viewports: list[MonitorViewport] = []
-    for region in layout["regions"]:
-        region_id = region["region_id"]
-        dcs_name = _VIEWPORT_REGION_TO_DCS_NAME.get(region_id)
-        if dcs_name is None:
-            continue
-        viewports.append(
-            MonitorViewport(
-                name=dcs_name,
-                x=int(round(int(region["x"]) * scale)),
-                y=int(round(int(region["y"]) * scale)),
-                width=int(round(int(region["width"]) * scale)),
-                height=int(round(int(region["height"]) * scale)),
-            )
-        )
-    expected_names = _expected_viewport_names()
-    actual_names = tuple(viewport.name for viewport in viewports)
-    if actual_names != expected_names:
-        raise ValueError(f"unexpected viewport order: {actual_names!r}")
-    return tuple(viewports)
-
-
-def _build_monitor_viewports_ultrawide_left_stack(screen_width: int, screen_height: int) -> tuple[MonitorViewport, ...]:
-    main_view_width = int(round(screen_height * (16 / 9)))
-    left_strip_width = screen_width - main_view_width
-    if left_strip_width <= 0:
-        raise ValueError("screen is not wide enough for ultrawide-left-stack layout")
-
-    viewport_size = min(
-        left_strip_width - 2 * ULTRAWIDE_STACK_MARGIN,
-        (screen_height - 4 * ULTRAWIDE_STACK_MARGIN) // 3,
-    )
-    if viewport_size <= 0:
-        raise ValueError("screen is too small for ultrawide-left-stack layout")
-
-    x = left_strip_width // 2 - viewport_size // 2
-    top_gap = (screen_height - viewport_size * 3) // 4
-    if top_gap < ULTRAWIDE_STACK_MARGIN:
-        top_gap = ULTRAWIDE_STACK_MARGIN
-    y_positions = (
-        top_gap,
-        top_gap * 2 + viewport_size,
-        top_gap * 3 + viewport_size * 2,
-    )
-    names = _expected_viewport_names()
+def _region_viewports(solution: dict[str, object], *, x_offset: int = 0, y_offset: int = 0) -> tuple[MonitorViewport, ...]:
+    regions = solution["regions"]
+    assert isinstance(regions, list)
     return tuple(
-        MonitorViewport(name=name, x=x, y=y, width=viewport_size, height=viewport_size)
-        for name, y in zip(names, y_positions)
+        MonitorViewport(
+            name=_region_id_to_dcs_name(region["region_id"]),
+            x=x_offset + int(region["x"]),
+            y=y_offset + int(region["y"]),
+            width=int(region["width"]),
+            height=int(region["height"]),
+        )
+        for region in regions
     )
 
 
 def build_monitor_setup_plan(*, main_width: int, main_height: int, mode: str = MODE_EXTENDED_RIGHT) -> MonitorSetupPlan:
     width = _require_positive_int(main_width, "main_width")
     height = _require_positive_int(main_height, "main_height")
+    layout = load_vision_layout()
+
     if mode == MODE_EXTENDED_RIGHT:
-        viewports = _build_monitor_viewports_extended(width)
+        export_solution = solve_layout_geometry(
+            layout,
+            output_width=COMPOSITE_CANVAS_WIDTH,
+            output_height=COMPOSITE_CANVAS_HEIGHT,
+        )
         total_width = width + COMPOSITE_CANVAS_WIDTH
         total_height = max(height, COMPOSITE_CANVAS_HEIGHT)
+        effective_main_x = 0
+        effective_main_y = 0
         effective_main_width = width
         effective_main_height = height
         canvas_width = COMPOSITE_CANVAS_WIDTH
         canvas_height = COMPOSITE_CANVAS_HEIGHT
-    elif mode == MODE_SINGLE_MONITOR:
-        viewports = _build_monitor_viewports_single(width, height)
-        top_band_height = max(viewport.y + viewport.height for viewport in viewports)
+        viewports = _region_viewports(export_solution, x_offset=width)
+    elif mode in {MODE_SINGLE_MONITOR, MODE_ULTRAWIDE_LEFT_STACK}:
+        solution = solve_layout_geometry(layout, output_width=width, output_height=height)
+        main_rect = solution["main_view_rect"]
+        strip_rect = solution["strip_rect"]
+        assert isinstance(main_rect, dict)
+        assert isinstance(strip_rect, dict)
         total_width = width
         total_height = height
-        effective_main_width = width
-        effective_main_height = height - top_band_height
-        canvas_width = width
-        canvas_height = top_band_height
-    elif mode == MODE_ULTRAWIDE_LEFT_STACK:
-        viewports = _build_monitor_viewports_ultrawide_left_stack(width, height)
-        main_view_width = int(round(height * (16 / 9)))
-        total_width = width
-        total_height = height
-        effective_main_width = main_view_width
-        effective_main_height = height
-        canvas_width = width - main_view_width
-        canvas_height = height
+        effective_main_x = int(main_rect["x"])
+        effective_main_y = int(main_rect["y"])
+        effective_main_width = int(main_rect["width"])
+        effective_main_height = int(main_rect["height"])
+        canvas_width = int(strip_rect["width"])
+        canvas_height = int(strip_rect["height"])
+        viewports = _region_viewports(solution)
     else:
         raise ValueError(f"unsupported mode: {mode}")
+
     lua_text = render_monitor_setup_lua(
         setup_name=MONITOR_SETUP_BASENAME,
         mode=mode,
+        main_x=effective_main_x,
+        main_y=effective_main_y,
         main_width=effective_main_width,
         main_height=effective_main_height,
         total_width=total_width,
@@ -221,6 +158,8 @@ def render_monitor_setup_lua(
     *,
     setup_name: str,
     mode: str,
+    main_x: int,
+    main_y: int,
     main_width: int,
     main_height: int,
     total_width: int,
@@ -232,21 +171,16 @@ def render_monitor_setup_lua(
     aspect = main_width / main_height
     if mode == MODE_EXTENDED_RIGHT:
         description = "SimTutor F/A-18C composite panel viewport PoC (extended desktop to the right)"
-        placement_comment = f"-- Composite export canvas on the right: {COMPOSITE_CANVAS_WIDTH}x{COMPOSITE_CANVAS_HEIGHT}"
-        center_x = 0
-        center_y = 0
+        placement_comment = f"-- Fixed debug export canvas on the right: {COMPOSITE_CANVAS_WIDTH}x{COMPOSITE_CANVAS_HEIGHT}"
     elif mode == MODE_SINGLE_MONITOR:
-        description = "SimTutor F/A-18C composite panel viewport PoC (single monitor top-row layout)"
-        placement_comment = f"-- Top-row viewport band on a single screen: {screen_width}x{screen_height - main_height}"
-        center_x = 0
-        center_y = screen_height - main_height
+        description = "SimTutor F/A-18C composite panel viewport PoC (single monitor normalized left-stack layout)"
+        placement_comment = f"-- Normalized export strip on a single screen: {screen_width - main_width}x{screen_height}"
     elif mode == MODE_ULTRAWIDE_LEFT_STACK:
-        description = "SimTutor F/A-18C composite panel viewport PoC (ultrawide left-stack layout)"
-        placement_comment = f"-- Left ultrawide strip for stacked MFCDs: {screen_width - main_width}x{screen_height}"
-        center_x = screen_width - main_width
-        center_y = 0
+        description = "SimTutor F/A-18C composite panel viewport PoC (ultrawide normalized left-stack layout)"
+        placement_comment = f"-- Normalized export strip on an ultrawide screen: {screen_width - main_width}x{screen_height}"
     else:
         raise ValueError(f"unsupported mode: {mode}")
+
     lines = [
         "_  = function(p) return p; end;",
         f"name = _('{setup_name}')",
@@ -259,8 +193,8 @@ def render_monitor_setup_lua(
         "Viewports = {}",
         "Viewports.Center =",
         "{",
-        f"    x = {center_x};",
-        f"    y = {center_y};",
+        f"    x = {main_x};",
+        f"    y = {main_y};",
         f"    width = {main_width};",
         f"    height = {main_height};",
         "    viewDx = 0;",
@@ -327,7 +261,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=str,
         choices=[MODE_EXTENDED_RIGHT, MODE_SINGLE_MONITOR, MODE_ULTRAWIDE_LEFT_STACK],
         default=MODE_EXTENDED_RIGHT,
-        help="Layout mode: extended-right uses a second desktop region; single-monitor places three MFCDs on the top band; ultrawide-left-stack uses the extra left strip of an ultrawide screen.",
+        help="Layout mode: extended-right uses a fixed debug canvas; single-monitor and ultrawide-left-stack both resolve the same normalized left-stack layout against the target screen.",
     )
     parser.add_argument("--main-width", type=int, required=True, help="Main screen width in pixels.")
     parser.add_argument("--main-height", type=int, required=True, help="Main screen height in pixels.")

--- a/tools/install_dcs_monitor_setup.py
+++ b/tools/install_dcs_monitor_setup.py
@@ -1,0 +1,364 @@
+"""
+Install a Saved Games monitor-setup Lua for the F/A-18C viewport PoC.
+
+Supported modes:
+- extended-right: place the 2560x1440 composite canvas to the right of the main viewport
+- single-monitor: place LEFT_MFCD/CENTER_MFCD/RIGHT_MFCD on the top band of one screen
+- ultrawide-left-stack: stack LEFT_MFCD/CENTER_MFCD/RIGHT_MFCD vertically in the extra left strip of an ultrawide screen
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+from adapters.vision_prompting import load_vision_layout
+from tools.install_dcs_hook import resolve_saved_games_dir
+
+MONITOR_SETUP_BASENAME = "SimTutor_FA18C_CompositePanel_v1"
+COMPOSITE_CANVAS_WIDTH = 2560
+COMPOSITE_CANVAS_HEIGHT = 1440
+TOP_ROW_CANONICAL_HEIGHT = 800
+MIN_SINGLE_MONITOR_MAIN_HEIGHT = 280
+MODE_EXTENDED_RIGHT = "extended-right"
+MODE_SINGLE_MONITOR = "single-monitor"
+MODE_ULTRAWIDE_LEFT_STACK = "ultrawide-left-stack"
+ULTRAWIDE_STACK_MARGIN = 24
+_VIEWPORT_REGION_TO_DCS_NAME = {
+    "left_ddi": "LEFT_MFCD",
+    "ampcd": "CENTER_MFCD",
+    "right_ddi": "RIGHT_MFCD",
+}
+
+
+@dataclass(frozen=True)
+class MonitorViewport:
+    name: str
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass(frozen=True)
+class MonitorSetupPlan:
+    setup_name: str
+    mode: str
+    main_width: int
+    main_height: int
+    total_width: int
+    total_height: int
+    canvas_width: int
+    canvas_height: int
+    viewports: tuple[MonitorViewport, ...]
+    lua_text: str
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    monitor_setup_path: Path
+    changed: bool
+    mode: str
+    total_width: int
+    total_height: int
+
+
+def _require_positive_int(value: int, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _expected_viewport_names() -> tuple[str, ...]:
+    return tuple(_VIEWPORT_REGION_TO_DCS_NAME.values())
+
+
+def _build_monitor_viewports_extended(main_width: int) -> tuple[MonitorViewport, ...]:
+    layout = load_vision_layout()
+    viewports: list[MonitorViewport] = []
+    for region in layout["regions"]:
+        region_id = region["region_id"]
+        dcs_name = _VIEWPORT_REGION_TO_DCS_NAME.get(region_id)
+        if dcs_name is None:
+            continue
+        viewports.append(
+            MonitorViewport(
+                name=dcs_name,
+                x=main_width + int(region["x"]),
+                y=int(region["y"]),
+                width=int(region["width"]),
+                height=int(region["height"]),
+            )
+        )
+    expected_names = _expected_viewport_names()
+    actual_names = tuple(viewport.name for viewport in viewports)
+    if actual_names != expected_names:
+        raise ValueError(f"unexpected viewport order: {actual_names!r}")
+    return tuple(viewports)
+
+
+def _single_monitor_scale(screen_width: int, screen_height: int) -> float:
+    width_scale = screen_width / COMPOSITE_CANVAS_WIDTH
+    height_scale = max(0.1, (screen_height - MIN_SINGLE_MONITOR_MAIN_HEIGHT) / TOP_ROW_CANONICAL_HEIGHT)
+    return min(width_scale, height_scale)
+
+
+def _build_monitor_viewports_single(screen_width: int, screen_height: int) -> tuple[MonitorViewport, ...]:
+    layout = load_vision_layout()
+    scale = _single_monitor_scale(screen_width, screen_height)
+    top_band_height = int(round(TOP_ROW_CANONICAL_HEIGHT * scale))
+    if screen_height - top_band_height < MIN_SINGLE_MONITOR_MAIN_HEIGHT:
+        raise ValueError("screen height is too small for single-monitor viewport layout")
+    viewports: list[MonitorViewport] = []
+    for region in layout["regions"]:
+        region_id = region["region_id"]
+        dcs_name = _VIEWPORT_REGION_TO_DCS_NAME.get(region_id)
+        if dcs_name is None:
+            continue
+        viewports.append(
+            MonitorViewport(
+                name=dcs_name,
+                x=int(round(int(region["x"]) * scale)),
+                y=int(round(int(region["y"]) * scale)),
+                width=int(round(int(region["width"]) * scale)),
+                height=int(round(int(region["height"]) * scale)),
+            )
+        )
+    expected_names = _expected_viewport_names()
+    actual_names = tuple(viewport.name for viewport in viewports)
+    if actual_names != expected_names:
+        raise ValueError(f"unexpected viewport order: {actual_names!r}")
+    return tuple(viewports)
+
+
+def _build_monitor_viewports_ultrawide_left_stack(screen_width: int, screen_height: int) -> tuple[MonitorViewport, ...]:
+    main_view_width = int(round(screen_height * (16 / 9)))
+    left_strip_width = screen_width - main_view_width
+    if left_strip_width <= 0:
+        raise ValueError("screen is not wide enough for ultrawide-left-stack layout")
+
+    viewport_size = min(
+        left_strip_width - 2 * ULTRAWIDE_STACK_MARGIN,
+        (screen_height - 4 * ULTRAWIDE_STACK_MARGIN) // 3,
+    )
+    if viewport_size <= 0:
+        raise ValueError("screen is too small for ultrawide-left-stack layout")
+
+    x = left_strip_width // 2 - viewport_size // 2
+    top_gap = (screen_height - viewport_size * 3) // 4
+    if top_gap < ULTRAWIDE_STACK_MARGIN:
+        top_gap = ULTRAWIDE_STACK_MARGIN
+    y_positions = (
+        top_gap,
+        top_gap * 2 + viewport_size,
+        top_gap * 3 + viewport_size * 2,
+    )
+    names = _expected_viewport_names()
+    return tuple(
+        MonitorViewport(name=name, x=x, y=y, width=viewport_size, height=viewport_size)
+        for name, y in zip(names, y_positions)
+    )
+
+
+def build_monitor_setup_plan(*, main_width: int, main_height: int, mode: str = MODE_EXTENDED_RIGHT) -> MonitorSetupPlan:
+    width = _require_positive_int(main_width, "main_width")
+    height = _require_positive_int(main_height, "main_height")
+    if mode == MODE_EXTENDED_RIGHT:
+        viewports = _build_monitor_viewports_extended(width)
+        total_width = width + COMPOSITE_CANVAS_WIDTH
+        total_height = max(height, COMPOSITE_CANVAS_HEIGHT)
+        effective_main_width = width
+        effective_main_height = height
+        canvas_width = COMPOSITE_CANVAS_WIDTH
+        canvas_height = COMPOSITE_CANVAS_HEIGHT
+    elif mode == MODE_SINGLE_MONITOR:
+        viewports = _build_monitor_viewports_single(width, height)
+        top_band_height = max(viewport.y + viewport.height for viewport in viewports)
+        total_width = width
+        total_height = height
+        effective_main_width = width
+        effective_main_height = height - top_band_height
+        canvas_width = width
+        canvas_height = top_band_height
+    elif mode == MODE_ULTRAWIDE_LEFT_STACK:
+        viewports = _build_monitor_viewports_ultrawide_left_stack(width, height)
+        main_view_width = int(round(height * (16 / 9)))
+        total_width = width
+        total_height = height
+        effective_main_width = main_view_width
+        effective_main_height = height
+        canvas_width = width - main_view_width
+        canvas_height = height
+    else:
+        raise ValueError(f"unsupported mode: {mode}")
+    lua_text = render_monitor_setup_lua(
+        setup_name=MONITOR_SETUP_BASENAME,
+        mode=mode,
+        main_width=effective_main_width,
+        main_height=effective_main_height,
+        total_width=total_width,
+        total_height=total_height,
+        screen_width=width,
+        screen_height=height,
+        viewports=viewports,
+    )
+    return MonitorSetupPlan(
+        setup_name=MONITOR_SETUP_BASENAME,
+        mode=mode,
+        main_width=effective_main_width,
+        main_height=effective_main_height,
+        total_width=total_width,
+        total_height=total_height,
+        canvas_width=canvas_width,
+        canvas_height=canvas_height,
+        viewports=viewports,
+        lua_text=lua_text,
+    )
+
+
+def render_monitor_setup_lua(
+    *,
+    setup_name: str,
+    mode: str,
+    main_width: int,
+    main_height: int,
+    total_width: int,
+    total_height: int,
+    screen_width: int,
+    screen_height: int,
+    viewports: tuple[MonitorViewport, ...],
+) -> str:
+    aspect = main_width / main_height
+    if mode == MODE_EXTENDED_RIGHT:
+        description = "SimTutor F/A-18C composite panel viewport PoC (extended desktop to the right)"
+        placement_comment = f"-- Composite export canvas on the right: {COMPOSITE_CANVAS_WIDTH}x{COMPOSITE_CANVAS_HEIGHT}"
+        center_x = 0
+        center_y = 0
+    elif mode == MODE_SINGLE_MONITOR:
+        description = "SimTutor F/A-18C composite panel viewport PoC (single monitor top-row layout)"
+        placement_comment = f"-- Top-row viewport band on a single screen: {screen_width}x{screen_height - main_height}"
+        center_x = 0
+        center_y = screen_height - main_height
+    elif mode == MODE_ULTRAWIDE_LEFT_STACK:
+        description = "SimTutor F/A-18C composite panel viewport PoC (ultrawide left-stack layout)"
+        placement_comment = f"-- Left ultrawide strip for stacked MFCDs: {screen_width - main_width}x{screen_height}"
+        center_x = screen_width - main_width
+        center_y = 0
+    else:
+        raise ValueError(f"unsupported mode: {mode}")
+    lines = [
+        "_  = function(p) return p; end;",
+        f"name = _('{setup_name}')",
+        f"Description = '{description}'",
+        "",
+        f"-- Recommended DCS resolution: {total_width}x{total_height}",
+        f"-- Main viewport: {main_width}x{main_height}",
+        placement_comment,
+        "",
+        "Viewports = {}",
+        "Viewports.Center =",
+        "{",
+        f"    x = {center_x};",
+        f"    y = {center_y};",
+        f"    width = {main_width};",
+        f"    height = {main_height};",
+        "    viewDx = 0;",
+        "    viewDy = 0;",
+        f"    aspect = {aspect:.10f};",
+        "}",
+        "",
+        "UIMainView = Viewports.Center",
+        "GU_MAIN_VIEWPORT = UIMainView",
+        "",
+    ]
+    for viewport in viewports:
+        lines.extend(
+            [
+                f"{viewport.name} =",
+                "{",
+                f"    x = {viewport.x};",
+                f"    y = {viewport.y};",
+                f"    width = {viewport.width};",
+                f"    height = {viewport.height};",
+                "}",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _monitor_setup_path(saved_games_dir: Path) -> Path:
+    return saved_games_dir / "Config" / "MonitorSetup" / f"{MONITOR_SETUP_BASENAME}.lua"
+
+
+def install_monitor_setup(
+    *,
+    saved_games_dir: Path,
+    main_width: int,
+    main_height: int,
+    mode: str = MODE_EXTENDED_RIGHT,
+) -> InstallResult:
+    plan = build_monitor_setup_plan(main_width=main_width, main_height=main_height, mode=mode)
+    path = _monitor_setup_path(saved_games_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    changed = True
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if existing == plan.lua_text:
+            changed = False
+    if changed:
+        path.write_text(plan.lua_text, encoding="utf-8")
+    return InstallResult(
+        monitor_setup_path=path,
+        changed=changed,
+        mode=plan.mode,
+        total_width=plan.total_width,
+        total_height=plan.total_height,
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Install SimTutor DCS monitor setup for the F/A-18C viewport PoC.")
+    parser.add_argument("--saved-games", type=str, default=None, help="Saved Games directory (defaults to <home>/Saved Games/<variant>).")
+    parser.add_argument("--dcs-variant", type=str, default="DCS", help="DCS variant folder under Saved Games (e.g. DCS, DCS.openbeta).")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=[MODE_EXTENDED_RIGHT, MODE_SINGLE_MONITOR, MODE_ULTRAWIDE_LEFT_STACK],
+        default=MODE_EXTENDED_RIGHT,
+        help="Layout mode: extended-right uses a second desktop region; single-monitor places three MFCDs on the top band; ultrawide-left-stack uses the extra left strip of an ultrawide screen.",
+    )
+    parser.add_argument("--main-width", type=int, required=True, help="Main screen width in pixels.")
+    parser.add_argument("--main-height", type=int, required=True, help="Main screen height in pixels.")
+    return parser
+
+
+def main() -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    saved_games_dir = resolve_saved_games_dir(args.saved_games, args.dcs_variant)
+
+    try:
+        result = install_monitor_setup(
+            saved_games_dir=saved_games_dir,
+            main_width=args.main_width,
+            main_height=args.main_height,
+            mode=args.mode,
+        )
+    except ValueError as exc:
+        print(f"Install failed: {exc}")
+        return 1
+
+    print(
+        "SimTutor monitor setup complete: "
+        f"path={result.monitor_setup_path}, "
+        f"mode={result.mode}, "
+        f"changed={result.changed}, "
+        f"recommended_resolution={result.total_width}x{result.total_height}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Introduced SVG asset for F/A-18C Composite Panel Layout v1.
- Created English and Chinese markdown documentation for the layout.
- Implemented vision prompting utilities for loading and rendering the layout.
- Updated telemetry contracts to include layout_id in VisionObservation.
- Enhanced pack metadata to include vision layout ID and priority steps.
- Added vision layout YAML file defining regions and properties.
- Developed tests for vision layout loading, rendering, and validation.