### PR TITLE
Add multi-candidate step generation

### DIFF
--- a/adapters/base_help_model.py
+++ b/adapters/base_help_model.py
@@ -499,7 +499,21 @@ class BaseHelpModel(ModelPort):
         schema_categories = schema["properties"]["diagnosis"]["properties"]["error_category"]["enum"]
 
         context = request.context if request and isinstance(request.context, dict) else {}
-        candidate_steps = context.get("candidate_steps")
+        raw_candidate_steps = context.get("candidate_steps")
+        candidate_step_items: list[dict[str, Any]] | None = None
+        if (
+            isinstance(raw_candidate_steps, list)
+            and raw_candidate_steps
+            and all(isinstance(item, Mapping) for item in raw_candidate_steps)
+        ):
+            candidate_step_items = [dict(item) for item in raw_candidate_steps]
+            candidate_steps = [
+                item.get("step_id")
+                for item in candidate_step_items
+                if isinstance(item.get("step_id"), str)
+            ]
+        else:
+            candidate_steps = raw_candidate_steps
         if not isinstance(candidate_steps, list) or not candidate_steps:
             candidate_steps = list(schema_step_ids)
         inference = deterministic_inference
@@ -514,6 +528,16 @@ class BaseHelpModel(ModelPort):
         )
         if not (isinstance(harness_conflicts, list) and HARNESS_LATE_VLM_CONFLICT in harness_conflicts):
             candidate_steps = self._prioritize_inferred_step(candidate_steps, inferred_step_id)
+        if candidate_step_items is not None:
+            by_step: dict[str, list[dict[str, Any]]] = {}
+            for item in candidate_step_items:
+                step_id = item.get("step_id")
+                if isinstance(step_id, str):
+                    by_step.setdefault(step_id, []).append(item)
+            candidate_step_items = []
+            for step_id in candidate_steps:
+                if isinstance(step_id, str):
+                    candidate_step_items.extend(by_step.get(step_id, []))
         allowlist = context.get("overlay_target_allowlist")
         if not isinstance(allowlist, list) or not allowlist:
             allowlist = list(schema_targets)
@@ -550,7 +574,7 @@ class BaseHelpModel(ModelPort):
             "intent": request.intent if request else "help",
             "message": request.message if request else None,
             "scenario_profile": scenario_profile,
-            "candidate_steps": candidate_steps,
+            "candidate_steps": candidate_step_items if candidate_step_items is not None else candidate_steps,
             "overlay_target_allowlist": allowlist,
             "vars": context.get("vars"),
             "recent_deltas": context.get("recent_deltas"),
@@ -874,7 +898,14 @@ class BaseHelpModel(ModelPort):
 
         candidate_steps = context.get("candidate_steps")
         if isinstance(candidate_steps, list) and candidate_steps:
-            allowed_steps = {sid for sid in candidate_steps if isinstance(sid, str)}
+            allowed_steps: set[str] = set()
+            for item in candidate_steps:
+                if isinstance(item, str):
+                    allowed_steps.add(item)
+                elif isinstance(item, Mapping):
+                    step_id = item.get("step_id")
+                    if isinstance(step_id, str) and step_id:
+                        allowed_steps.add(step_id)
             for path in ("diagnosis.step_id", "next.step_id"):
                 section, key = path.split(".")
                 sid = help_obj[section][key]

--- a/adapters/prompting.py
+++ b/adapters/prompting.py
@@ -799,6 +799,97 @@ def _normalize_enum_list(values: Any, fallback: list[str]) -> list[str]:
     return list(fallback)
 
 
