### PR TITLE
fix: prevent S06 bleed air auto-completion and add S16 flap switch guidance

### DIFF
--- a/adapters/telemetry_pipeline.py
+++ b/adapters/telemetry_pipeline.py
@@ -92,6 +92,7 @@ DEFAULT_SELECTED_VAR_KEYS: tuple[str, ...] = (
     "obogs_ready",
     "fcs_reset_pressed",
     "fcs_reset_complete",
+    "flap_mode_value",
     "flap_auto",
     "flap_configured",
     "takeoff_trim_pressed",

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -1623,6 +1623,29 @@ def _build_procedural_action_hint(
             return _hint("obogs_flow_knob", "OBOGS control is already ON, but FLOW is not yet ON; set the OXY FLOW knob next.")
         return None
 
+    if inferred_step_id == "S16":
+        allowed = {item for item in allowed_targets if isinstance(item, str) and item}
+        if not allowed:
+            return None
+
+        def _hint(target: str, reason: str) -> dict[str, Any] | None:
+            if target not in allowed:
+                return None
+            return {"target": target, "reason": reason}
+
+        if vars_selected.get("flap_auto") is True:
+            return None
+        flap_mode = vars_selected.get("flap_mode_value")
+        if isinstance(flap_mode, (int, float)) and int(flap_mode) == 2:
+            return _hint(
+                "flap_switch",
+                "Flap switch is at FULL (cold-start default). Move the flap switch to AUTO.",
+            )
+        return _hint(
+            "flap_switch",
+            "Set the flap switch to AUTO before continuing.",
+        )
+
     if inferred_step_id == "S19":
         allowed = {item for item in allowed_targets if isinstance(item, str) and item}
         if not allowed:

--- a/packs/fa18c_startup/telemetry_map.yaml
+++ b/packs/fa18c_startup/telemetry_map.yaml
@@ -66,7 +66,7 @@ vars:
   right_ddi_on: "bios.RIGHT_DDI_BRT_CTL > 0"
   mpcd_on: "bios.AMPCD_BRT_CTL > 0"
   hud_on: "bios.HUD_SYM_BRT > 0"
-  bleed_air_cycle_complete: "derived(vars.bleed_air_norm or vars.engine_crank_left or vars.left_ddi_on or vars.right_ddi_on or vars.rpm_l_gte_60)"
+  bleed_air_cycle_complete: "derived(vars.bleed_air_norm)"
   core_avionics_online: "derived(bios.LEFT_DDI_BRT_CTL > 0 and bios.RIGHT_DDI_BRT_CTL > 0 and bios.AMPCD_BRT_CTL > 0 and bios.HUD_SYM_BRT > 0)"
 
   # Key switches / sensor panel

--- a/tests/test_var_resolver.py
+++ b/tests/test_var_resolver.py
@@ -378,6 +378,7 @@ def test_var_resolver_pack_fire_test_completion_requires_direct_switch_evidence(
             "R_GEN_SW": 1,
             "APU_CONTROL_SW": 1,
             "APU_READY_LT": 1,
+            "BLEED_AIR_KNOB": 2,
             "ENGINE_CRANK_SW": 0,
             "IFEI_RPM_R": 68,
             "IFEI_RPM_L": 65,


### PR DESCRIPTION
## Summary
**S06**: Removed unrelated fallback conditions from `bleed_air_cycle_complete`. Previously, DDI power-up (S08), left engine crank, or left RPM≥60 would retroactively mark the bleed air cycle as complete. Now only `bleed_air_norm` (knob physically at NORM) satisfies the check.

**S16**: Added procedural action hint to guide the user to set the flap switch to AUTO. When the flap is at FULL (cold-start default), the hint specifically mentions this. Also added `flap_mode_value` to the telemetry pipeline selected var keys.

## Test plan
- [x] All non-IO tests pass
- [x] `bleed_air_cycle_complete` now only true when `BLEED_AIR_KNOB == 2`
- [x] S16 hint generates correct guidance for flap at FULL vs other non-AUTO positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)