### PR TITLE
feat: add StepHarnessSpec contract

### DIFF
--- a/adapters/step_harness_specs.py
+++ b/adapters/step_harness_specs.py
@@ -60,7 +60,7 @@ def step_signal_profiles_from_specs(
             "observability": spec.observability_status,
             "observability_status": spec.observability_status,
             "ui_targets": list(spec.declared_ui_targets),
-            "overlay_enabled": bool(spec.allowed_overlay_targets),
+            "overlay_enabled": spec.overlay_enabled,
             "requires_visual_confirmation": spec.requires_visual_confirmation,
             "step_harness_spec": spec,
         }
@@ -78,7 +78,7 @@ def step_fallback_profiles_from_specs(
         profiles[step_id] = {
             "ui_targets": list(spec.declared_ui_targets),
             "gate_var_refs": list(spec.telemetry_facts),
-            "overlay_enabled": bool(spec.allowed_overlay_targets),
+            "overlay_enabled": spec.overlay_enabled,
             "step_harness_spec": spec,
         }
     return profiles
@@ -164,6 +164,7 @@ def _build_step_harness_spec(
         signal_quality=signal_quality,
         requires_visual_confirmation=requires_visual_confirmation,
         declared_ui_targets=raw_targets,
+        overlay_enabled=overlay_enabled,
     )
 
 

--- a/adapters/step_harness_specs.py
+++ b/adapters/step_harness_specs.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from adapters.pack_gates import load_pack_gate_config
-from adapters.step_inference import load_pack_steps
+from adapters.step_inference import format_gate_rule_condition, load_pack_steps
 from core.step_harness import RecoveryActionPolicy, SignalQualityRequirement, StepHarnessSpec
 from core.step_signal_metadata import (
     STEP_EVIDENCE_REQUIREMENT_VALUES,
@@ -35,13 +35,15 @@ def load_step_harness_specs(
     vision_config = _load_vision_config(path)
 
     specs: dict[str, StepHarnessSpec] = {}
-    for step in steps:
+    for step_idx, step in enumerate(steps):
         step_id = _extract_step_id(step)
         if step_id is None or step_id in specs:
             continue
         specs[step_id] = _build_step_harness_spec(
             step_id,
+            step_idx=step_idx,
             step=step,
+            pack_path=path,
             precondition_gates=precondition_gates,
             completion_gates=completion_gates,
             vision_config=vision_config,
@@ -57,7 +59,7 @@ def step_signal_profiles_from_specs(
         profile: dict[str, Any] = {
             "observability": spec.observability_status,
             "observability_status": spec.observability_status,
-            "ui_targets": list(spec.allowed_overlay_targets),
+            "ui_targets": list(spec.declared_ui_targets),
             "overlay_enabled": bool(spec.allowed_overlay_targets),
             "requires_visual_confirmation": spec.requires_visual_confirmation,
             "step_harness_spec": spec,
@@ -74,7 +76,7 @@ def step_fallback_profiles_from_specs(
     profiles: dict[str, dict[str, Any]] = {}
     for step_id, spec in specs.items():
         profiles[step_id] = {
-            "ui_targets": list(spec.allowed_overlay_targets),
+            "ui_targets": list(spec.declared_ui_targets),
             "gate_var_refs": list(spec.telemetry_facts),
             "overlay_enabled": bool(spec.allowed_overlay_targets),
             "step_harness_spec": spec,
@@ -85,17 +87,23 @@ def step_fallback_profiles_from_specs(
 def _build_step_harness_spec(
     step_id: str,
     *,
+    step_idx: int,
     step: Mapping[str, Any],
+    pack_path: Path | None,
     precondition_gates: Mapping[str, Any],
     completion_gates: Mapping[str, Any],
     vision_config: Mapping[str, Any],
 ) -> StepHarnessSpec:
     harness = step.get("harness")
     harness_map = harness if isinstance(harness, Mapping) else {}
-    required_observables = _evidence_requirements(step.get("evidence_requirements"))
+    required_observables = _evidence_requirements(
+        step.get("evidence_requirements"),
+        step_idx=step_idx,
+        pack_path=pack_path,
+    )
     optional_observables = _dedupe_non_empty_strings(harness_map.get("optional_observables"))
-    raw_targets = _dedupe_non_empty_strings(step.get("ui_targets"))
-    overlay_enabled = step.get("overlay_enabled", True) is not False
+    raw_targets = _ui_targets(step.get("ui_targets"), step_idx=step_idx, pack_path=pack_path)
+    overlay_enabled = _overlay_enabled(step.get("overlay_enabled"), step_idx=step_idx, pack_path=pack_path)
     allowed_overlay_targets = raw_targets if overlay_enabled else ()
     forbidden_overlay_targets = _dedupe_non_empty_strings(harness_map.get("forbidden_overlay_targets"))
     if not overlay_enabled:
@@ -106,19 +114,19 @@ def _build_step_harness_spec(
         precondition_gates=precondition_gates,
         completion_gates=completion_gates,
     )
-    vision_facts = _collect_step_vision_fact_refs(step_id, vision_config)
+    vision_facts, completion_vision_facts = _collect_step_vision_fact_refs(step_id, vision_config)
     recent_action_facts = (
-        tuple(f"RECENT_ACTIONS.{target}" for target in allowed_overlay_targets)
+        tuple(f"RECENT_ACTIONS.{target}" for target in raw_targets)
         if "delta" in required_observables
         else ()
     )
     completion_predicates = _completion_predicates(
         step_id,
         completion_gates=completion_gates,
-        vision_facts=vision_facts,
+        vision_facts=completion_vision_facts,
     )
 
-    observability = normalize_observability_status(step.get("observability")) or "observable"
+    observability = _observability_status(step.get("observability"), step_idx=step_idx, pack_path=pack_path)
     requires_visual_confirmation_raw = step.get("requires_visual_confirmation")
     requires_visual_confirmation = (
         bool(requires_visual_confirmation_raw)
@@ -137,7 +145,7 @@ def _build_step_harness_spec(
     )
     recovery_policy = _recovery_policy(
         requires_visual_confirmation=requires_visual_confirmation,
-        allowed_overlay_targets=allowed_overlay_targets,
+        recovery_targets=raw_targets,
         harness_map=harness_map,
     )
     return StepHarnessSpec(
@@ -155,6 +163,7 @@ def _build_step_harness_spec(
         observability_status=observability,
         signal_quality=signal_quality,
         requires_visual_confirmation=requires_visual_confirmation,
+        declared_ui_targets=raw_targets,
     )
 
 
@@ -173,13 +182,72 @@ def _extract_step_id(step: Mapping[str, Any]) -> str | None:
     return None
 
 
-def _evidence_requirements(raw: Any) -> tuple[str, ...]:
+def _pack_path_text(pack_path: Path | None) -> str:
+    return str(pack_path) if pack_path is not None else "<default pack>"
+
+
+def _observability_status(raw: Any, *, step_idx: int, pack_path: Path | None) -> str:
+    if raw is None:
+        return "observable"
+    observability = normalize_observability_status(raw)
+    if observability is None:
+        allowed = ", ".join(sorted(("observable", "partial", "unobservable")))
+        raise ValueError(
+            f"pack.steps[{step_idx}].observability must be one of {{{allowed}}}: {_pack_path_text(pack_path)}"
+        )
+    return observability
+
+
+def _evidence_requirements(raw: Any, *, step_idx: int, pack_path: Path | None) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"pack.steps[{step_idx}].evidence_requirements must be a list: {_pack_path_text(pack_path)}"
+        )
     out: list[str] = []
-    for item in _iter_strings(raw):
-        if item not in STEP_EVIDENCE_REQUIREMENT_VALUES or item in out:
+    for req_idx, item in enumerate(raw):
+        if not isinstance(item, str) or not item:
+            raise ValueError(
+                f"pack.steps[{step_idx}].evidence_requirements[{req_idx}] must be non-empty string: "
+                f"{_pack_path_text(pack_path)}"
+            )
+        if item not in STEP_EVIDENCE_REQUIREMENT_VALUES:
+            allowed = ", ".join(sorted(STEP_EVIDENCE_REQUIREMENT_VALUES))
+            raise ValueError(
+                f"pack.steps[{step_idx}].evidence_requirements[{req_idx}] must be one of "
+                f"{{{allowed}}}: {_pack_path_text(pack_path)}"
+            )
+        if item in out:
             continue
         out.append(item)
     return tuple(out)
+
+
+def _ui_targets(raw: Any, *, step_idx: int, pack_path: Path | None) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"pack.steps[{step_idx}].ui_targets must be a list: {_pack_path_text(pack_path)}")
+    out: list[str] = []
+    for target_idx, target in enumerate(raw):
+        if not isinstance(target, str) or not target:
+            raise ValueError(
+                f"pack.steps[{step_idx}].ui_targets[{target_idx}] must be non-empty string: "
+                f"{_pack_path_text(pack_path)}"
+            )
+        if target in out:
+            continue
+        out.append(target)
+    return tuple(out)
+
+
+def _overlay_enabled(raw: Any, *, step_idx: int, pack_path: Path | None) -> bool:
+    if raw is None:
+        return True
+    if not isinstance(raw, bool):
+        raise ValueError(f"pack.steps[{step_idx}].overlay_enabled must be a bool: {_pack_path_text(pack_path)}")
+    return raw
 
 
 def _dedupe_non_empty_strings(raw: Any) -> tuple[str, ...]:
@@ -244,12 +312,32 @@ def _normalize_rule_var_ref(raw: Any) -> str | None:
     return f"VARS.{value}"
 
 
-def _collect_step_vision_fact_refs(step_id: str, vision_config: Mapping[str, Any]) -> tuple[str, ...]:
+def _collect_step_vision_fact_refs(
+    step_id: str,
+    vision_config: Mapping[str, Any],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
     binding = vision_config.get("step_bindings", {}).get(step_id, {})
-    if not isinstance(binding, Mapping):
-        return ()
-    fact_ids = _dedupe((*_iter_strings(binding.get("all_of")), *_iter_strings(binding.get("any_of"))))
-    return tuple(f"VISION_FACTS.{fact_id}" for fact_id in fact_ids)
+    binding_fact_ids: tuple[str, ...] = ()
+    if isinstance(binding, Mapping):
+        binding_fact_ids = _dedupe((*_iter_strings(binding.get("all_of")), *_iter_strings(binding.get("any_of"))))
+
+    support_fact_ids: list[str] = list(binding_fact_ids)
+    facts_by_id = vision_config.get("facts_by_id")
+    if isinstance(facts_by_id, Mapping):
+        for fact_id, fact in facts_by_id.items():
+            if not isinstance(fact_id, str) or not isinstance(fact, Mapping):
+                continue
+            steps = fact.get("steps")
+            if not isinstance(steps, (list, tuple)) or step_id not in steps:
+                continue
+            support_fact_ids.append(fact_id)
+
+    all_fact_ids = _dedupe(support_fact_ids)
+    completion_fact_ids = _dedupe(binding_fact_ids)
+    return (
+        tuple(f"VISION_FACTS.{fact_id}" for fact_id in all_fact_ids),
+        tuple(f"VISION_FACTS.{fact_id}" for fact_id in completion_fact_ids),
+    )
 
 
 def _completion_predicates(
@@ -259,10 +347,15 @@ def _completion_predicates(
     vision_facts: tuple[str, ...],
 ) -> tuple[str, ...]:
     predicates: list[str] = []
-    if _coerce_rules(completion_gates.get(step_id)):
+    completion_rules = _coerce_rules(completion_gates.get(step_id))
+    if completion_rules:
         predicates.append(f"GATES.{step_id}.completion")
+        for rule in completion_rules:
+            condition = format_gate_rule_condition(rule)
+            if condition:
+                predicates.append(condition)
     predicates.extend(f"{fact_ref}==seen" for fact_ref in vision_facts)
-    return tuple(predicates)
+    return _dedupe(predicates)
 
 
 def _signal_quality_requirement(
@@ -321,7 +414,7 @@ def _latch_semantics(
 def _recovery_policy(
     *,
     requires_visual_confirmation: bool,
-    allowed_overlay_targets: tuple[str, ...],
+    recovery_targets: tuple[str, ...],
     harness_map: Mapping[str, Any],
 ) -> RecoveryActionPolicy:
     raw = harness_map.get("recovery_policy")
@@ -334,9 +427,9 @@ def _recovery_policy(
                 fallback_message=raw.get("fallback_message") if isinstance(raw.get("fallback_message"), str) else None,
             )
     if requires_visual_confirmation:
-        return RecoveryActionPolicy(kind="visual_confirmation", allowed_targets=allowed_overlay_targets)
-    if allowed_overlay_targets:
-        return RecoveryActionPolicy(kind="retry_allowed_targets", allowed_targets=allowed_overlay_targets)
+        return RecoveryActionPolicy(kind="visual_confirmation", allowed_targets=recovery_targets)
+    if recovery_targets:
+        return RecoveryActionPolicy(kind="retry_allowed_targets", allowed_targets=recovery_targets)
     return RecoveryActionPolicy(kind="manual_guidance")
 
 

--- a/adapters/step_harness_specs.py
+++ b/adapters/step_harness_specs.py
@@ -1,0 +1,363 @@
+"""
+Pack-derived StepHarnessSpec loader.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from adapters.pack_gates import load_pack_gate_config
+from adapters.step_inference import load_pack_steps
+from core.step_harness import RecoveryActionPolicy, SignalQualityRequirement, StepHarnessSpec
+from core.step_signal_metadata import (
+    STEP_EVIDENCE_REQUIREMENT_VALUES,
+    compute_requires_visual_confirmation,
+    normalize_observability_status,
+)
+from core.vision_facts import VisionFactsConfigError, load_vision_facts_config
+
+
+_DEFAULT_LATCH_SEMANTICS = "none"
+
+
+def load_step_harness_specs(
+    pack_path: str | Path | None = None,
+    *,
+    scenario_profile: str | None = None,
+) -> dict[str, StepHarnessSpec]:
+    path = Path(pack_path) if pack_path else None
+    steps = load_pack_steps(path)
+    gate_config = load_pack_gate_config(path, scenario_profile=scenario_profile)
+    precondition_gates = gate_config.get("precondition_gates", {})
+    completion_gates = gate_config.get("completion_gates", {})
+    vision_config = _load_vision_config(path)
+
+    specs: dict[str, StepHarnessSpec] = {}
+    for step in steps:
+        step_id = _extract_step_id(step)
+        if step_id is None or step_id in specs:
+            continue
+        specs[step_id] = _build_step_harness_spec(
+            step_id,
+            step=step,
+            precondition_gates=precondition_gates,
+            completion_gates=completion_gates,
+            vision_config=vision_config,
+        )
+    return specs
+
+
+def step_signal_profiles_from_specs(
+    specs: Mapping[str, StepHarnessSpec],
+) -> dict[str, dict[str, Any]]:
+    profiles: dict[str, dict[str, Any]] = {}
+    for step_id, spec in specs.items():
+        profile: dict[str, Any] = {
+            "observability": spec.observability_status,
+            "observability_status": spec.observability_status,
+            "ui_targets": list(spec.allowed_overlay_targets),
+            "overlay_enabled": bool(spec.allowed_overlay_targets),
+            "requires_visual_confirmation": spec.requires_visual_confirmation,
+            "step_harness_spec": spec,
+        }
+        if spec.required_observables:
+            profile["evidence_requirements"] = list(spec.required_observables)
+        profiles[step_id] = profile
+    return profiles
+
+
+def step_fallback_profiles_from_specs(
+    specs: Mapping[str, StepHarnessSpec],
+) -> dict[str, dict[str, Any]]:
+    profiles: dict[str, dict[str, Any]] = {}
+    for step_id, spec in specs.items():
+        profiles[step_id] = {
+            "ui_targets": list(spec.allowed_overlay_targets),
+            "gate_var_refs": list(spec.telemetry_facts),
+            "overlay_enabled": bool(spec.allowed_overlay_targets),
+            "step_harness_spec": spec,
+        }
+    return profiles
+
+
+def _build_step_harness_spec(
+    step_id: str,
+    *,
+    step: Mapping[str, Any],
+    precondition_gates: Mapping[str, Any],
+    completion_gates: Mapping[str, Any],
+    vision_config: Mapping[str, Any],
+) -> StepHarnessSpec:
+    harness = step.get("harness")
+    harness_map = harness if isinstance(harness, Mapping) else {}
+    required_observables = _evidence_requirements(step.get("evidence_requirements"))
+    optional_observables = _dedupe_non_empty_strings(harness_map.get("optional_observables"))
+    raw_targets = _dedupe_non_empty_strings(step.get("ui_targets"))
+    overlay_enabled = step.get("overlay_enabled", True) is not False
+    allowed_overlay_targets = raw_targets if overlay_enabled else ()
+    forbidden_overlay_targets = _dedupe_non_empty_strings(harness_map.get("forbidden_overlay_targets"))
+    if not overlay_enabled:
+        forbidden_overlay_targets = _dedupe((*forbidden_overlay_targets, *raw_targets))
+
+    telemetry_facts = _collect_gate_var_refs(
+        step_id,
+        precondition_gates=precondition_gates,
+        completion_gates=completion_gates,
+    )
+    vision_facts = _collect_step_vision_fact_refs(step_id, vision_config)
+    recent_action_facts = (
+        tuple(f"RECENT_ACTIONS.{target}" for target in allowed_overlay_targets)
+        if "delta" in required_observables
+        else ()
+    )
+    completion_predicates = _completion_predicates(
+        step_id,
+        completion_gates=completion_gates,
+        vision_facts=vision_facts,
+    )
+
+    observability = normalize_observability_status(step.get("observability")) or "observable"
+    requires_visual_confirmation_raw = step.get("requires_visual_confirmation")
+    requires_visual_confirmation = (
+        bool(requires_visual_confirmation_raw)
+        if isinstance(requires_visual_confirmation_raw, bool)
+        else compute_requires_visual_confirmation(observability, required_observables)
+    )
+    signal_quality = _signal_quality_requirement(
+        vision_facts=vision_facts,
+        vision_config=vision_config,
+        harness_map=harness_map,
+    )
+    latch_semantics = _latch_semantics(
+        vision_facts=vision_facts,
+        vision_config=vision_config,
+        harness_map=harness_map,
+    )
+    recovery_policy = _recovery_policy(
+        requires_visual_confirmation=requires_visual_confirmation,
+        allowed_overlay_targets=allowed_overlay_targets,
+        harness_map=harness_map,
+    )
+    return StepHarnessSpec(
+        step_id=step_id,
+        required_observables=required_observables,
+        optional_observables=optional_observables,
+        telemetry_facts=telemetry_facts,
+        vision_facts=vision_facts,
+        recent_action_facts=recent_action_facts,
+        completion_predicates=completion_predicates,
+        latch_semantics=latch_semantics,
+        allowed_overlay_targets=allowed_overlay_targets,
+        forbidden_overlay_targets=forbidden_overlay_targets,
+        recovery_policy=recovery_policy,
+        observability_status=observability,
+        signal_quality=signal_quality,
+        requires_visual_confirmation=requires_visual_confirmation,
+    )
+
+
+def _load_vision_config(pack_path: Path | None) -> dict[str, Any]:
+    try:
+        return load_vision_facts_config(pack_path=pack_path) if pack_path is not None else load_vision_facts_config()
+    except (FileNotFoundError, OSError, ValueError, VisionFactsConfigError):
+        return {"facts_by_id": {}, "step_bindings": {}}
+
+
+def _extract_step_id(step: Mapping[str, Any]) -> str | None:
+    for key in ("id", "step_id"):
+        raw = step.get(key)
+        if isinstance(raw, str) and raw:
+            return raw
+    return None
+
+
+def _evidence_requirements(raw: Any) -> tuple[str, ...]:
+    out: list[str] = []
+    for item in _iter_strings(raw):
+        if item not in STEP_EVIDENCE_REQUIREMENT_VALUES or item in out:
+            continue
+        out.append(item)
+    return tuple(out)
+
+
+def _dedupe_non_empty_strings(raw: Any) -> tuple[str, ...]:
+    return _dedupe(_iter_strings(raw))
+
+
+def _iter_strings(raw: Any) -> tuple[str, ...]:
+    if isinstance(raw, str):
+        return (raw,) if raw else ()
+    if not isinstance(raw, Iterable) or isinstance(raw, (bytes, Mapping)):
+        return ()
+    return tuple(item for item in raw if isinstance(item, str) and item)
+
+
+def _dedupe(values: Iterable[str]) -> tuple[str, ...]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+    return tuple(out)
+
+
+def _collect_gate_var_refs(
+    step_id: str,
+    *,
+    precondition_gates: Mapping[str, Any],
+    completion_gates: Mapping[str, Any],
+) -> tuple[str, ...]:
+    refs: list[str] = []
+    for gate_map in (precondition_gates, completion_gates):
+        for rule in _coerce_rules(gate_map.get(step_id)):
+            ref = _normalize_rule_var_ref(rule.get("var"))
+            if ref is None:
+                continue
+            refs.append(ref)
+    return _dedupe(refs)
+
+
+def _coerce_rules(raw: Any) -> tuple[Mapping[str, Any], ...]:
+    if isinstance(raw, Mapping):
+        return (raw,)
+    if not isinstance(raw, Iterable) or isinstance(raw, (str, bytes)):
+        return ()
+    return tuple(item for item in raw if isinstance(item, Mapping))
+
+
+def _normalize_rule_var_ref(raw: Any) -> str | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    value = raw
+    if value.startswith("payload.vars."):
+        value = value[len("payload.vars.") :]
+    elif value.startswith("vars."):
+        value = value[len("vars.") :]
+    elif "." in value:
+        return None
+    if not value:
+        return None
+    return f"VARS.{value}"
+
+
+def _collect_step_vision_fact_refs(step_id: str, vision_config: Mapping[str, Any]) -> tuple[str, ...]:
+    binding = vision_config.get("step_bindings", {}).get(step_id, {})
+    if not isinstance(binding, Mapping):
+        return ()
+    fact_ids = _dedupe((*_iter_strings(binding.get("all_of")), *_iter_strings(binding.get("any_of"))))
+    return tuple(f"VISION_FACTS.{fact_id}" for fact_id in fact_ids)
+
+
+def _completion_predicates(
+    step_id: str,
+    *,
+    completion_gates: Mapping[str, Any],
+    vision_facts: tuple[str, ...],
+) -> tuple[str, ...]:
+    predicates: list[str] = []
+    if _coerce_rules(completion_gates.get(step_id)):
+        predicates.append(f"GATES.{step_id}.completion")
+    predicates.extend(f"{fact_ref}==seen" for fact_ref in vision_facts)
+    return tuple(predicates)
+
+
+def _signal_quality_requirement(
+    *,
+    vision_facts: tuple[str, ...],
+    vision_config: Mapping[str, Any],
+    harness_map: Mapping[str, Any],
+) -> SignalQualityRequirement:
+    min_confidence = _optional_float(harness_map.get("min_confidence"))
+    freshness_ms = _optional_int(harness_map.get("freshness_ms"))
+    if freshness_ms is None:
+        freshness_ms = _freshness_from_vision_facts(vision_facts, vision_config)
+    return SignalQualityRequirement(min_confidence=min_confidence, freshness_ms=freshness_ms)
+
+
+def _freshness_from_vision_facts(
+    vision_facts: tuple[str, ...],
+    vision_config: Mapping[str, Any],
+) -> int | None:
+    facts_by_id = vision_config.get("facts_by_id", {})
+    if not isinstance(facts_by_id, Mapping):
+        return None
+    values: list[int] = []
+    for fact_ref in vision_facts:
+        fact_id = fact_ref.removeprefix("VISION_FACTS.")
+        fact = facts_by_id.get(fact_id)
+        if not isinstance(fact, Mapping):
+            continue
+        expires_after_ms = fact.get("expires_after_ms")
+        if isinstance(expires_after_ms, int) and not isinstance(expires_after_ms, bool):
+            values.append(expires_after_ms)
+    if not values:
+        return None
+    return max(values)
+
+
+def _latch_semantics(
+    *,
+    vision_facts: tuple[str, ...],
+    vision_config: Mapping[str, Any],
+    harness_map: Mapping[str, Any],
+) -> str:
+    raw = harness_map.get("latch_semantics")
+    if isinstance(raw, str) and raw:
+        return raw
+    facts_by_id = vision_config.get("facts_by_id", {})
+    if isinstance(facts_by_id, Mapping):
+        for fact_ref in vision_facts:
+            fact_id = fact_ref.removeprefix("VISION_FACTS.")
+            fact = facts_by_id.get(fact_id)
+            if isinstance(fact, Mapping) and fact.get("sticky") is True:
+                return "sticky_visual_completion"
+    return _DEFAULT_LATCH_SEMANTICS
+
+
+def _recovery_policy(
+    *,
+    requires_visual_confirmation: bool,
+    allowed_overlay_targets: tuple[str, ...],
+    harness_map: Mapping[str, Any],
+) -> RecoveryActionPolicy:
+    raw = harness_map.get("recovery_policy")
+    if isinstance(raw, Mapping):
+        kind = raw.get("kind")
+        if isinstance(kind, str) and kind:
+            return RecoveryActionPolicy(
+                kind=kind,
+                allowed_targets=_dedupe_non_empty_strings(raw.get("allowed_targets")),
+                fallback_message=raw.get("fallback_message") if isinstance(raw.get("fallback_message"), str) else None,
+            )
+    if requires_visual_confirmation:
+        return RecoveryActionPolicy(kind="visual_confirmation", allowed_targets=allowed_overlay_targets)
+    if allowed_overlay_targets:
+        return RecoveryActionPolicy(kind="retry_allowed_targets", allowed_targets=allowed_overlay_targets)
+    return RecoveryActionPolicy(kind="manual_guidance")
+
+
+def _optional_float(raw: Any) -> float | None:
+    if isinstance(raw, bool) or raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    return None
+
+
+def _optional_int(raw: Any) -> int | None:
+    if isinstance(raw, bool) or raw is None:
+        return None
+    if isinstance(raw, int):
+        return raw
+    return None
+
+
+__all__ = [
+    "load_step_harness_specs",
+    "step_fallback_profiles_from_specs",
+    "step_signal_profiles_from_specs",
+]

--- a/adapters/step_inference.py
+++ b/adapters/step_inference.py
@@ -33,7 +33,13 @@ _DEFAULT_PACK_PATH = _REPO_ROOT / "packs" / "fa18c_startup" / "pack.yaml"
 _MAX_MISSING_CONDITIONS = 8
 _MAX_RECENT_UI_TARGETS = 24
 _UNKNOWN_TEXT_VALUES = frozenset({"unknown", "unk", "missing", "n/a", "na"})
-_PACK_METADATA_MERGE_FIELDS = ("observability", "evidence_requirements", "ui_targets", "requires_visual_confirmation")
+_PACK_METADATA_MERGE_FIELDS = (
+    "observability",
+    "evidence_requirements",
+    "ui_targets",
+    "overlay_enabled",
+    "requires_visual_confirmation",
+)
 RecentUiTargetsInput: TypeAlias = Sequence[str] | Mapping[str, Any] | IterableABC[str] | None
 
 

--- a/core/step_harness.py
+++ b/core/step_harness.py
@@ -56,6 +56,7 @@ class StepHarnessSpec:
     signal_quality: SignalQualityRequirement
     requires_visual_confirmation: bool
     declared_ui_targets: tuple[str, ...] = ()
+    overlay_enabled: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -74,6 +75,7 @@ class StepHarnessSpec:
             "signal_quality": self.signal_quality.to_dict(),
             "requires_visual_confirmation": self.requires_visual_confirmation,
             "declared_ui_targets": list(self.declared_ui_targets),
+            "overlay_enabled": self.overlay_enabled,
         }
 
 

--- a/core/step_harness.py
+++ b/core/step_harness.py
@@ -1,0 +1,82 @@
+"""
+Typed per-step harness contracts.
+
+The domain object is intentionally independent from live runtime modules so
+adapters, replay evaluation, and tests can consume step contracts directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RecoveryActionPolicy:
+    kind: str
+    allowed_targets: tuple[str, ...] = ()
+    fallback_message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "kind": self.kind,
+            "allowed_targets": list(self.allowed_targets),
+        }
+        if self.fallback_message is not None:
+            out["fallback_message"] = self.fallback_message
+        return out
+
+
+@dataclass(frozen=True)
+class SignalQualityRequirement:
+    min_confidence: float | None = None
+    freshness_ms: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "min_confidence": self.min_confidence,
+            "freshness_ms": self.freshness_ms,
+        }
+
+
+@dataclass(frozen=True)
+class StepHarnessSpec:
+    step_id: str
+    required_observables: tuple[str, ...]
+    optional_observables: tuple[str, ...]
+    telemetry_facts: tuple[str, ...]
+    vision_facts: tuple[str, ...]
+    recent_action_facts: tuple[str, ...]
+    completion_predicates: tuple[str, ...]
+    latch_semantics: str
+    allowed_overlay_targets: tuple[str, ...]
+    forbidden_overlay_targets: tuple[str, ...]
+    recovery_policy: RecoveryActionPolicy
+    observability_status: str
+    signal_quality: SignalQualityRequirement
+    requires_visual_confirmation: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "required_observables": list(self.required_observables),
+            "optional_observables": list(self.optional_observables),
+            "telemetry_facts": list(self.telemetry_facts),
+            "vision_facts": list(self.vision_facts),
+            "recent_action_facts": list(self.recent_action_facts),
+            "completion_predicates": list(self.completion_predicates),
+            "latch_semantics": self.latch_semantics,
+            "allowed_overlay_targets": list(self.allowed_overlay_targets),
+            "forbidden_overlay_targets": list(self.forbidden_overlay_targets),
+            "recovery_policy": self.recovery_policy.to_dict(),
+            "observability_status": self.observability_status,
+            "signal_quality": self.signal_quality.to_dict(),
+            "requires_visual_confirmation": self.requires_visual_confirmation,
+        }
+
+
+__all__ = [
+    "RecoveryActionPolicy",
+    "SignalQualityRequirement",
+    "StepHarnessSpec",
+]

--- a/core/step_harness.py
+++ b/core/step_harness.py
@@ -55,6 +55,7 @@ class StepHarnessSpec:
     observability_status: str
     signal_quality: SignalQualityRequirement
     requires_visual_confirmation: bool
+    declared_ui_targets: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -72,6 +73,7 @@ class StepHarnessSpec:
             "observability_status": self.observability_status,
             "signal_quality": self.signal_quality.to_dict(),
             "requires_visual_confirmation": self.requires_visual_confirmation,
+            "declared_ui_targets": list(self.declared_ui_targets),
         }
 
 

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -4627,6 +4627,8 @@ class LiveDcsTutorLoop:
         step_fallback_profile = self.step_fallback_profiles.get(overlay_step_id)
         if not isinstance(step_fallback_profile, Mapping):
             return None, f"unsupported_step:{overlay_step_id}"
+        if step_fallback_profile.get("overlay_enabled") is False:
+            return None, f"overlay_disabled:{overlay_step_id}"
         fallback_targets_raw = step_fallback_profile.get("ui_targets")
         fallback_targets = _normalize_step_ui_targets(fallback_targets_raw)
         if not fallback_targets:

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -4627,12 +4627,12 @@ class LiveDcsTutorLoop:
         step_fallback_profile = self.step_fallback_profiles.get(overlay_step_id)
         if not isinstance(step_fallback_profile, Mapping):
             return None, f"unsupported_step:{overlay_step_id}"
-        if step_fallback_profile.get("overlay_enabled") is False:
-            return None, f"overlay_disabled:{overlay_step_id}"
         fallback_targets_raw = step_fallback_profile.get("ui_targets")
         fallback_targets = _normalize_step_ui_targets(fallback_targets_raw)
         if not fallback_targets:
             return None, f"unsupported_step:{overlay_step_id}"
+        if step_fallback_profile.get("overlay_enabled") is False:
+            return None, f"overlay_disabled:{overlay_step_id}"
         declared_fallback_target = fallback_targets[0]
         missing_conditions_raw = hint.get("missing_conditions")
         missing_conditions = [

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -47,6 +47,11 @@ from adapters.recent_actions import (
 )
 from adapters.response_mapping import map_help_response_to_tutor_response
 from adapters.source_chunk_refs import build_source_chunk_ref
+from adapters.step_harness_specs import (
+    load_step_harness_specs,
+    step_fallback_profiles_from_specs,
+    step_signal_profiles_from_specs,
+)
 from adapters.step_inference import StepInferenceResult, infer_step_id, load_pack_steps
 from adapters.telemetry_pipeline import enrich_bios_observation
 from adapters.vision_capture_trigger import (
@@ -2478,7 +2483,11 @@ class LiveDcsTutorLoop:
                 source_policy=self.knowledge_source_policy,
             )
         self.pack_steps = load_pack_steps(self.pack_path)
-        self.step_signal_profiles = _load_step_signal_profiles(self.pack_path)
+        self.step_harness_specs = load_step_harness_specs(
+            self.pack_path,
+            scenario_profile=self.scenario_profile,
+        )
+        self.step_signal_profiles = step_signal_profiles_from_specs(self.step_harness_specs)
         gate_config = load_pack_gate_config(
             self.pack_path,
             scenario_profile=self.scenario_profile,
@@ -2488,11 +2497,7 @@ class LiveDcsTutorLoop:
         self.candidate_steps = _load_step_ids(self.pack_path)
         self.overlay_allowlist = _load_overlay_allowlist(self.pack_path, self.ui_map_path)
         self.overlay_allowset = set(self.overlay_allowlist)
-        self.step_fallback_profiles = _build_step_fallback_profiles(
-            self.pack_steps,
-            precondition_gates=self.precondition_gates,
-            completion_gates=self.completion_gates,
-        )
+        self.step_fallback_profiles = step_fallback_profiles_from_specs(self.step_harness_specs)
         self.recent_ring = RecentDeltaRingBuffer(window_s=8.0, max_items=20)
         self.vision_sync_window_ms = (
             int(vision_sync_window_ms)
@@ -3037,6 +3042,10 @@ class LiveDcsTutorLoop:
             "scenario_profile": self.scenario_profile,
             "vision_fact_status": vision_fact_context.get("status"),
         }
+        if isinstance(inference.inferred_step_id, str) and inference.inferred_step_id:
+            step_harness_spec = self.step_harness_specs.get(inference.inferred_step_id)
+            if step_harness_spec is not None:
+                deterministic_hint["step_harness_spec"] = step_harness_spec.to_dict()
         if isinstance(step_signal_profile, Mapping):
                 observability = step_signal_profile.get("observability")
                 if isinstance(observability, str) and observability:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -2087,6 +2087,60 @@ def test_safe_fallback_overlay_respects_overlay_disabled_with_declared_targets(t
     assert fallback_reason == "overlay_disabled:S01"
 
 
+def test_safe_fallback_overlay_reports_unsupported_when_overlay_disabled_has_no_targets(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_overlay_disabled_no_targets.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        "pack_id: test\n"
+        "version: v1\n"
+        "steps:\n"
+        "  - id: S01\n"
+        "    observability: observable\n"
+        "    overlay_enabled: false\n"
+        "    evidence_requirements: [delta]\n"
+        "    ui_targets: []\n"
+        "precondition_gates:\n"
+        "  S01: []\n"
+        "completion_gates:\n"
+        "  S01: []\n",
+        encoding="utf-8",
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+        pack_path=pack,
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "vars": {},
+                "gates": {},
+                "recent_deltas": [],
+                "overlay_target_allowlist": [],
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S01",
+                    "overlay_step_id": "S01",
+                    "missing_conditions": ["vars.apu_on==true"],
+                    "step_evidence_requirements": ["delta"],
+                },
+            },
+        )
+        fallback_help_obj, fallback_reason = loop._build_safe_fallback_overlay_help_obj(request)
+    finally:
+        loop.close()
+
+    assert fallback_help_obj is None
+    assert fallback_reason == "unsupported_step:S01"
+
+
 def test_live_loop_allowlist_filter_keeps_actions_for_remaining_targets_with_evidence(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_allowlist_partial_filter.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -716,6 +716,10 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
     assert hint.get("inferred_step_id")
     assert isinstance(hint.get("requires_visual_confirmation"), bool)
     assert hint.get("step_ui_targets") == ["apu_switch"]
+    harness_spec = hint.get("step_harness_spec")
+    assert isinstance(harness_spec, dict)
+    assert harness_spec["step_id"] == hint["inferred_step_id"]
+    assert harness_spec["allowed_overlay_targets"] == ["apu_switch"]
     gates = request.context["gates"]
     assert isinstance(gates, dict)
     assert "S03.completion" in gates

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -2031,6 +2031,62 @@ def test_resolve_step_overlay_allowlist_returns_empty_for_overlay_disabled_step(
     assert allowlist == []
 
 
+def test_safe_fallback_overlay_respects_overlay_disabled_with_declared_targets(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_overlay_disabled.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        "pack_id: test\n"
+        "version: v1\n"
+        "steps:\n"
+        "  - id: S01\n"
+        "    observability: observable\n"
+        "    overlay_enabled: false\n"
+        "    evidence_requirements: [delta]\n"
+        "    ui_targets: [apu_switch]\n"
+        "precondition_gates:\n"
+        "  S01: []\n"
+        "completion_gates:\n"
+        "  S01: []\n",
+        encoding="utf-8",
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+        pack_path=pack,
+        ui_map_path=Path(_default_pack_path()).parent / "ui_map.yaml",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "vars": {},
+                "gates": {},
+                "recent_deltas": [{"ui_target": "apu_switch", "k": "APU_CONTROL_SW"}],
+                "overlay_target_allowlist": [],
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S01",
+                    "overlay_step_id": "S01",
+                    "missing_conditions": ["vars.apu_on==true"],
+                    "recent_ui_targets": ["apu_switch"],
+                    "step_evidence_requirements": ["delta"],
+                },
+            },
+        )
+        fallback_help_obj, fallback_reason = loop._build_safe_fallback_overlay_help_obj(request)
+    finally:
+        loop.close()
+
+    assert fallback_help_obj is None
+    assert fallback_reason == "overlay_disabled:S01"
+
+
 def test_live_loop_allowlist_filter_keeps_actions_for_remaining_targets_with_evidence(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_allowlist_partial_filter.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])

--- a/tests/test_pack_gates.py
+++ b/tests/test_pack_gates.py
@@ -21,12 +21,12 @@ def _obs_with_vars(**vars_map):
     }
 
 
-def test_pack_gate_config_contains_s01_to_s25_for_precondition_and_completion() -> None:
+def test_pack_gate_config_contains_s01_to_s33_for_precondition_and_completion() -> None:
     cfg = load_pack_gate_config(PACK_PATH)
     pre = cfg["precondition_gates"]
     comp = cfg["completion_gates"]
 
-    for step_id in [f"S{i:02d}" for i in range(1, 26)]:
+    for step_id in [f"S{i:02d}" for i in range(1, 34)]:
         assert step_id in pre, f"missing precondition gate config for {step_id}"
         assert step_id in comp, f"missing completion gate config for {step_id}"
         assert isinstance(pre[step_id], tuple)

--- a/tests/test_step_harness_specs.py
+++ b/tests/test_step_harness_specs.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from adapters.step_harness_specs import load_step_harness_specs
 from core.step_harness import StepHarnessSpec
 
@@ -49,17 +51,26 @@ def test_step_harness_spec_derives_early_telemetry_delta_and_gate_contract() -> 
 def test_step_harness_spec_derives_vlm_contract_for_s18_and_s19() -> None:
     specs = load_step_harness_specs(PACK_PATH)
 
+    s15 = specs["S15"]
+    assert s15.vision_facts == ("VISION_FACTS.fcs_page_x_marks_visible",)
+    assert s15.requires_visual_confirmation is True
+    assert s15.signal_quality.freshness_ms == 2000
+
     s18 = specs["S18"]
     assert s18.observability_status == "partial"
     assert s18.required_observables == ("delta", "gate", "visual")
-    assert s18.vision_facts == ("VISION_FACTS.fcsmc_page_visible",)
+    assert s18.vision_facts == (
+        "VISION_FACTS.fcsmc_page_visible",
+        "VISION_FACTS.bit_root_page_visible",
+    )
     assert "VISION_FACTS.fcsmc_page_visible==seen" in s18.completion_predicates
     assert s18.requires_visual_confirmation is True
     assert s18.signal_quality.freshness_ms == 2000
     assert s18.allowed_overlay_targets == ("right_mdi_pb18", "right_mdi_pb5")
 
     s19 = specs["S19"]
-    assert s19.vision_facts == ("VISION_FACTS.fcsmc_final_go_result_visible",)
+    assert "VISION_FACTS.fcsmc_final_go_result_visible" in s19.vision_facts
+    assert "VISION_FACTS.fcsmc_final_go_result_visible==seen" in s19.completion_predicates
     assert s19.latch_semantics == "sticky_visual_completion"
     assert s19.signal_quality.freshness_ms == 600000
     assert s19.recovery_policy.kind == "visual_confirmation"
@@ -99,4 +110,54 @@ def test_step_harness_spec_preserves_s20_to_s27_split_four_down_targets() -> Non
         assert spec.allowed_overlay_targets == targets
         assert spec.observability_status == "observable"
         assert spec.required_observables == ("var", "gate")
-        assert spec.completion_predicates == (f"GATES.{step_id}.completion",)
+        assert f"GATES.{step_id}.completion" in spec.completion_predicates
+
+
+def test_step_harness_spec_keeps_raw_ui_targets_when_overlay_is_disabled(tmp_path: Path) -> None:
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        "pack_id: test\n"
+        "version: v1\n"
+        "steps:\n"
+        "  - id: S01\n"
+        "    observability: partial\n"
+        "    overlay_enabled: false\n"
+        "    evidence_requirements: [delta]\n"
+        "    ui_targets: [manual_switch]\n"
+        "precondition_gates: {S01: []}\n"
+        "completion_gates: {S01: []}\n",
+        encoding="utf-8",
+    )
+
+    spec = load_step_harness_specs(pack)["S01"]
+
+    assert spec.allowed_overlay_targets == ()
+    assert spec.forbidden_overlay_targets == ("manual_switch",)
+    assert spec.declared_ui_targets == ("manual_switch",)
+    assert spec.recent_action_facts == ("RECENT_ACTIONS.manual_switch",)
+    assert spec.recovery_policy.allowed_targets == ("manual_switch",)
+
+
+def test_step_harness_spec_validates_pack_step_metadata(tmp_path: Path) -> None:
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        "pack_id: test\n"
+        "version: v1\n"
+        "steps:\n"
+        "  - id: S01\n"
+        "    observability: maybe\n"
+        "precondition_gates: {S01: []}\n"
+        "completion_gates: {S01: []}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"pack\.steps\[0\]\.observability must be one of"):
+        load_step_harness_specs(pack)
+
+
+def test_step_harness_spec_completion_predicates_include_scenario_overrides() -> None:
+    airfield = load_step_harness_specs(PACK_PATH)["S31"]
+    carrier = load_step_harness_specs(PACK_PATH, scenario_profile="carrier")["S31"]
+
+    assert "vars.radar_altimeter_bug_value in [180,220]" in airfield.completion_predicates
+    assert "vars.radar_altimeter_bug_value in [30,60]" in carrier.completion_predicates

--- a/tests/test_step_harness_specs.py
+++ b/tests/test_step_harness_specs.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+from adapters.step_harness_specs import load_step_harness_specs
+from core.step_harness import StepHarnessSpec
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+PACK_PATH = BASE_DIR / "packs" / "fa18c_startup" / "pack.yaml"
+
+
+def test_load_step_harness_specs_exposes_all_fa18c_steps_without_live_dcs_import() -> None:
+    specs = load_step_harness_specs(PACK_PATH)
+
+    assert list(specs.keys()) == [f"S{i:02d}" for i in range(1, 34)]
+    assert all(isinstance(spec, StepHarnessSpec) for spec in specs.values())
+
+
+def test_step_harness_spec_derives_early_telemetry_delta_and_gate_contract() -> None:
+    specs = load_step_harness_specs(PACK_PATH)
+
+    s01 = specs["S01"]
+    assert s01.step_id == "S01"
+    assert s01.observability_status == "observable"
+    assert s01.required_observables == ("var", "gate", "delta")
+    assert s01.telemetry_facts == ("VARS.battery_on", "VARS.l_gen_on", "VARS.r_gen_on")
+    assert s01.recent_action_facts == (
+        "RECENT_ACTIONS.battery_switch",
+        "RECENT_ACTIONS.generator_left_switch",
+        "RECENT_ACTIONS.generator_right_switch",
+    )
+    assert "GATES.S01.completion" in s01.completion_predicates
+    assert s01.allowed_overlay_targets == (
+        "battery_switch",
+        "generator_left_switch",
+        "generator_right_switch",
+    )
+    assert s01.recovery_policy.kind == "retry_allowed_targets"
+
+    s02 = specs["S02"]
+    assert s02.required_observables == ("var", "delta", "gate")
+    assert s02.telemetry_facts == (
+        "VARS.power_available",
+        "VARS.fire_test_a_complete",
+        "VARS.fire_test_b_complete",
+    )
+    assert s02.allowed_overlay_targets == ("fire_test_switch",)
+
+
+def test_step_harness_spec_derives_vlm_contract_for_s18_and_s19() -> None:
+    specs = load_step_harness_specs(PACK_PATH)
+
+    s18 = specs["S18"]
+    assert s18.observability_status == "partial"
+    assert s18.required_observables == ("delta", "gate", "visual")
+    assert s18.vision_facts == ("VISION_FACTS.fcsmc_page_visible",)
+    assert "VISION_FACTS.fcsmc_page_visible==seen" in s18.completion_predicates
+    assert s18.requires_visual_confirmation is True
+    assert s18.signal_quality.freshness_ms == 2000
+    assert s18.allowed_overlay_targets == ("right_mdi_pb18", "right_mdi_pb5")
+
+    s19 = specs["S19"]
+    assert s19.vision_facts == ("VISION_FACTS.fcsmc_final_go_result_visible",)
+    assert s19.latch_semantics == "sticky_visual_completion"
+    assert s19.signal_quality.freshness_ms == 600000
+    assert s19.recovery_policy.kind == "visual_confirmation"
+
+
+def test_step_harness_spec_marks_partial_manual_steps_without_forcing_visual_confirmation() -> None:
+    specs = load_step_harness_specs(PACK_PATH)
+
+    s17 = specs["S17"]
+    assert s17.observability_status == "partial"
+    assert s17.requires_visual_confirmation is False
+    assert s17.required_observables == ("delta", "gate")
+    assert s17.recent_action_facts == ("RECENT_ACTIONS.takeoff_trim_button",)
+
+    s30 = specs["S30"]
+    assert s30.observability_status == "partial"
+    assert s30.requires_visual_confirmation is False
+    assert s30.required_observables == ("delta", "rag", "gate")
+    assert s30.allowed_overlay_targets == ("standby_altimeter_pressure_knob",)
+
+
+def test_step_harness_spec_preserves_s20_to_s27_split_four_down_targets() -> None:
+    specs = load_step_harness_specs(PACK_PATH)
+
+    expected_targets = {
+        "S20": ("refuel_probe_switch",),
+        "S21": ("refuel_probe_switch",),
+        "S22": ("launch_bar_switch",),
+        "S23": ("launch_bar_switch",),
+        "S24": ("arresting_hook_handle",),
+        "S25": ("arresting_hook_handle",),
+        "S26": ("pitot_heater_switch",),
+        "S27": ("flap_switch",),
+    }
+    for step_id, targets in expected_targets.items():
+        spec = specs[step_id]
+        assert spec.allowed_overlay_targets == targets
+        assert spec.observability_status == "observable"
+        assert spec.required_observables == ("var", "gate")
+        assert spec.completion_predicates == (f"GATES.{step_id}.completion",)


### PR DESCRIPTION
Closes #269. Adds typed StepHarnessSpec contracts derived from existing pack steps, gates, and vision facts; wires live runtime to consume them while keeping existing pack gates and UI targets backward compatible. Verified with targeted pytest suites.