+def _build_candidate_step_payload(values: Any, fallback: list[str]) -> list[dict[str, Any]]:
+    allowed = set(fallback)
+    payload: list[dict[str, Any]] = []
+    seen_candidates: set[tuple[str, str]] = set()
+
+    if isinstance(values, list) and values and all(isinstance(item, Mapping) for item in values):
+        for item in values:
+            step_id_raw = item.get("step_id")
+            source = str(_sanitize_scalar(item.get("source") or "unknown"))
+            key = (step_id_raw, source) if isinstance(step_id_raw, str) else ("", "")
+            if not isinstance(step_id_raw, str) or step_id_raw not in allowed or key in seen_candidates:
+                continue
+            seen_candidates.add(key)
+            candidate: dict[str, Any] = {
+                "step_id": step_id_raw,
+                "source": source,
+                "role": str(_sanitize_scalar(item.get("role") or "candidate")),
+                "supporting_evidence_refs": _string_items(item.get("supporting_evidence_refs"))[:8],
+                "refuting_evidence_refs": _string_items(item.get("refuting_evidence_refs"))[:8],
+                "missing_conditions": _string_items(item.get("missing_conditions"))[:MAX_MISSING_CONDITIONS_SIGNAL_ITEMS],
+                "proposed_next_action_target_ids": _string_items(item.get("proposed_next_action_target_ids"))[:8],
+                "reason": str(_sanitize_scalar(item.get("reason") or "")),
+            }
+            confidence = item.get("confidence")
+            if isinstance(confidence, (int, float)) and not isinstance(confidence, bool):
+                candidate["confidence"] = round(float(confidence), 3)
+            payload.append(candidate)
+        if payload:
+            return payload
+
+    step_ids = _normalize_enum_list(values, fallback)
+    for step_id in step_ids:
+        payload.append(
+            {
+                "step_id": step_id,
+                "source": "legacy_order",
+                "role": "fallback",
+                "confidence": 0.1,
+                "reason": "ordered step id fallback",
+            }
+        )
+    return payload
+
+
+def _candidate_step_ids(candidate_steps: list[dict[str, Any]]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in candidate_steps:
+        step_id = item.get("step_id")
+        if isinstance(step_id, str) and step_id and step_id not in seen:
+            seen.add(step_id)
+            out.append(step_id)
+    return out
+
+
+def _reorder_candidate_step_payload(
+    candidate_steps: list[dict[str, Any]],
+    ordered_step_ids: list[str],
+) -> list[dict[str, Any]]:
+    by_step: dict[str, list[dict[str, Any]]] = {}
+    for item in candidate_steps:
+        step_id = item.get("step_id")
+        if isinstance(step_id, str):
+            by_step.setdefault(step_id, []).append(item)
+    reordered: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for step_id in ordered_step_ids:
+        items = by_step.get(step_id)
+        if not items or step_id in seen:
+            continue
+        seen.add(step_id)
+        reordered.extend(items)
+    for item in candidate_steps:
+        step_id = item.get("step_id")
+        if isinstance(step_id, str) and step_id not in seen:
+            reordered.append(item)
+    return reordered
+
+
+def _filter_candidate_step_payload(
+    candidate_steps: list[dict[str, Any]],
+    allowed_step_ids: list[str],
+) -> list[dict[str, Any]]:
+    allowed = set(allowed_step_ids)
+    return [
+        item
+        for item in _reorder_candidate_step_payload(candidate_steps, allowed_step_ids)
+        if isinstance(item.get("step_id"), str) and item["step_id"] in allowed
+    ]
+
+
 def _build_deterministic_step_hint(context: Mapping[str, Any]) -> dict[str, Any]:
     raw = context.get("deterministic_step_hint")
     if not isinstance(raw, Mapping):
@@ -1272,7 +1363,13 @@ def build_help_prompt_result(
     schema_category_enum = list(schema["properties"]["diagnosis"]["properties"]["error_category"]["enum"])
     category_enum = _normalize_enum_list(context.get("error_category_enum"), schema_category_enum)
 
-    candidate_steps = _normalize_enum_list(context.get("candidate_steps"), step_enum)
+    raw_candidate_steps = context.get("candidate_steps")
+    has_structured_candidate_steps = (
+        isinstance(raw_candidate_steps, list)
+        and any(isinstance(item, Mapping) for item in raw_candidate_steps)
+    )
+    candidate_step_payload = _build_candidate_step_payload(raw_candidate_steps, step_enum)
+    candidate_steps = _candidate_step_ids(candidate_step_payload) or list(step_enum)
     overlay_targets = _normalize_enum_list(context.get("overlay_target_allowlist"), target_enum)
     max_vars = DEFAULT_MAX_VARS_ITEMS
     recent_deltas_summary = _build_delta_summary(context, top_k=MAX_DELTA_SUMMARY_ITEMS)
@@ -1300,6 +1397,7 @@ def build_help_prompt_result(
         )
     )
     candidate_steps = _reprioritize_candidate_steps_for_harness(candidate_steps, state_harness)
+    candidate_step_payload = _reorder_candidate_step_payload(candidate_step_payload, candidate_steps)
     multimodal_input = _build_multimodal_input_payload(context)
     scenario_profile_raw = context.get("scenario_profile")
     scenario_profile = (
@@ -1517,8 +1615,10 @@ def build_help_prompt_result(
             "overlay": {"targets": example_targets, "evidence": example_overlay_evidence},
             "explanations": ["Use concise guidance." if lang == "en" else "请给出简洁指导。"],
         }
+        current_candidate_step_payload = _filter_candidate_step_payload(candidate_step_payload, candidate_steps)
         payload = {
             "allowed_step_ids": candidate_steps,
+            "candidate_steps": current_candidate_step_payload,
             "allowed_overlay_targets": overlay_targets,
             "allowed_overlay_evidence_types": overlay_evidence_type_enum,
             "allowed_error_categories": category_enum,
@@ -1675,6 +1775,19 @@ def build_help_prompt_result(
                 },
                 "allowed_evidence_refs": compact_allowed_refs,
             }
+            if has_structured_candidate_steps:
+                compact_candidate_steps = _filter_candidate_step_payload(
+                    candidate_step_payload,
+                    candidate_steps[:3],
+                )
+                compact_payload["candidate_steps"] = [
+                    {
+                        key: item[key]
+                        for key in ("step_id", "source", "role", "confidence")
+                        if key in item
+                    }
+                    for item in compact_candidate_steps[:3]
+                ]
             if compact_harness_has_signal:
                 compact_payload["state_harness"] = compact_state_harness
             compact_visual_refs = [ref for ref in compact_allowed_refs if isinstance(ref, str) and ref.startswith("VISION_FACTS.")]
@@ -1778,6 +1891,7 @@ def build_help_prompt_result(
             and isinstance(state_harness.get("vision_evidence", {}).get("visual_candidate_steps"), list)
             else []
         ),
+        "candidate_step_ids": list(candidate_steps),
         "multimodal_input_attached": bool(multimodal_input.get("attached")),
     }
     return PromptBuildResult(prompt=prompt, metadata=meta)

--- a/core/evidence_packet.py
+++ b/core/evidence_packet.py
@@ -259,6 +259,32 @@ class DeterministicCandidateEvidence:
 
 
 @dataclass(frozen=True)
+class StepCandidate:
+    step_id: str
+    source: str
+    role: str
+    supporting_evidence_refs: tuple[str, ...]
+    refuting_evidence_refs: tuple[str, ...]
+    confidence: float
+    missing_conditions: tuple[str, ...]
+    proposed_next_action_target_ids: tuple[str, ...]
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "source": self.source,
+            "role": self.role,
+            "supporting_evidence_refs": list(self.supporting_evidence_refs),
+            "refuting_evidence_refs": list(self.refuting_evidence_refs),
+            "confidence": self.confidence,
+            "missing_conditions": list(self.missing_conditions),
+            "proposed_next_action_target_ids": list(self.proposed_next_action_target_ids),
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
 class EvidencePacket:
     telemetry_evidence: TelemetryEvidence
     vision_evidence: VisionEvidence
@@ -567,6 +593,191 @@ def build_evidence_packet(context: Mapping[str, Any]) -> EvidencePacket:
     )
 
 
