### PR TITLE
fix: add latch and debounce for S22 BINGO fuel to prevent double-tap requirement

### DIFF
--- a/adapters/telemetry_pipeline.py
+++ b/adapters/telemetry_pipeline.py
@@ -126,6 +126,7 @@ _MOMENTARY_COMPLETION_KEYS: tuple[str, ...] = (
     "fcs_reset_complete",
     "takeoff_trim_set",
     "probe_cycle_complete",
+    "bingo_fuel_set",
 )
 _MOMENTARY_COMPLETION_TRIGGER_VARS: dict[str, str] = {
     "fire_test_complete": "fire_test_active",
@@ -135,6 +136,7 @@ _MOMENTARY_COMPLETION_TRIGGER_VARS: dict[str, str] = {
     "fcs_reset_complete": "fcs_reset_pressed",
     "takeoff_trim_set": "takeoff_trim_pressed",
     "probe_cycle_complete": "probe_extended",
+    "bingo_fuel_set": "ifei_up_or_down_pressed",
 }
 _COMPLETION_LATCHES: OrderedDict[str, dict[str, bool | float]] = OrderedDict()
 _COMPLETION_LATCHES_LOADED = False

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -1635,6 +1635,29 @@ def _build_procedural_action_hint(
             "On the right DDI BIT FAILURES page, press PB5 to enter the FCS-MC BIT page before holding the FCS BIT switch.",
         )
 
+    if inferred_step_id == "S22":
+        allowed = {item for item in allowed_targets if isinstance(item, str) and item}
+        if not allowed:
+            return None
+
+        def _hint(target: str, reason: str) -> dict[str, Any] | None:
+            if target not in allowed:
+                return None
+            return {"target": target, "reason": reason}
+
+        if vars_selected.get("bingo_fuel_set") is True:
+            return None
+        if vars_selected.get("ifei_up_pressed") is True or vars_selected.get("ifei_down_pressed") is True:
+            return _hint(
+                "ifei_up_button",
+                "IFEI button press detected — the BINGO fuel value has been set; wait a moment for the updated value to register.",
+            )
+        return _hint(
+            "ifei_up_button",
+            "Press the IFEI UP button to set the BINGO fuel value for the mission.",
+        )
+
+
     if inferred_step_id != "S09":
         return None
     if vars_selected.get("comm1_freq_134_000") is True:

--- a/packs/fa18c_startup/delta_policy.yaml
+++ b/packs/fa18c_startup/delta_policy.yaml
@@ -18,6 +18,7 @@ ignore_bios_keys:
 debounce_ms_by_key:
   SAI_PITCH: 300
   SAI_RATE_OF_TURN: 300
+  IFEI_BINGO: 300
 
 epsilon_by_key:
   SAI_PITCH: 8.0

--- a/packs/fa18c_startup/telemetry_map.yaml
+++ b/packs/fa18c_startup/telemetry_map.yaml
@@ -155,6 +155,7 @@ vars:
 
   ifei_up_pressed: "bios.IFEI_UP_BTN == 1"
   ifei_down_pressed: "bios.IFEI_DWN_BTN == 1"
+  ifei_up_or_down_pressed: "derived(vars.ifei_up_pressed or vars.ifei_down_pressed)"
   bingo_fuel_set: "derived(num(bios.IFEI_BINGO) > 0)"
 
   standby_pressure_set_0: "derived(num(bios.STBY_PRESS_SET_0))"


### PR DESCRIPTION
## Summary
- Added `bingo_fuel_set` to completion latch mechanism so the first successful observation persists across frames
- Added `ifei_up_or_down_pressed` derived variable as latch trigger
- Added 300ms debounce for `IFEI_BINGO` in delta policy
- Added S22 procedural action hint for BINGO fuel guidance

## Test plan
- [x] All non-IO tests pass
- [x] S22 now produces contextual hints based on BINGO/latch state

🤖 Generated with [Claude Code](https://claude.com/claude-code)