### PR TITLE
Fix evidence packet core guard marker

### DIFF
--- a/core/evidence_packet.py
+++ b/core/evidence_packet.py
@@ -2,8 +2,8 @@
 Normalized evidence packet for help-cycle adjudication.
 
 This module intentionally depends only on core Python data structures. Runtime
-adapters may feed it telemetry, VLM facts, gate results, and recent actions, but
-the packet itself remains independent from DCS, OpenAI, and overlay transport.
+adapters may feed it telemetry, VLM facts, gate results, and recent actions,
+but the packet itself remains independent from concrete transport providers.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- remove forbidden core-layer marker from the EvidencePacket module docstring
- keep the architecture note provider-neutral so ci_guard passes

## Tests
- python3 tools/ci_guard.py
- source ~/venvs/iefmmq-wsl/bin/activate && python -m py_compile core/evidence_packet.py