+def _visual_refs(vision_evidence: VisionEvidence) -> tuple[str, ...]:
+    return tuple(f"VISION_FACTS.{fact_id}" for fact_id in vision_evidence.late_display_anchors)
+
+
+def _gate_refs_for_step(gate_evidence: GateEvidence, step_id: str) -> tuple[str, ...]:
+    refs: list[str] = []
+    prefix = f"{step_id}."
+    for gate_id in gate_evidence.blocked_gate_ids:
+        if gate_id == step_id or gate_id.startswith(prefix):
+            refs.append(f"GATES.{gate_id}")
+    return tuple(refs)
+
+
+def _targets_for_step(step_id: str, step_harness_specs: Mapping[str, Any] | None) -> tuple[str, ...]:
+    if not isinstance(step_harness_specs, Mapping):
+        return ()
+    spec = step_harness_specs.get(step_id)
+    if spec is None:
+        return ()
+    allowed = getattr(spec, "allowed_overlay_targets", None)
+    if allowed:
+        return tuple(_string_items(allowed))
+    declared = getattr(spec, "declared_ui_targets", None)
+    return tuple(_string_items(declared))
+
+
+def _visual_candidate_step_ids(packet: EvidencePacket) -> tuple[str, ...]:
+    anchors = set(packet.vision_evidence.late_display_anchors)
+    if "fcsmc_final_go_result_visible" in anchors:
+        return ("S20",)
+    if anchors.intersection(
+        {
+            "fcsmc_page_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_intermediate_result_visible",
+        }
+    ):
+        return ("S19", "S18", "S20")
+    return tuple(packet.vision_evidence.visual_candidate_steps)
+
+
+def _candidate_reason(source: str, step_id: str) -> str:
+    if source == "deterministic":
+        return "forward deterministic inference fallback"
+    if source == "sticky_state":
+        return "sticky VLM completion state supports advancing to the next procedure step"
+    if source == "visual_anchor":
+        return "fresh VLM visual anchors support this procedure step"
+    if source == "gate_blocker":
+        return "blocked gate evidence points at this procedure step"
+    if source == "recent_action":
+        return "recent cockpit action matches this step target set"
+    return f"{source} supports {step_id}"
+
+
+def build_step_candidates(
+    packet: EvidencePacket,
+    *,
+    step_harness_specs: Mapping[str, Any] | None = None,
+    ordered_step_ids: list[str] | tuple[str, ...] | None = None,
+    max_candidates: int = 8,
+) -> tuple[StepCandidate, ...]:
+    """
+    Generate ordered adjudication candidates for a help cycle.
+
+    Deterministic inference remains present, but it is explicitly marked as
+    non-authoritative so downstream code can compare it with visual, gate, and
+    recent-action evidence instead of inheriting a single final truth.
+    """
+    candidates: list[StepCandidate] = []
+    seen_candidates: set[tuple[str, str]] = set()
+    visual_refs = _visual_refs(packet.vision_evidence)
+    has_visual_conflict = CONFLICT_STALE_TELEMETRY_VS_FRESH_VISUAL_FACTS in packet.conflicts
+
+    def _append(candidate: StepCandidate) -> None:
+        key = (candidate.step_id, candidate.source)
+        if not candidate.step_id or key in seen_candidates:
+            return
+        seen_candidates.add(key)
+        candidates.append(candidate)
+
+    visual_source = (
+        "sticky_state"
+        if "fcsmc_final_go_result_visible" in packet.vision_evidence.late_display_anchors
+        else "visual_anchor"
+    )
+    for step_id in _visual_candidate_step_ids(packet):
+        _append(
+            StepCandidate(
+                step_id=step_id,
+                source=visual_source,
+                role="candidate",
+                supporting_evidence_refs=visual_refs,
+                refuting_evidence_refs=(),
+                confidence=0.92 if visual_source == "sticky_state" else 0.86,
+                missing_conditions=(),
+                proposed_next_action_target_ids=_targets_for_step(step_id, step_harness_specs),
+                reason=_candidate_reason(visual_source, step_id),
+            )
+        )
+
+    deterministic_step_id = packet.deterministic_candidate.step_id
+    if isinstance(deterministic_step_id, str) and deterministic_step_id:
+        _append(
+            StepCandidate(
+                step_id=deterministic_step_id,
+                source="deterministic",
+                role=packet.deterministic_candidate.role,
+                supporting_evidence_refs=_gate_refs_for_step(packet.gate_evidence, deterministic_step_id),
+                refuting_evidence_refs=visual_refs if has_visual_conflict else (),
+                confidence=0.35 if has_visual_conflict else 0.55,
+                missing_conditions=packet.deterministic_candidate.missing_conditions,
+                proposed_next_action_target_ids=_targets_for_step(deterministic_step_id, step_harness_specs),
+                reason=_candidate_reason("deterministic", deterministic_step_id),
+            )
+        )
+
+    for gate in packet.gate_evidence.blocked_gates:
+        step_id = gate.get("step_id")
+        if not isinstance(step_id, str) or not step_id:
+            gate_id = gate.get("gate_id")
+            if isinstance(gate_id, str) and "." in gate_id:
+                step_id = gate_id.split(".", 1)[0]
+        if not isinstance(step_id, str) or not step_id:
+            continue
+        gate_id = gate.get("gate_id")
+        refs = (f"GATES.{gate_id}",) if isinstance(gate_id, str) and gate_id else ()
+        _append(
+            StepCandidate(
+                step_id=step_id,
+                source="gate_blocker",
+                role="candidate",
+                supporting_evidence_refs=refs,
+                refuting_evidence_refs=(),
+                confidence=0.66,
+                missing_conditions=(),
+                proposed_next_action_target_ids=_targets_for_step(step_id, step_harness_specs),
+                reason=_candidate_reason("gate_blocker", step_id),
+            )
+        )
+
+    recent_targets = set(packet.recent_action_evidence.target_ids)
+    if recent_targets and isinstance(step_harness_specs, Mapping):
+        for step_id in ordered_step_ids or tuple(step_harness_specs.keys()):
+            if not isinstance(step_id, str) or (step_id, "recent_action") in seen_candidates:
+                continue
+            matched_targets = sorted(recent_targets.intersection(_targets_for_step(step_id, step_harness_specs)))
+            if not matched_targets:
+                continue
+            _append(
+                StepCandidate(
+                    step_id=step_id,
+                    source="recent_action",
+                    role="candidate",
+                    supporting_evidence_refs=tuple(f"RECENT_ACTIONS.{target}" for target in matched_targets),
+                    refuting_evidence_refs=(),
+                    confidence=0.5,
+                    missing_conditions=(),
+                    proposed_next_action_target_ids=tuple(matched_targets),
+                    reason=_candidate_reason("recent_action", step_id),
+                )
+            )
+
+    if ordered_step_ids and not candidates:
+        for step_id in ordered_step_ids:
+            if not isinstance(step_id, str) or not step_id:
+                continue
+            _append(
+                StepCandidate(
+                    step_id=step_id,
+                    source="procedure_order",
+                    role="fallback",
+                    supporting_evidence_refs=(),
+                    refuting_evidence_refs=(),
+                    confidence=0.1,
+                    missing_conditions=(),
+                    proposed_next_action_target_ids=_targets_for_step(step_id, step_harness_specs),
+                    reason="procedure order fallback candidate",
+                )
+            )
+            break
+
+    return tuple(candidates[: max(1, int(max_candidates))])
+
+
 __all__ = [
     "CONFLICT_LATCH_MISSING_VS_LATER_STAGE_EVIDENCE",
     "CONFLICT_RECENT_ACTION_VS_GATE_CONTRADICTION",
@@ -575,5 +786,7 @@ __all__ = [
     "DEFAULT_LATE_DISPLAY_ANCHOR_FACTS",
     "DEFAULT_VISUAL_CANDIDATE_STEP_GROUPS",
     "EvidencePacket",
+    "StepCandidate",
     "build_evidence_packet",
+    "build_step_candidates",
 ]

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -128,7 +128,7 @@ from core.vision_facts import (
     prune_expired_facts,
     snapshot_to_list,
 )
-from core.evidence_packet import build_evidence_packet
+from core.evidence_packet import build_evidence_packet, build_step_candidates
 from core.vars import VarResolver
 from ports.knowledge_port import KnowledgePort, KnowledgeRetrieveWithMetaPort
 from simtutor.cli_parsing import parse_env_int, parse_non_negative_int_arg
@@ -3118,6 +3118,14 @@ class LiveDcsTutorLoop:
         evidence_packet = build_evidence_packet(preliminary_harness_context)
         state_harness = evidence_packet.to_state_harness_dict()
         evidence_packet_summary = evidence_packet.compact_summary()
+        candidate_step_payload = [
+            candidate.to_dict()
+            for candidate in build_step_candidates(
+                evidence_packet,
+                step_harness_specs=self.step_harness_specs,
+                ordered_step_ids=_reprioritize_steps_for_state_harness(self.candidate_steps, state_harness),
+            )
+        ]
         rag_topk, grounding_meta = self._build_grounding_context(deterministic_hint)
         overlay_target_allowlist = _resolve_step_overlay_allowlist(
             overlay_step_id,
@@ -3159,7 +3167,7 @@ class LiveDcsTutorLoop:
             "recent_actions": recent_actions,
             "pack_path": str(self.pack_path),
             "telemetry_map_path": str(self.telemetry_map_path),
-            "candidate_steps": _reprioritize_steps_for_state_harness(self.candidate_steps, state_harness),
+            "candidate_steps": candidate_step_payload,
             "overlay_target_allowlist": overlay_target_allowlist,
             "state_harness": state_harness,
             "evidence_packet_summary": evidence_packet_summary,
@@ -3238,7 +3246,7 @@ class LiveDcsTutorLoop:
                 if isinstance(value, bool) or value is None
             },
             "recent_buttons": recent_buttons,
-            "candidate_steps": self.candidate_steps,
+            "candidate_steps": candidate_step_payload,
             "overlay_target_allowlist": self.overlay_allowlist,
             "deterministic_step_hint": deterministic_hint,
             "scenario_profile": self.scenario_profile,

--- a/tests/test_base_help_model.py
+++ b/tests/test_base_help_model.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from adapters import base_help_model
 from adapters.openai_compat_model import OpenAICompatModel
+from core.types import TutorRequest
 from tests._fakes import FakeClient
 
 
@@ -105,3 +106,25 @@ def test_expand_presented_missing_condition_keeps_derived_condition_when_all_fal
     )
 
     assert expanded == ("vars.apu_start_support_complete==true",)
