### PR TITLE
fix: tighten S19 final GO result detection — coerce all non-final_go result_kinds to not_seen

### DIFF
--- a/adapters/step_inference.py
+++ b/adapters/step_inference.py
@@ -896,7 +896,7 @@ def _vision_fact_state_is_seen(fact: Mapping[str, Any] | None) -> bool:
 def _is_s18_final_go_result_fact(fact: Mapping[str, Any]) -> bool:
     kind = fact.get("result_kind")
     if kind is None:
-        return fact.get("state") == "seen"
+        return False
     return kind == "final_go"
 
 

--- a/core/vision_facts.py
+++ b/core/vision_facts.py
@@ -300,7 +300,7 @@ def _coerce_s18_result_fact_state(
         return state
     if result_kind == "final_go":
         return state
-    if result_kind in {"intermediate_go", "in_test", "not_ready"}:
+    if result_kind != "final_go":
         return "not_seen"
     return state
 

--- a/tests/test_vision_fact_state.py
+++ b/tests/test_vision_fact_state.py
@@ -178,7 +178,7 @@ def test_merge_vision_fact_observation_downgrades_nonfinal_s18_go_claim_from_see
     )
 
     assert snapshot["fcsmc_final_go_result_visible"]["result_kind"] == "other"
-    assert snapshot["fcsmc_final_go_result_visible"]["state"] == "seen"
+    assert snapshot["fcsmc_final_go_result_visible"]["state"] == "not_seen"
     assert "confidence" not in snapshot["fcsmc_final_go_result_visible"]
 
 
@@ -599,7 +599,7 @@ def test_extract_vision_fact_snapshot_does_not_backfill_final_go_from_only_fcsa_
     )
 
     assert snapshot["fcsmc_final_go_result_visible"]["result_kind"] == "other"
-    assert snapshot["fcsmc_final_go_result_visible"]["state"] == "seen"
+    assert snapshot["fcsmc_final_go_result_visible"]["state"] == "not_seen"
 
 
 def test_extract_vision_fact_snapshot_strips_invalid_result_kind_when_note_cannot_backfill() -> None:


### PR DESCRIPTION
## Summary
- `_coerce_s18_result_fact_state` now coerces ALL non-`final_go` result_kinds (including `other`) to `not_seen` on `fcsmc_final_go_result_visible`
- `_is_s18_final_go_result_fact` returns `False` when `result_kind` is `None` instead of falling back to `state == "seen"`
- Updated 2 test assertions that validated the old buggy behavior

## Test plan
- [x] All 1094 tests pass
- [x] `fcsmc_final_go_result_visible` with `result_kind="other"` → `state="not_seen"`
- [x] `fcsmc_final_go_result_visible` with `result_kind=None` → not counted as seen in `_is_s18_final_go_result_fact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)