### PR TITLE
fix: extend S20 overlay text rewrite to cover all four-down checklist targets

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -3463,20 +3463,25 @@ class LiveDcsTutorLoop:
                 response.metadata["action_hint_overlay_override_original_message"] = original_message
             if original_explanations and original_explanations != [rewritten]:
                 response.metadata["action_hint_overlay_override_original_explanations"] = original_explanations
-        elif (
-            inferred_step_id == "S20"
-            and override_kind == "action_hint"
-            and action_target == "launch_bar_switch"
-        ):
+        elif inferred_step_id == "S20" and override_kind == "action_hint":
             original_message = response.message
             original_explanations = list(response.explanations)
-            if self.lang == "zh":
-                rewritten = "加油管在本次启动中已经完成伸出检查。下一步请继续四落检查，操作发射杆开关。"
+            if action_target == "launch_bar_switch":
+                if self.lang == "zh":
+                    rewritten = "加油管在本次启动中已经完成伸出检查。下一步请继续四落检查，操作发射杆开关。"
+                else:
+                    rewritten = (
+                        "The refueling probe has already been cycled during this startup. "
+                        "Continue the four-down checklist with the launch bar switch next."
+                    )
             else:
-                rewritten = (
-                    "The refueling probe has already been cycled during this startup. "
-                    "Continue the four-down checklist with the launch bar switch next."
-                )
+                hint_reason = action_hint.get("reason") if isinstance(action_hint, Mapping) else None
+                if isinstance(hint_reason, str) and hint_reason:
+                    rewritten = hint_reason
+                elif self.lang == "zh":
+                    rewritten = "请按系统提示操作当前高亮目标，继续完成四落检查。"
+                else:
+                    rewritten = "Follow the highlighted target to continue the four-down checklist."
             response.message = rewritten
             response.explanations = [rewritten]
             if original_message != rewritten:


### PR DESCRIPTION
## Summary
- Generalized the S20 handler in `_apply_action_hint_overlay_override` to cover all four-down checklist targets (refuel_probe_switch, launch_bar_switch, arresting_hook_handle, pitot_heater_switch)
- Uses `action_hint["reason"]` for non-launch_bar targets to keep text consistent with the highlighted control
- Falls back to generic four-down guidance if reason is unavailable

## Test plan
- [x] All non-IO tests pass
- [x] S20 overlay target and help text now agree for all four-down checklist items

🤖 Generated with [Claude Code](https://claude.com/claude-code)