+
+
+def test_validate_context_bounds_accepts_structured_candidate_steps() -> None:
+    model = OpenAICompatModel(client=FakeClient(responses=[]), lang="en")
+    request = TutorRequest(
+        intent="help",
+        message="help",
+        context={
+            "candidate_steps": [
+                {"step_id": "S02", "source": "visual_anchor"},
+                {"step_id": "S01", "source": "deterministic"},
+            ],
+            "overlay_target_allowlist": ["apu_switch"],
+        },
+    )
+    help_obj = {
+        "diagnosis": {"step_id": "S02"},
+        "next": {"step_id": "S02"},
+        "overlay": {"targets": ["apu_switch"]},
+    }
+
+    model._validate_context_bounds(help_obj, request)

--- a/tests/test_evidence_packet.py
+++ b/tests/test_evidence_packet.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
+
 from core.evidence_packet import (
     CONFLICT_LATCH_MISSING_VS_LATER_STAGE_EVIDENCE,
     CONFLICT_RECENT_ACTION_VS_GATE_CONTRADICTION,
     CONFLICT_STALE_TELEMETRY_VS_FRESH_VISUAL_FACTS,
+    build_step_candidates,
     build_evidence_packet,
 )
 
@@ -157,3 +160,141 @@ def test_evidence_packet_can_render_legacy_state_harness_payload() -> None:
     assert legacy["recent_action_evidence"]["recent_buttons"] == ["eng_crank_switch"]
     assert legacy["deterministic_candidate"]["step_id"] == "S05"
     assert packet.compact_summary()["telemetry_status"] == "nominal"
+
+
+def test_step_candidates_outrank_bootstrap_deterministic_when_visual_anchors_conflict() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {
+                "battery_on": False,
+                "power_available": False,
+                "vars_source_missing": [f"missing_{idx}" for idx in range(25)],
+            },
+            "vision": {"observation_seq": 2},
+            "vision_fact_summary": {
+                "status": "available",
+                "fresh_fact_ids": ["tac_page_visible", "bit_root_page_visible"],
+                "seen_fact_ids": ["tac_page_visible", "bit_root_page_visible"],
+                "not_seen_fact_ids": ["fcs_page_visible"],
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S01",
+                "missing_conditions": ["vars.battery_on==true"],
+            },
+        }
+    )
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+
+    assert candidates[0]["step_id"] == "S08"
+    assert candidates[0]["source"] == "visual_anchor"
+    assert candidates[0]["supporting_evidence_refs"] == [
+        "VISION_FACTS.bit_root_page_visible",
+        "VISION_FACTS.tac_page_visible",
+    ]
+    deterministic = next(item for item in candidates if item["source"] == "deterministic")
+    assert deterministic["step_id"] == "S01"
+    assert deterministic["role"] == "candidate_not_authoritative"
+
+
+def test_step_candidates_represent_s19_fcsmc_visual_state_and_final_go_sticky_progression() -> None:
+    in_test_packet = build_evidence_packet(
+        {
+            "vision_fact_summary": {
+                "status": "available",
+                "fresh_fact_ids": ["fcsmc_page_visible", "fcsmc_in_test_visible"],
+                "seen_fact_ids": ["fcsmc_page_visible", "fcsmc_in_test_visible"],
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S18",
+                "missing_conditions": ["vision_facts.fcsmc_page_visible==seen"],
+            },
+        }
+    )
+    in_test_candidates = [item.to_dict() for item in build_step_candidates(in_test_packet)]
+
+    assert in_test_candidates[0]["step_id"] == "S19"
+    assert in_test_candidates[0]["source"] == "visual_anchor"
+    assert "VISION_FACTS.fcsmc_in_test_visible" in in_test_candidates[0]["supporting_evidence_refs"]
+    assert any(
+        item["step_id"] == "S18" and item["source"] == "deterministic"
+        for item in in_test_candidates
+    )
+
+    final_packet = build_evidence_packet(
+        {
+            "vision_facts": [
+                {
+                    "fact_id": "fcsmc_final_go_result_visible",
+                    "state": "seen",
+                    "sticky": True,
+                    "expires_after_ms": 600000,
+                }
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S19",
+                "missing_conditions": ["vision_facts.fcsmc_final_go_result_visible==seen"],
+            },
+        }
+    )
+    final_candidates = [item.to_dict() for item in build_step_candidates(final_packet)]
+
+    assert final_candidates[0]["step_id"] == "S20"
+    assert final_candidates[0]["source"] == "sticky_state"
+    assert final_candidates[0]["supporting_evidence_refs"] == [
+        "VISION_FACTS.fcsmc_final_go_result_visible"
+    ]
+
+
+def test_step_candidates_keep_four_down_deterministic_progression_when_telemetry_only() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {"refuel_probe_extended": False},
+            "gates": {
+                "S20.completion": {
+                    "status": "blocked",
+                    "reason_code": "refuel_probe_not_extended",
+                    "reason": "vars.refuel_probe_extended==true",
+                }
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S20",
+                "overlay_step_id": "S20",
+                "missing_conditions": ["vars.refuel_probe_extended==true"],
+            },
+        }
+    )
+
+    ordered_step_ids = [f"S{idx:02d}" for idx in range(1, 34)]
+    candidates = [item.to_dict() for item in build_step_candidates(packet, ordered_step_ids=ordered_step_ids)]
+
+    assert candidates[0]["step_id"] == "S20"
+    assert candidates[0]["source"] == "deterministic"
+    assert candidates[0]["role"] == "candidate_not_authoritative"
+    assert "GATES.S20.completion" in candidates[0]["supporting_evidence_refs"]
+    assert not any(item["source"] == "procedure_order" and item["step_id"] == "S01" for item in candidates)
+
+
+def test_step_candidates_include_recent_action_matches_from_harness_specs() -> None:
+    packet = build_evidence_packet(
+        {
+            "recent_actions": {"recent_buttons": ["left_mdi_pb18"]},
+            "recent_deltas": [{"mapped_ui_target": "left_mdi_pb18", "seq": 8}],
+        }
+    )
+    specs = {
+        "S08": SimpleNamespace(
+            allowed_overlay_targets=("left_mdi_pb18", "left_mdi_pb15"),
+            declared_ui_targets=("left_mdi_pb18", "left_mdi_pb15"),
+        )
+    }
+
+    candidates = [
+        item.to_dict()
+        for item in build_step_candidates(packet, step_harness_specs=specs, ordered_step_ids=["S08"])
+    ]
+
+    assert candidates[0]["step_id"] == "S08"
+    assert candidates[0]["source"] == "recent_action"
+    assert candidates[0]["supporting_evidence_refs"] == ["RECENT_ACTIONS.left_mdi_pb18"]
+    assert candidates[0]["proposed_next_action_target_ids"] == ["left_mdi_pb18"]

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -704,7 +704,13 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
     assert request is not None
     assert request.intent == "help"
     assert "candidate_steps" in request.context
-    assert request.context["candidate_steps"] == [f"S{i:02d}" for i in range(1, 34)]
+    candidate_steps = request.context["candidate_steps"]
+    assert isinstance(candidate_steps, list)
+    assert candidate_steps[0]["source"] == "deterministic"
+    assert candidate_steps[0]["role"] == "candidate_not_authoritative"
+    assert candidate_steps[0]["step_id"]
+    assert "supporting_evidence_refs" in candidate_steps[0]
+    assert "proposed_next_action_target_ids" in candidate_steps[0]
     assert "recent_deltas" in request.context
     assert "recent_actions" in request.context
     assert "deterministic_step_hint" in request.context

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -43,6 +43,8 @@ def test_prompt_contains_enum_constraints_delta_summary_and_evidence_sources() -
     payload = _extract_prompt_constraints_json(prompt)
 
     assert payload["allowed_step_ids"] == ["S02", "S03"]
+    assert [item["step_id"] for item in payload["candidate_steps"]] == ["S02", "S03"]
+    assert payload["candidate_steps"][0]["source"] == "legacy_order"
     assert payload["allowed_overlay_targets"] == ["apu_switch", "battery_switch"]
     assert payload["allowed_overlay_evidence_types"] == ["var", "gate", "rag", "delta", "visual"]
     assert payload["allowed_error_categories"]
@@ -66,6 +68,82 @@ def test_prompt_contains_enum_constraints_delta_summary_and_evidence_sources() -
     assert sample_evidence["ref"] in payload["allowed_evidence_refs"]
     assert len(sample_evidence["quote"]) <= 120
     assert sample_evidence["type"] == infer_evidence_type_from_ref(sample_evidence["ref"])
+
+
+def test_prompt_accepts_structured_candidate_steps_and_keeps_allowed_step_ids() -> None:
+    ctx = _base_context()
+    ctx["candidate_steps"] = [
+        {
+            "step_id": "S08",
+            "source": "visual_anchor",
+            "role": "candidate",
+            "supporting_evidence_refs": ["VISION_FACTS.tac_page_visible"],
+            "refuting_evidence_refs": ["VARS.battery_on"],
+            "confidence": 0.86,
+            "missing_conditions": ["vision_facts.fcs_page_visible==seen"],
+            "proposed_next_action_target_ids": ["left_mdi_pb18"],
+            "reason": "fresh VLM page anchors outrank bootstrap telemetry",
+        },
+        {
+            "step_id": "S01",
+            "source": "deterministic",
+            "role": "candidate_not_authoritative",
+            "supporting_evidence_refs": ["GATES.S01.completion"],
+            "refuting_evidence_refs": ["VISION_FACTS.tac_page_visible"],
+            "confidence": 0.35,
+            "missing_conditions": ["vars.battery_on==true"],
+            "proposed_next_action_target_ids": ["battery_switch"],
+            "reason": "forward deterministic fallback",
+        },
+    ]
+    ctx["deterministic_step_hint"] = {
+        "inferred_step_id": "S01",
+        "missing_conditions": ["vars.battery_on==true"],
+    }
+
+    result = build_help_prompt_result(ctx, "en", max_prompt_chars=20000, max_prompt_tokens_est=6000)
+    payload = _extract_prompt_constraints_json(result.prompt)
+
+    assert payload["allowed_step_ids"] == ["S08", "S01"]
+    assert payload["candidate_steps"][0]["step_id"] == "S08"
+    assert payload["candidate_steps"][0]["source"] == "visual_anchor"
+    assert payload["candidate_steps"][1]["role"] == "candidate_not_authoritative"
+    assert result.metadata["candidate_step_ids"] == ["S08", "S01"]
+
+
+def test_prompt_compact_template_keeps_minimal_structured_candidate_steps() -> None:
+    ctx = _base_context()
+    ctx["candidate_steps"] = [
+        {
+            "step_id": "S08",
+            "source": "visual_anchor",
+            "role": "candidate",
+            "confidence": 0.86,
+            "supporting_evidence_refs": ["VISION_FACTS.tac_page_visible"],
+        },
+        {
+            "step_id": "S01",
+            "source": "deterministic",
+            "role": "candidate_not_authoritative",
+            "confidence": 0.35,
+            "missing_conditions": ["vars.battery_on==true"],
+        },
+    ]
+
+    result = build_help_prompt_result(ctx, "en", max_prompt_chars=500, max_prompt_tokens_est=120)
+
+    assert "compact_template" in result.metadata["trim_reasons"]
+    constraints_line = next(line for line in result.prompt.splitlines() if line.startswith("constraints="))
+    payload = json.loads(constraints_line[len("constraints=") :])
+    assert payload["candidate_steps"][0] == {
+        "confidence": 0.86,
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S08",
+    }
+    assert {
+        item["step_id"] for item in payload["candidate_steps"]
+    }.issubset(set(payload["allowed_step_ids"]))
 
 
 def test_prompt_exposes_single_target_policy_and_evidence_contract() -> None:


### PR DESCRIPTION
## Summary
- add structured StepCandidate generation from evidence packets
- include deterministic, visual anchor, sticky state, gate, and recent-action candidate sources
- pass structured candidate_steps through live help context and prompt builders while preserving allowed step ids

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_evidence_packet.py tests/test_prompting.py tests/test_base_help_model.py tests/test_live_dcs.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #271