### PR TITLE
Add telemetry window digest

### DIFF
--- a/adapters/prompting.py
+++ b/adapters/prompting.py
@@ -1037,6 +1037,27 @@ def _string_items(raw: Any) -> list[str]:
     return out
 
 
+def _sanitize_digest_prompt_scalar(raw: Any) -> Any:
+    value = _sanitize_scalar(raw)
+    if isinstance(value, (list, tuple, set, dict)):
+        value = str(value)
+    if isinstance(value, str) and len(value) > 80:
+        return value[:80] + "..."
+    return value
+
+
+def _sanitize_digest_prompt_item(raw: Mapping[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for field in fields:
+        if field not in raw:
+            continue
+        value = _sanitize_digest_prompt_scalar(raw.get(field))
+        if value is None:
+            continue
+        out[field] = value
+    return out
+
+
 def build_state_harness(context: Mapping[str, Any]) -> dict[str, Any]:
     return build_evidence_packet(context).to_state_harness_dict()
 
@@ -1060,6 +1081,8 @@ def _reprioritize_candidate_steps_for_harness(candidate_steps: list[str], state_
 def _build_state_harness_prompt_payload(state_harness: Mapping[str, Any], *, compact: bool = False) -> dict[str, Any]:
     telemetry_raw = state_harness.get("telemetry_evidence")
     telemetry = telemetry_raw if isinstance(telemetry_raw, Mapping) else {}
+    telemetry_window_raw = state_harness.get("telemetry_window_digest")
+    telemetry_window = telemetry_window_raw if isinstance(telemetry_window_raw, Mapping) else {}
     vision_raw = state_harness.get("vision_evidence")
     vision = vision_raw if isinstance(vision_raw, Mapping) else {}
     deterministic_raw = state_harness.get("deterministic_candidate")
@@ -1086,6 +1109,41 @@ def _build_state_harness_prompt_payload(state_harness: Mapping[str, Any], *, com
             "role": deterministic.get("role"),
         },
     }
+    telemetry_window_payload = {
+        "window_duration_s": telemetry_window.get("window_duration_s"),
+        "frame_count": telemetry_window.get("frame_count"),
+        "latest_seq": telemetry_window.get("latest_seq"),
+        "latest_t_wall": telemetry_window.get("latest_t_wall"),
+        "changed_vars": [
+            _sanitize_digest_prompt_item(
+                item,
+                ("var", "first_value", "last_value", "transition_count", "latest_transition_age_s"),
+            )
+            for item in telemetry_window.get("changed_vars", [])
+            if isinstance(item, Mapping)
+        ][:6],
+        "stable_true_vars": _string_items(telemetry_window.get("stable_true_vars"))[:8],
+        "stable_false_vars": _string_items(telemetry_window.get("stable_false_vars"))[:8],
+        "unknown_or_missing_vars": _string_items(telemetry_window.get("unknown_or_missing_vars"))[:8],
+        "first_frame_only_values": [
+            _sanitize_digest_prompt_item(item, ("var", "value"))
+            for item in telemetry_window.get("first_frame_only_values", [])
+            if isinstance(item, Mapping)
+        ][:4],
+        "last_seen_true": [
+            _sanitize_digest_prompt_item(item, ("var", "seq", "age_s"))
+            for item in telemetry_window.get("last_seen_true", [])
+            if isinstance(item, Mapping)
+        ][:6],
+        "contradictions": _string_items(telemetry_window.get("contradictions"))[:6],
+    }
+    if (
+        telemetry_window_payload["frame_count"]
+        or telemetry_window_payload["changed_vars"]
+        or telemetry_window_payload["contradictions"]
+        or telemetry_window_payload["first_frame_only_values"]
+    ):
+        payload["telemetry_window_digest"] = telemetry_window_payload
     if not compact:
         payload["telemetry_evidence"]["early_vars"] = telemetry.get("early_vars", {})
         payload["vision_evidence"]["seen_fact_ids"] = _string_items(vision.get("seen_fact_ids"))[:8]
@@ -1106,6 +1164,9 @@ def _build_state_harness_prompt_payload(state_harness: Mapping[str, Any], *, com
             "source_status": recent.get("source_status"),
             "recent_buttons": _string_items(recent.get("recent_buttons"))[:6],
         }
+    else:
+        if "telemetry_window_digest" in payload:
+            payload["telemetry_window_digest"].pop("last_seen_true", None)
     return payload
 
 
@@ -1456,6 +1517,7 @@ def build_help_prompt_result(
             "禁止仅凭 VARS.fcs_bit_switch_up 的 true/false 单独判断 S19 所处页面阶段；必须把它与 VLM 视觉事实标注一起解释。",
             "overlay.evidence 每项必须包含 target/type/ref/quote/grounding_confidence，字段顺序固定为 target,type,ref,quote,grounding_confidence，type 必须与 ref 前缀匹配，quote 最长 120 字符，且 ref 必须逐字匹配 allowed_evidence_refs 中的完整条目（含 @frame_id）。若证据不足，返回空 targets 和空 evidence。",
             "state_harness 是证据裁决包；deterministic_step_hint 只是候选，不是最终裁判。",
+            "使用 telemetry_window_digest 裁决最近 telemetry 时间窗；主 help LLM 保持 text-only，不得要求或粘贴 raw full JSONL。telemetry sequence evidence may override 误导性的首帧/current-frame 值；冲突时解释原因并选择完整序列最支持的 candidate_steps 项。",
             "若 state_harness.conflicts 含 early_step_from_telemetry_vs_late_display_from_vlm，不得仅因 battery_on=false/早期 latch=false 输出 S01/S02/S03；说明 telemetry 可能是首帧或未恢复，选择视觉一致步骤或要求确认。",
             "若 VLM fresh/seen 含 tac_page_visible+bit_root_page_visible 且 fcs_page_visible=not_seen，按 S08 恢复：左 DDI TAC -> SUPT/FCS，不退回电瓶、Fire Test 或 APU。",
             "若 deterministic_step_hint.missing_conditions_count=0 且 deterministic_step_hint.gate_blocker_count=0，说明所有步骤的完成条件均已满足，冷启动流程已完成。此时 diagnosis.step_id 和 next.step_id 应使用 deterministic_step_hint.inferred_step_id（通常为 S33），不要猜测别的步骤；overlay 应为空，explanation 应明确说明流程已完成。",
@@ -1513,6 +1575,7 @@ def build_help_prompt_result(
             "Never use VARS.fcs_bit_switch_up by itself to decide which S19 page/state the user is on. Combine it with the VLM visual fact labels.",
             "Each overlay.evidence item must include target/type/ref/quote/grounding_confidence in that exact field order. The type must match the ref prefix, quote length must be <= 120 chars, and the ref must exactly match a full entry from allowed_evidence_refs (including any @frame_id suffix). If not enough evidence, return empty targets and empty evidence.",
             "state_harness arbitrates evidence; deterministic_step_hint is a candidate, not final authority.",
+            "Use telemetry_window_digest: telemetry sequence evidence may override; do not paste raw full JSONL.",
             "If state_harness.conflicts has early_step_from_telemetry_vs_late_display_from_vlm, do not output S01/S02/S03 from battery_on=false/early latches=false; say telemetry may be stale and choose VLM-consistent step or ask confirmation.",
             "If VLM fresh/seen has tac_page_visible+bit_root_page_visible and fcs_page_visible=not_seen, do S08 recovery: Left DDI TAC -> SUPT/FCS.",
             "If deterministic_step_hint.missing_conditions_count=0 and deterministic_step_hint.gate_blocker_count=0, all step completion conditions are satisfied and the cold-start procedure is finished. Use deterministic_step_hint.inferred_step_id (typically S33) for diagnosis.step_id and next.step_id, do not guess a different step, keep overlay empty, and make the explanation explicitly say the procedure is complete.",
@@ -1578,6 +1641,21 @@ def build_help_prompt_result(
             priority_targets=overlay_target_priority,
             ui_map_path=ui_map_path,
         )
+        state_harness_payload = _build_state_harness_prompt_payload(state_harness)
+        decision_priority = [
+            "state_harness",
+            "gates_summary",
+            "vision_fact_summary",
+            "deterministic_step_hint",
+            "overlay_target_policy",
+            "recent_actions_signal",
+            "recent_deltas_summary",
+            "current_vars_selected",
+            "EVIDENCE_SOURCES.VISION_FACTS",
+            "EVIDENCE_SOURCES.RAG_SNIPPETS",
+        ]
+        if "telemetry_window_digest" in state_harness_payload:
+            decision_priority.insert(3, "telemetry_window_digest")
         next_step = candidate_steps[1] if len(candidate_steps) > 1 else candidate_steps[0]
         example_targets: list[str] = []
         priority_candidates = current_overlay_target_policy.get("candidate_targets_in_priority_order")
@@ -1622,24 +1700,13 @@ def build_help_prompt_result(
             "allowed_overlay_targets": overlay_targets,
             "allowed_overlay_evidence_types": overlay_evidence_type_enum,
             "allowed_error_categories": category_enum,
-            "decision_priority": [
-                "state_harness",
-                "gates_summary",
-                "vision_fact_summary",
-                "deterministic_step_hint",
-                "overlay_target_policy",
-                "recent_actions_signal",
-                "recent_deltas_summary",
-                "current_vars_selected",
-                "EVIDENCE_SOURCES.VISION_FACTS",
-                "EVIDENCE_SOURCES.RAG_SNIPPETS",
-            ],
+            "decision_priority": decision_priority,
             "scenario_profile": scenario_profile,
             "current_vars_selected": selected_vars,
             "gates_summary": gates_summary,
             "recent_deltas_summary": recent_deltas_summary,
             "recent_actions_signal": recent_actions_signal,
-            "state_harness": _build_state_harness_prompt_payload(state_harness),
+            "state_harness": state_harness_payload,
             "deterministic_step_hint": deterministic_step_hint,
             "vision_fact_summary": vision_fact_summary,
             "multimodal_input": multimodal_input,
@@ -1750,6 +1817,8 @@ def build_help_prompt_result(
             compact_state_harness = _build_state_harness_prompt_payload(state_harness, compact=True)
             compact_harness_has_signal = bool(
                 compact_state_harness.get("conflicts")
+                or compact_state_harness.get("telemetry_window_digest", {}).get("frame_count")
+                or compact_state_harness.get("telemetry_window_digest", {}).get("contradictions")
                 or compact_state_harness.get("vision_evidence", {}).get("late_display_anchors")
                 or compact_state_harness.get("vision_evidence", {}).get("visual_candidate_steps")
                 or compact_state_harness.get("telemetry_evidence", {}).get("source_status") == "low_confidence_bootstrap"
@@ -1757,6 +1826,8 @@ def build_help_prompt_result(
             compact_decision_priority = ["gates_summary", "deterministic_step_hint"]
             if compact_harness_has_signal:
                 compact_decision_priority.insert(0, "state_harness")
+                if "telemetry_window_digest" in compact_state_harness:
+                    compact_decision_priority.insert(1, "telemetry_window_digest")
             compact_payload = {
                 "allowed_step_ids": candidate_steps[:3],
                 "allowed_overlay_targets": overlay_targets,

--- a/core/evidence_packet.py
+++ b/core/evidence_packet.py
@@ -53,6 +53,69 @@ DEFAULT_VISUAL_CANDIDATE_STEP_GROUPS: tuple[tuple[tuple[str, ...], tuple[str, ..
 CONFLICT_STALE_TELEMETRY_VS_FRESH_VISUAL_FACTS = "early_step_from_telemetry_vs_late_display_from_vlm"
 CONFLICT_LATCH_MISSING_VS_LATER_STAGE_EVIDENCE = "latch_missing_vs_later_stage_evidence"
 CONFLICT_RECENT_ACTION_VS_GATE_CONTRADICTION = "recent_action_vs_gate_contradiction"
+CONFLICT_TELEMETRY_WINDOW_VS_SINGLE_FRAME = "telemetry_window_conflicts_with_single_frame_hint"
+CONTRADICTION_BATTERY_FIRST_FRAME_REFUTED = (
+    "battery_on=false only in first frame but later downstream avionics evidence is present"
+)
+CONTRADICTION_FIRE_TEST_LATCH_MISSING_LATER_STAGE = (
+    "fire_test latch missing while later-stage telemetry evidence is present"
+)
+CONTRADICTION_RECENT_TRANSITION_BLOCKED_GATE = (
+    "recent telemetry transition conflicts with current blocked gate"
+)
+MAX_DIGEST_STRING_VALUE_CHARS = 80
+
+IMPORTANT_BOOLEAN_VARS = frozenset(
+    {
+        "battery_on",
+        "power_available",
+        "left_ddi_on",
+        "right_ddi_on",
+        "mpcd_on",
+        "hud_on",
+        "fire_test_a_complete",
+        "fire_test_b_complete",
+        "fire_test_complete",
+        "fcs_bit_switch_up",
+        "pitot_heat_on",
+        "flap_auto",
+    }
+)
+DOWNSTREAM_AVIONICS_VARS = frozenset(
+    {
+        "power_available",
+        "left_ddi_on",
+        "right_ddi_on",
+        "mpcd_on",
+        "hud_on",
+    }
+)
+EARLY_LATCH_VARS = frozenset(
+    {
+        "fire_test_a_complete",
+        "fire_test_b_complete",
+        "fire_test_complete",
+    }
+)
+TELEMETRY_WINDOW_CANDIDATE_VARS = frozenset(
+    {
+        "battery_on",
+        "power_available",
+        "left_ddi_on",
+        "right_ddi_on",
+        "mpcd_on",
+        "hud_on",
+        "fire_test_a_complete",
+        "fire_test_b_complete",
+        "fire_test_complete",
+        "fcs_bit_switch_up",
+        "ext_refuel_probe_value",
+        "launch_bar_switch_value",
+        "hook_handle_value",
+        "pitot_heat_on",
+        "flap_auto",
+    }
+)
 
 
 def _string_items(raw: Any) -> list[str]:
@@ -78,6 +141,54 @@ def _coerce_number(raw: Any) -> int | float | None:
     if isinstance(raw, bool) or not isinstance(raw, (int, float)):
         return None
     return raw
+
+
+def _safe_digest_value(raw: Any) -> Any:
+    if raw is None or isinstance(raw, (bool, int, float)):
+        return raw
+    if isinstance(raw, str):
+        return raw if len(raw) <= MAX_DIGEST_STRING_VALUE_CHARS else raw[:MAX_DIGEST_STRING_VALUE_CHARS] + "..."
+    text = str(raw)
+    return text if len(text) <= MAX_DIGEST_STRING_VALUE_CHARS else text[:MAX_DIGEST_STRING_VALUE_CHARS] + "..."
+
+
+def _frame_vars(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        return {}
+    vars_raw = raw.get("vars")
+    if isinstance(vars_raw, Mapping):
+        return {
+            key: _safe_digest_value(value)
+            for key, value in vars_raw.items()
+            if isinstance(key, str) and key
+        }
+    delta_raw = raw.get("delta")
+    if isinstance(delta_raw, Mapping):
+        return {
+            key: _safe_digest_value(value)
+            for key, value in delta_raw.items()
+            if isinstance(key, str) and key
+        }
+    return {}
+
+
+def _frame_vars_are_full_snapshot(raw: Mapping[str, Any]) -> bool:
+    if raw.get("vars_is_full_snapshot") is True or raw.get("frame_kind") == "vars_snapshot":
+        return True
+    return isinstance(raw.get("vars"), Mapping) and not isinstance(raw.get("delta"), Mapping)
+
+
+def _latest_frame_meta(frames: tuple[dict[str, Any], ...]) -> tuple[int | None, int | float | None]:
+    latest_seq: int | None = None
+    latest_t_wall: int | float | None = None
+    for frame in frames:
+        seq = _coerce_int(frame.get("seq"))
+        if seq is not None:
+            latest_seq = seq
+        t_wall = _coerce_number(frame.get("t_wall"))
+        if t_wall is not None:
+            latest_t_wall = t_wall
+    return latest_seq, latest_t_wall
 
 
 def _late_display_anchor_fact_ids(context: Mapping[str, Any]) -> set[str]:
@@ -138,6 +249,59 @@ class TelemetryEvidence:
             "observation_seq": self.freshness.get("observation_seq"),
             "vars_source_missing_count": self.missing_source_count,
             "early_vars": dict(self.early_vars),
+        }
+
+
+@dataclass(frozen=True)
+class TelemetryWindowDigest:
+    window_duration_s: float | None
+    frame_count: int
+    latest_seq: int | None
+    latest_t_wall: int | float | None
+    changed_vars: tuple[dict[str, Any], ...]
+    stable_true_vars: tuple[str, ...]
+    stable_false_vars: tuple[str, ...]
+    unknown_or_missing_vars: tuple[str, ...]
+    first_frame_only_values: tuple[dict[str, Any], ...]
+    last_seen_true: tuple[dict[str, Any], ...]
+    contradictions: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "window_duration_s": self.window_duration_s,
+            "frame_count": self.frame_count,
+            "latest_seq": self.latest_seq,
+            "latest_t_wall": self.latest_t_wall,
+            "changed_vars": [dict(item) for item in self.changed_vars],
+            "stable_true_vars": list(self.stable_true_vars),
+            "stable_false_vars": list(self.stable_false_vars),
+            "unknown_or_missing_vars": list(self.unknown_or_missing_vars),
+            "first_frame_only_values": [dict(item) for item in self.first_frame_only_values],
+            "last_seen_true": [dict(item) for item in self.last_seen_true],
+            "contradictions": list(self.contradictions),
+        }
+
+    def to_state_harness_dict(self) -> dict[str, Any]:
+        return {
+            "window_duration_s": self.window_duration_s,
+            "frame_count": self.frame_count,
+            "latest_seq": self.latest_seq,
+            "latest_t_wall": self.latest_t_wall,
+            "changed_vars": [dict(item) for item in self.changed_vars[:12]],
+            "stable_true_vars": list(self.stable_true_vars[:16]),
+            "stable_false_vars": list(self.stable_false_vars[:16]),
+            "unknown_or_missing_vars": list(self.unknown_or_missing_vars[:16]),
+            "first_frame_only_values": [dict(item) for item in self.first_frame_only_values[:8]],
+            "last_seen_true": [dict(item) for item in self.last_seen_true[:12]],
+            "contradictions": list(self.contradictions[:8]),
+        }
+
+    def compact_summary(self) -> dict[str, Any]:
+        return {
+            "frame_count": self.frame_count,
+            "latest_seq": self.latest_seq,
+            "changed_var_count": len(self.changed_vars),
+            "contradiction_count": len(self.contradictions),
         }
 
 
@@ -287,6 +451,7 @@ class StepCandidate:
 @dataclass(frozen=True)
 class EvidencePacket:
     telemetry_evidence: TelemetryEvidence
+    telemetry_window_digest: TelemetryWindowDigest
     vision_evidence: VisionEvidence
     gate_evidence: GateEvidence
     recent_action_evidence: RecentActionEvidence
@@ -296,6 +461,7 @@ class EvidencePacket:
     def to_dict(self) -> dict[str, Any]:
         return {
             "telemetry_evidence": self.telemetry_evidence.to_dict(),
+            "telemetry_window_digest": self.telemetry_window_digest.to_dict(),
             "vision_evidence": self.vision_evidence.to_dict(),
             "gate_evidence": self.gate_evidence.to_dict(),
             "recent_action_evidence": self.recent_action_evidence.to_dict(),
@@ -307,10 +473,15 @@ class EvidencePacket:
         legacy_conflicts = [
             conflict
             for conflict in self.conflicts
-            if conflict == CONFLICT_STALE_TELEMETRY_VS_FRESH_VISUAL_FACTS
+            if conflict
+            in {
+                CONFLICT_STALE_TELEMETRY_VS_FRESH_VISUAL_FACTS,
+                CONFLICT_TELEMETRY_WINDOW_VS_SINGLE_FRAME,
+            }
         ]
         return {
             "telemetry_evidence": self.telemetry_evidence.to_state_harness_dict(),
+            "telemetry_window_digest": self.telemetry_window_digest.to_state_harness_dict(),
             "vision_evidence": self.vision_evidence.to_state_harness_dict(),
             "gate_evidence": self.gate_evidence.to_state_harness_dict(),
             "recent_action_evidence": self.recent_action_evidence.to_state_harness_dict(),
@@ -322,6 +493,7 @@ class EvidencePacket:
         return {
             "telemetry_status": self.telemetry_evidence.source_status,
             "telemetry_missing_source_count": self.telemetry_evidence.missing_source_count,
+            "telemetry_window_digest": self.telemetry_window_digest.compact_summary(),
             "vision_status": self.vision_evidence.source_status,
             "vision_seen_count": len(self.vision_evidence.seen_fact_ids),
             "vision_fresh_count": len(self.vision_evidence.fresh_fact_ids),
@@ -369,6 +541,185 @@ def _build_telemetry_evidence(context: Mapping[str, Any]) -> TelemetryEvidence:
             for key in ("battery_on", "power_available", "fire_test_a_complete", "fire_test_b_complete")
             if key in vars_map
         },
+    )
+
+
+def _build_telemetry_window_digest(context: Mapping[str, Any]) -> TelemetryWindowDigest:
+    frames_raw = context.get("telemetry_window_frames")
+    raw_frames = frames_raw if isinstance(frames_raw, list) else []
+    frames: list[dict[str, Any]] = []
+    for raw in raw_frames:
+        if not isinstance(raw, Mapping):
+            continue
+        frame_vars = _frame_vars(raw)
+        frames.append(
+            {
+                "seq": _coerce_int(raw.get("seq")),
+                "t_wall": _coerce_number(raw.get("t_wall")),
+                "vars": frame_vars,
+                "vars_is_full_snapshot": _frame_vars_are_full_snapshot(raw),
+            }
+        )
+
+    frame_tuple = tuple(frames)
+    latest_seq, latest_t_wall = _latest_frame_meta(frame_tuple)
+    t_values = [frame["t_wall"] for frame in frame_tuple if _coerce_number(frame.get("t_wall")) is not None]
+    window_duration_s = None
+    if len(t_values) >= 2:
+        window_duration_s = round(float(t_values[-1]) - float(t_values[0]), 3)
+
+    vars_raw = context.get("vars")
+    latest_vars = vars_raw if isinstance(vars_raw, Mapping) else {}
+    missing_vars = set(_string_items(latest_vars.get("vars_source_missing")))
+    for key, value in latest_vars.items():
+        if isinstance(key, str) and key and value is None:
+            missing_vars.add(key)
+
+    observations: dict[str, list[tuple[Any, int | None, int | float | None]]] = {}
+    for frame in frame_tuple:
+        seq = _coerce_int(frame.get("seq"))
+        t_wall = _coerce_number(frame.get("t_wall"))
+        vars_map = frame.get("vars")
+        if not isinstance(vars_map, Mapping):
+            continue
+        for key, value in vars_map.items():
+            if not isinstance(key, str) or not key:
+                continue
+            observations.setdefault(key, []).append((_safe_digest_value(value), seq, t_wall))
+
+    for key, value in latest_vars.items():
+        if not isinstance(key, str) or not key or key == "vars_source_missing" or value is None:
+            continue
+        if key in observations:
+            continue
+        observed = observations.setdefault(key, [])
+        safe_value = _safe_digest_value(value)
+        if not observed or observed[-1][0] != safe_value:
+            observed.append((safe_value, latest_seq, latest_t_wall))
+
+    changed_vars: list[dict[str, Any]] = []
+    stable_true_vars: list[str] = []
+    stable_false_vars: list[str] = []
+    last_seen_true: list[dict[str, Any]] = []
+    for key in sorted(observations.keys()):
+        values = observations[key]
+        if not values:
+            continue
+        compact_values = [value for value, _, _ in values]
+        transition_count = 0
+        latest_transition_t = values[-1][2]
+        for idx in range(1, len(compact_values)):
+            if compact_values[idx] != compact_values[idx - 1]:
+                transition_count += 1
+                latest_transition_t = values[idx][2]
+        if transition_count:
+            age = None
+            if latest_t_wall is not None and latest_transition_t is not None:
+                age = round(float(latest_t_wall) - float(latest_transition_t), 3)
+            changed_vars.append(
+                {
+                    "var": key,
+                    "first_value": compact_values[0],
+                    "last_value": compact_values[-1],
+                    "transition_count": transition_count,
+                    "latest_transition_age_s": age,
+                }
+            )
+
+        if key in IMPORTANT_BOOLEAN_VARS and compact_values and all(
+            value is True or value is False or value is None for value in compact_values
+        ):
+            if all(value is True for value in compact_values):
+                stable_true_vars.append(key)
+            elif all(value is False for value in compact_values):
+                stable_false_vars.append(key)
+            true_observations = [
+                (seq, t_wall)
+                for value, seq, t_wall in values
+                if value is True
+            ]
+            if true_observations:
+                seq, t_wall = true_observations[-1]
+                entry: dict[str, Any] = {"var": key}
+                if seq is not None:
+                    entry["seq"] = seq
+                if latest_t_wall is not None and t_wall is not None:
+                    entry["age_s"] = round(float(latest_t_wall) - float(t_wall), 3)
+                last_seen_true.append(entry)
+
+    first_frame_only_values: list[dict[str, Any]] = []
+    if (
+        len(frame_tuple) >= 2
+        and bool(frame_tuple[0].get("vars_is_full_snapshot"))
+        and any(bool(frame.get("vars_is_full_snapshot")) for frame in frame_tuple[1:])
+    ):
+        first_vars = frame_tuple[0].get("vars")
+        later_keys = {
+            key
+            for frame in frame_tuple[1:]
+            if bool(frame.get("vars_is_full_snapshot"))
+            if isinstance(frame.get("vars"), Mapping)
+            for key in frame["vars"].keys()
+            if isinstance(key, str)
+        }
+        if isinstance(first_vars, Mapping):
+            later_vars = [
+                frame["vars"]
+                for frame in frame_tuple[1:]
+                if bool(frame.get("vars_is_full_snapshot")) and isinstance(frame.get("vars"), Mapping)
+            ]
+            for key, value in first_vars.items():
+                later_present = key in later_keys
+                later_has_known_value = any(vars_map.get(key) is not None for vars_map in later_vars)
+                if isinstance(key, str) and key and (not later_present or not later_has_known_value):
+                    first_frame_only_values.append({"var": key, "value": _safe_digest_value(value)})
+
+    downstream_true = any(
+        latest_vars.get(key) is True
+        or key in stable_true_vars
+        or any(item.get("var") == key and item.get("last_value") is True for item in changed_vars)
+        for key in DOWNSTREAM_AVIONICS_VARS
+    )
+    contradictions: list[str] = []
+    if downstream_true and any(
+        item.get("var") == "battery_on" and item.get("value") is False
+        for item in first_frame_only_values
+    ):
+        contradictions.append(CONTRADICTION_BATTERY_FIRST_FRAME_REFUTED)
+    if downstream_true and (
+        missing_vars.intersection(EARLY_LATCH_VARS)
+        or any("fire_test" in item for item in _string_items(context.get("deterministic_step_hint", {}).get("missing_conditions") if isinstance(context.get("deterministic_step_hint"), Mapping) else []))
+    ):
+        contradictions.append(CONTRADICTION_FIRE_TEST_LATCH_MISSING_LATER_STAGE)
+
+    gate_raw = context.get("gates")
+    gates = gate_raw if isinstance(gate_raw, Mapping) else {}
+    changed_names = {
+        item.get("var")
+        for item in changed_vars
+        if isinstance(item.get("var"), str) and item.get("var") in TELEMETRY_WINDOW_CANDIDATE_VARS
+    }
+    for gate in gates.values():
+        if not isinstance(gate, Mapping) or gate.get("status") != "blocked":
+            continue
+        searchable = " ".join(str(gate.get(key, "")) for key in ("gate_id", "reason_code", "reason"))
+        if any(name in searchable for name in changed_names):
+            contradictions.append(CONTRADICTION_RECENT_TRANSITION_BLOCKED_GATE)
+            break
+
+    unknown_or_missing = sorted(missing_vars)
+    return TelemetryWindowDigest(
+        window_duration_s=window_duration_s,
+        frame_count=len(frame_tuple),
+        latest_seq=latest_seq,
+        latest_t_wall=latest_t_wall,
+        changed_vars=tuple(changed_vars[:24]),
+        stable_true_vars=tuple(_string_items(stable_true_vars)[:24]),
+        stable_false_vars=tuple(_string_items(stable_false_vars)[:24]),
+        unknown_or_missing_vars=tuple(unknown_or_missing[:32]),
+        first_frame_only_values=tuple(first_frame_only_values[:16]),
+        last_seen_true=tuple(last_seen_true[:24]),
+        contradictions=tuple(_string_items(contradictions)),
     )
 
 
@@ -548,12 +899,21 @@ def _has_recent_action_gate_contradiction(
 def _build_conflicts(
     *,
     telemetry_evidence: TelemetryEvidence,
+    telemetry_window_digest: TelemetryWindowDigest,
     vision_evidence: VisionEvidence,
     gate_evidence: GateEvidence,
     recent_action_evidence: RecentActionEvidence,
     deterministic_candidate: DeterministicCandidateEvidence,
 ) -> tuple[str, ...]:
     conflicts: list[str] = []
+    if any(
+        item in telemetry_window_digest.contradictions
+        for item in {
+            CONTRADICTION_BATTERY_FIRST_FRAME_REFUTED,
+            CONTRADICTION_FIRE_TEST_LATCH_MISSING_LATER_STAGE,
+        }
+    ):
+        conflicts.append(CONFLICT_TELEMETRY_WINDOW_VS_SINGLE_FRAME)
     if (
         deterministic_candidate.step_id in EARLY_STEP_IDS
         and len(vision_evidence.late_display_anchors) >= 2
@@ -561,7 +921,11 @@ def _build_conflicts(
         conflicts.append(CONFLICT_STALE_TELEMETRY_VS_FRESH_VISUAL_FACTS)
     if (
         deterministic_candidate.missing_conditions
-        and vision_evidence.late_display_anchors
+        and (
+            vision_evidence.late_display_anchors
+            or CONTRADICTION_FIRE_TEST_LATCH_MISSING_LATER_STAGE
+            in telemetry_window_digest.contradictions
+        )
         and any("_complete" in item or "latch" in item for item in deterministic_candidate.missing_conditions)
     ):
         conflicts.append(CONFLICT_LATCH_MISSING_VS_LATER_STAGE_EVIDENCE)
@@ -572,12 +936,14 @@ def _build_conflicts(
 
 def build_evidence_packet(context: Mapping[str, Any]) -> EvidencePacket:
     telemetry_evidence = _build_telemetry_evidence(context)
+    telemetry_window_digest = _build_telemetry_window_digest(context)
     vision_evidence = _build_vision_evidence(context)
     gate_evidence = _build_gate_evidence(context)
     recent_action_evidence = _build_recent_action_evidence(context)
     deterministic_candidate = _build_deterministic_candidate(context)
     conflicts = _build_conflicts(
         telemetry_evidence=telemetry_evidence,
+        telemetry_window_digest=telemetry_window_digest,
         vision_evidence=vision_evidence,
         gate_evidence=gate_evidence,
         recent_action_evidence=recent_action_evidence,
@@ -585,6 +951,7 @@ def build_evidence_packet(context: Mapping[str, Any]) -> EvidencePacket:
     )
     return EvidencePacket(
         telemetry_evidence=telemetry_evidence,
+        telemetry_window_digest=telemetry_window_digest,
         vision_evidence=vision_evidence,
         gate_evidence=gate_evidence,
         recent_action_evidence=recent_action_evidence,
@@ -645,7 +1012,82 @@ def _candidate_reason(source: str, step_id: str) -> str:
         return "blocked gate evidence points at this procedure step"
     if source == "recent_action":
         return "recent cockpit action matches this step target set"
+    if source == "telemetry_window":
+        return "recent telemetry window sequence supports this procedure region"
     return f"{source} supports {step_id}"
+
+
+def _telemetry_window_refs_for_var(kind: str, var_name: str) -> tuple[str, ...]:
+    return (f"TELEMETRY_WINDOW.{kind}.{var_name}",)
+
+
+def _changed_var_map(digest: TelemetryWindowDigest) -> dict[str, dict[str, Any]]:
+    return {
+        item["var"]: item
+        for item in digest.changed_vars
+        if isinstance(item.get("var"), str)
+    }
+
+
+def _has_first_frame_false(digest: TelemetryWindowDigest, var_name: str) -> bool:
+    return any(
+        item.get("var") == var_name and item.get("value") is False
+        for item in digest.first_frame_only_values
+    )
+
+
+def _supports_later_avionics(digest: TelemetryWindowDigest) -> bool:
+    changed = _changed_var_map(digest)
+    for var_name in DOWNSTREAM_AVIONICS_VARS:
+        if var_name in digest.stable_true_vars:
+            return True
+        item = changed.get(var_name)
+        if item is not None and item.get("last_value") is True:
+            return True
+    return False
+
+
+def _telemetry_progression_candidates(digest: TelemetryWindowDigest) -> tuple[tuple[str, str, str], ...]:
+    changed = _changed_var_map(digest)
+    out: list[tuple[str, str, str]] = []
+
+    probe = changed.get("ext_refuel_probe_value")
+    if probe is not None:
+        last = _coerce_number(probe.get("last_value"))
+        if last is not None and last >= 60000:
+            out.append(("S21", "changed_vars", "ext_refuel_probe_value"))
+        elif last is not None and last <= 5000:
+            out.append(("S22", "changed_vars", "ext_refuel_probe_value"))
+
+    launch_bar = changed.get("launch_bar_switch_value")
+    if launch_bar is not None:
+        last = _coerce_number(launch_bar.get("last_value"))
+        if last == 1:
+            out.append(("S23", "changed_vars", "launch_bar_switch_value"))
+        elif last == 0:
+            out.append(("S24", "changed_vars", "launch_bar_switch_value"))
+
+    hook = changed.get("hook_handle_value")
+    if hook is not None:
+        last = _coerce_number(hook.get("last_value"))
+        if last == 1:
+            out.append(("S25", "changed_vars", "hook_handle_value"))
+        elif last == 0:
+            out.append(("S26", "changed_vars", "hook_handle_value"))
+
+    pitot = changed.get("pitot_heat_on")
+    if pitot is not None and pitot.get("last_value") is True:
+        out.append(("S27", "changed_vars", "pitot_heat_on"))
+    changed = _changed_var_map(digest)
+
+    def _age(item: tuple[str, str, str]) -> float:
+        changed_item = changed.get(item[2])
+        if changed_item is None:
+            return 999999.0
+        raw_age = changed_item.get("latest_transition_age_s")
+        return float(raw_age) if isinstance(raw_age, (int, float)) and not isinstance(raw_age, bool) else 999999.0
+
+    return tuple(sorted(out, key=_age))
 
 
 def build_step_candidates(
@@ -693,6 +1135,93 @@ def build_step_candidates(
                 reason=_candidate_reason(visual_source, step_id),
             )
         )
+
+    telemetry_digest = packet.telemetry_window_digest
+    if telemetry_digest.frame_count:
+        if _has_first_frame_false(telemetry_digest, "battery_on") and _supports_later_avionics(telemetry_digest):
+            refs = []
+            if "left_ddi_on" in telemetry_digest.stable_true_vars:
+                refs.extend(_telemetry_window_refs_for_var("stable_true_vars", "left_ddi_on"))
+            elif "power_available" in telemetry_digest.stable_true_vars:
+                refs.extend(_telemetry_window_refs_for_var("stable_true_vars", "power_available"))
+            else:
+                refs.extend(_telemetry_window_refs_for_var("last_seen_true", "power_available"))
+            _append(
+                StepCandidate(
+                    step_id="S08",
+                    source="telemetry_window",
+                    role="candidate",
+                    supporting_evidence_refs=tuple(refs),
+                    refuting_evidence_refs=_telemetry_window_refs_for_var(
+                        "first_frame_only_values",
+                        "battery_on",
+                    ),
+                    confidence=0.82,
+                    missing_conditions=(),
+                    proposed_next_action_target_ids=_targets_for_step("S08", step_harness_specs),
+                    reason=_candidate_reason("telemetry_window", "S08"),
+                )
+            )
+        elif (
+            "fire_test latch missing while later-stage telemetry evidence is present"
+            in telemetry_digest.contradictions
+            and _supports_later_avionics(telemetry_digest)
+        ):
+            _append(
+                StepCandidate(
+                    step_id="S08",
+                    source="telemetry_window",
+                    role="candidate",
+                    supporting_evidence_refs=_telemetry_window_refs_for_var(
+                        "stable_true_vars",
+                        "left_ddi_on",
+                    ),
+                    refuting_evidence_refs=tuple(
+                        f"TELEMETRY_WINDOW.unknown_or_missing_vars.{var_name}"
+                        for var_name in telemetry_digest.unknown_or_missing_vars
+                        if var_name in EARLY_LATCH_VARS
+                    ),
+                    confidence=0.78,
+                    missing_conditions=(),
+                    proposed_next_action_target_ids=_targets_for_step("S08", step_harness_specs),
+                    reason=_candidate_reason("telemetry_window", "S08"),
+                )
+            )
+
+        changed = _changed_var_map(telemetry_digest)
+        fcs_bit_switch = changed.get("fcs_bit_switch_up")
+        if fcs_bit_switch is not None and fcs_bit_switch.get("last_value") is True:
+            _append(
+                StepCandidate(
+                    step_id="S19",
+                    source="telemetry_window",
+                    role="candidate",
+                    supporting_evidence_refs=_telemetry_window_refs_for_var(
+                        "changed_vars",
+                        "fcs_bit_switch_up",
+                    ),
+                    refuting_evidence_refs=_gate_refs_for_step(packet.gate_evidence, "S19"),
+                    confidence=0.74,
+                    missing_conditions=(),
+                    proposed_next_action_target_ids=_targets_for_step("S19", step_harness_specs),
+                    reason=_candidate_reason("telemetry_window", "S19"),
+                )
+            )
+
+        for step_id, ref_kind, var_name in _telemetry_progression_candidates(telemetry_digest):
+            _append(
+                StepCandidate(
+                    step_id=step_id,
+                    source="telemetry_window",
+                    role="candidate",
+                    supporting_evidence_refs=_telemetry_window_refs_for_var(ref_kind, var_name),
+                    refuting_evidence_refs=(),
+                    confidence=0.7,
+                    missing_conditions=(),
+                    proposed_next_action_target_ids=_targets_for_step(step_id, step_harness_specs),
+                    reason=_candidate_reason("telemetry_window", step_id),
+                )
+            )
 
     deterministic_step_id = packet.deterministic_candidate.step_id
     if isinstance(deterministic_step_id, str) and deterministic_step_id:
@@ -782,11 +1311,13 @@ __all__ = [
     "CONFLICT_LATCH_MISSING_VS_LATER_STAGE_EVIDENCE",
     "CONFLICT_RECENT_ACTION_VS_GATE_CONTRADICTION",
     "CONFLICT_STALE_TELEMETRY_VS_FRESH_VISUAL_FACTS",
+    "CONFLICT_TELEMETRY_WINDOW_VS_SINGLE_FRAME",
     "EARLY_STEP_IDS",
     "DEFAULT_LATE_DISPLAY_ANCHOR_FACTS",
     "DEFAULT_VISUAL_CANDIDATE_STEP_GROUPS",
     "EvidencePacket",
     "StepCandidate",
+    "TelemetryWindowDigest",
     "build_evidence_packet",
     "build_step_candidates",
 ]

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -690,7 +690,159 @@ def _sanitize_state_harness_for_event(raw: Any) -> dict[str, Any]:
         value = raw.get(key)
         if isinstance(value, Mapping):
             sanitized[key] = dict(value)
+    telemetry_window_digest = _sanitize_telemetry_window_digest_for_event(raw.get("telemetry_window_digest"))
+    if telemetry_window_digest:
+        sanitized["telemetry_window_digest"] = telemetry_window_digest
     return sanitized
+
+
+def _sanitize_digest_scalar(raw: Any) -> Any:
+    if raw is None or isinstance(raw, bool) or isinstance(raw, (int, float)):
+        return raw
+    if isinstance(raw, str):
+        return raw if len(raw) <= 80 else raw[:80] + "..."
+    return None
+
+
+def _sanitize_telemetry_window_digest_for_event(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        return {}
+    sanitized: dict[str, Any] = {}
+    for key in ("window_duration_s", "latest_t_wall"):
+        value = raw.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            sanitized[key] = value
+        elif value is None:
+            sanitized[key] = None
+    for key in ("frame_count", "latest_seq"):
+        value = raw.get(key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            sanitized[key] = value
+        elif value is None:
+            sanitized[key] = None
+    for key in ("stable_true_vars", "stable_false_vars", "unknown_or_missing_vars", "contradictions"):
+        values = raw.get(key)
+        if isinstance(values, list):
+            sanitized[key] = [item for item in values if isinstance(item, str) and len(item) <= 120][:16]
+    for key in ("changed_vars", "first_frame_only_values", "last_seen_true"):
+        values = raw.get(key)
+        if not isinstance(values, list):
+            continue
+        items: list[dict[str, Any]] = []
+        for item in values:
+            if not isinstance(item, Mapping):
+                continue
+            entry: dict[str, Any] = {}
+            for field in (
+                "var",
+                "first_value",
+                "last_value",
+                "value",
+                "transition_count",
+                "latest_transition_age_s",
+                "seq",
+                "age_s",
+            ):
+                if field not in item:
+                    continue
+                value = _sanitize_digest_scalar(item.get(field))
+                if value is not None:
+                    entry[field] = value
+            if entry:
+                items.append(entry)
+            if len(items) >= 8:
+                break
+        sanitized[key] = items
+    return sanitized
+
+
+def _telemetry_window_frames_from_var_snapshots(frames: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in frames:
+        if not isinstance(item, Mapping):
+            continue
+        delta = item.get("delta")
+        if not isinstance(delta, Mapping):
+            continue
+        out.append(
+            {
+                "seq": item.get("seq"),
+                "t_wall": item.get("t_wall"),
+                "vars": dict(delta),
+                "vars_is_full_snapshot": True,
+            }
+        )
+    return out
+
+
+_TELEMETRY_WINDOW_SIGNATURE_VARS = {
+    "battery_on",
+    "power_available",
+    "left_ddi_on",
+    "right_ddi_on",
+    "mpcd_on",
+    "hud_on",
+    "fire_test_a_complete",
+    "fire_test_b_complete",
+    "fire_test_complete",
+    "fcs_bit_switch_up",
+    "ext_refuel_probe_value",
+    "launch_bar_switch_value",
+    "hook_handle_value",
+    "pitot_heat_on",
+    "flap_auto",
+}
+
+
+def _telemetry_window_signature(state_harness: Mapping[str, Any]) -> dict[str, Any]:
+    raw = state_harness.get("telemetry_window_digest")
+    digest = raw if isinstance(raw, Mapping) else {}
+    changed: list[dict[str, Any]] = []
+    for item in digest.get("changed_vars", []):
+        if not isinstance(item, Mapping):
+            continue
+        var_name = item.get("var")
+        if not isinstance(var_name, str) or not var_name:
+            continue
+        if var_name not in _TELEMETRY_WINDOW_SIGNATURE_VARS:
+            continue
+        changed.append(
+            {
+                "var": var_name,
+                "first_value": _sanitize_digest_scalar(item.get("first_value")),
+                "last_value": _sanitize_digest_scalar(item.get("last_value")),
+                "transition_count": item.get("transition_count"),
+            }
+        )
+    first_frame_only: list[dict[str, Any]] = []
+    for item in digest.get("first_frame_only_values", []):
+        if not isinstance(item, Mapping):
+            continue
+        var_name = item.get("var")
+        if not isinstance(var_name, str) or not var_name:
+            continue
+        if var_name not in _TELEMETRY_WINDOW_SIGNATURE_VARS:
+            continue
+        first_frame_only.append(
+            {
+                "var": var_name,
+                "value": _sanitize_digest_scalar(item.get("value")),
+            }
+        )
+    contradictions = [
+        item for item in digest.get("contradictions", []) if isinstance(item, str)
+    ][:8]
+    if not changed:
+        contradictions = [
+            item
+            for item in contradictions
+            if item != "recent telemetry transition conflicts with current blocked gate"
+        ]
+    return {
+        "changed_vars": changed[:12],
+        "first_frame_only_values": first_frame_only[:8],
+        "contradictions": contradictions,
+    }
 
 
 def _sanitize_evidence_packet_summary_for_event(raw: Any) -> dict[str, Any]:
@@ -716,6 +868,15 @@ def _sanitize_evidence_packet_summary_for_event(raw: Any) -> dict[str, Any]:
         sanitized["conflicts"] = [
             item for item in conflicts if isinstance(item, str) and len(item) <= 120
         ][:8]
+    telemetry_window_digest = raw.get("telemetry_window_digest")
+    if isinstance(telemetry_window_digest, Mapping):
+        sanitized["telemetry_window_digest"] = {
+            key: value
+            for key, value in telemetry_window_digest.items()
+            if key in {"frame_count", "latest_seq", "changed_var_count", "contradiction_count"}
+            and (isinstance(value, int) or value is None)
+            and not isinstance(value, bool)
+        }
     return sanitized
 
 
@@ -2534,6 +2695,7 @@ class LiveDcsTutorLoop:
         self.overlay_allowset = set(self.overlay_allowlist)
         self.step_fallback_profiles = step_fallback_profiles_from_specs(self.step_harness_specs)
         self.recent_ring = RecentDeltaRingBuffer(window_s=8.0, max_items=20)
+        self.telemetry_window_ring = RecentDeltaRingBuffer(window_s=8.0, max_items=20)
         self.vision_sync_window_ms = (
             int(vision_sync_window_ms)
             if isinstance(vision_sync_window_ms, int) and vision_sync_window_ms > 0
@@ -2808,6 +2970,8 @@ class LiveDcsTutorLoop:
             self._remember_step_interactions(current_delta_targets)
         if isinstance(delta, Mapping) and t_wall is not None:
             self.recent_ring.add_delta(delta, t_wall=t_wall, seq=seq)
+        if isinstance(enriched_vars, Mapping) and t_wall is not None:
+            self.telemetry_window_ring.add_delta(enriched_vars, t_wall=t_wall, seq=seq)
 
         self._emit_event(
             kind="observation",
@@ -2991,6 +3155,12 @@ class LiveDcsTutorLoop:
 
         now_t_wall = _coerce_float(payload.get("t_wall"))
         recent_frames = self.recent_ring.snapshot(now_t_wall=now_t_wall) if now_t_wall is not None else self.recent_ring.snapshot()
+        telemetry_window_frames_raw = (
+            self.telemetry_window_ring.snapshot(now_t_wall=now_t_wall)
+            if now_t_wall is not None
+            else self.telemetry_window_ring.snapshot()
+        )
+        telemetry_window_frames = _telemetry_window_frames_from_var_snapshots(telemetry_window_frames_raw)
         recent_deltas = build_prompt_recent_deltas(recent_frames, self.mapper, max_items=20)
         recent_actions = build_recent_button_signal(recent_frames, self.mapper, max_items=8)
         recent_buttons = [
@@ -3109,6 +3279,7 @@ class LiveDcsTutorLoop:
             "gates": gates,
             "recent_deltas": recent_deltas,
             "recent_actions": recent_actions,
+            "telemetry_window_frames": telemetry_window_frames,
             "deterministic_step_hint": deterministic_hint,
             "telemetry": {"t_wall": now_t_wall} if now_t_wall is not None else {},
             "vision": vision_context,
@@ -3266,6 +3437,7 @@ class LiveDcsTutorLoop:
             },
             "state_harness": {
                 "conflicts": list(state_harness.get("conflicts", [])),
+                "telemetry_window_digest": _telemetry_window_signature(state_harness),
                 "telemetry_status": (
                     state_harness.get("telemetry_evidence", {}).get("source_status")
                     if isinstance(state_harness.get("telemetry_evidence"), Mapping)
@@ -3273,7 +3445,11 @@ class LiveDcsTutorLoop:
                 ),
                 "visual_candidate_steps": _visual_candidate_steps_from_state_harness(state_harness),
             },
-            "evidence_packet_summary": evidence_packet_summary,
+            "evidence_packet_summary": {
+                key: value
+                for key, value in evidence_packet_summary.items()
+                if key != "telemetry_window_digest"
+            },
         }
         state_key = _stable_hash_json(state_signature)
         return req, prompt_result.metadata, state_key

--- a/tests/test_evidence_packet.py
+++ b/tests/test_evidence_packet.py
@@ -298,3 +298,235 @@ def test_step_candidates_include_recent_action_matches_from_harness_specs() -> N
     assert candidates[0]["source"] == "recent_action"
     assert candidates[0]["supporting_evidence_refs"] == ["RECENT_ACTIONS.left_mdi_pb18"]
     assert candidates[0]["proposed_next_action_target_ids"] == ["left_mdi_pb18"]
+
+
+def test_telemetry_window_digest_marks_first_frame_bootstrap_refuted_by_later_power() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {
+                "power_available": True,
+                "left_ddi_on": True,
+                "battery_on": None,
+                "vars_source_missing": ["battery_on"],
+            },
+            "telemetry_window_frames": [
+                {
+                    "seq": 1,
+                    "t_wall": 10.0,
+                    "vars": {"battery_on": False, "power_available": False},
+                },
+                {
+                    "seq": 2,
+                    "t_wall": 13.0,
+                    "vars": {"power_available": True, "left_ddi_on": True},
+                },
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S01",
+                "missing_conditions": ["vars.battery_on==true"],
+            },
+        }
+    )
+
+    payload = packet.to_dict()
+    digest = payload["telemetry_window_digest"]
+
+    assert digest["window_duration_s"] == 3.0
+    assert digest["frame_count"] == 2
+    assert digest["latest_seq"] == 2
+    assert digest["first_frame_only_values"] == [{"var": "battery_on", "value": False}]
+    assert any(
+        item["var"] == "power_available" and item["last_value"] is True
+        for item in digest["changed_vars"]
+    )
+    assert "left_ddi_on" in digest["stable_true_vars"]
+    assert "battery_on" in digest["unknown_or_missing_vars"]
+    assert "battery_on=false only in first frame but later downstream avionics evidence is present" in digest["contradictions"]
+    assert "telemetry_window_conflicts_with_single_frame_hint" in packet.to_state_harness_dict()["conflicts"]
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+    telemetry_candidate = next(item for item in candidates if item["source"] == "telemetry_window")
+    assert telemetry_candidate["step_id"] == "S08"
+    assert telemetry_candidate["refuting_evidence_refs"] == ["TELEMETRY_WINDOW.first_frame_only_values.battery_on"]
+
+
+def test_telemetry_window_candidate_handles_missing_early_latch_with_later_evidence() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {
+                "power_available": True,
+                "left_ddi_on": True,
+                "fire_test_a_complete": None,
+                "vars_source_missing": ["fire_test_a_complete"],
+            },
+            "telemetry_window_frames": [
+                {"seq": 5, "t_wall": 20.0, "vars": {"power_available": True}},
+                {"seq": 6, "t_wall": 21.5, "vars": {"left_ddi_on": True}},
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S02",
+                "missing_conditions": ["vars.fire_test_a_complete==true"],
+            },
+        }
+    )
+
+    payload = packet.to_dict()
+    digest = payload["telemetry_window_digest"]
+
+    assert "fire_test_a_complete" in digest["unknown_or_missing_vars"]
+    assert "fire_test latch missing while later-stage telemetry evidence is present" in digest["contradictions"]
+    assert CONFLICT_LATCH_MISSING_VS_LATER_STAGE_EVIDENCE in payload["conflicts"]
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+    telemetry_candidate = next(item for item in candidates if item["source"] == "telemetry_window")
+    assert telemetry_candidate["step_id"] == "S08"
+    assert "TELEMETRY_WINDOW.stable_true_vars.left_ddi_on" in telemetry_candidate["supporting_evidence_refs"]
+
+
+def test_telemetry_window_candidate_exposes_recent_transition_when_gate_still_blocked() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {"fcs_bit_switch_up": False},
+            "telemetry_window_frames": [
+                {"seq": 8, "t_wall": 30.0, "vars": {"fcs_bit_switch_up": False}},
+                {"seq": 9, "t_wall": 31.0, "vars": {"fcs_bit_switch_up": True}},
+            ],
+            "gates": {
+                "S19.completion": {
+                    "status": "blocked",
+                    "step_id": "S19",
+                    "reason_code": "fcs_bit_switch_up_missing",
+                    "reason": "vars.fcs_bit_switch_up==true",
+                }
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S19",
+                "missing_conditions": ["vars.fcs_bit_switch_up==true"],
+            },
+        }
+    )
+
+    digest = packet.to_dict()["telemetry_window_digest"]
+
+    assert digest["changed_vars"][0]["var"] == "fcs_bit_switch_up"
+    assert digest["changed_vars"][0]["first_value"] is False
+    assert digest["changed_vars"][0]["last_value"] is True
+    assert "recent telemetry transition conflicts with current blocked gate" in digest["contradictions"]
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+    telemetry_candidate = next(item for item in candidates if item["source"] == "telemetry_window")
+    assert telemetry_candidate["step_id"] == "S19"
+    assert "TELEMETRY_WINDOW.changed_vars.fcs_bit_switch_up" in telemetry_candidate["supporting_evidence_refs"]
+
+
+def test_telemetry_window_candidates_cover_four_down_progression_from_telemetry_only() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {
+                "ext_refuel_probe_value": 65000,
+                "launch_bar_switch_value": 1,
+                "hook_handle_value": 1,
+                "pitot_heat_on": True,
+                "flap_auto": False,
+            },
+            "telemetry_window_frames": [
+                {
+                    "seq": 20,
+                    "t_wall": 40.0,
+                    "vars": {
+                        "ext_refuel_probe_value": 0,
+                        "launch_bar_switch_value": 0,
+                        "hook_handle_value": 0,
+                        "pitot_heat_on": False,
+                    },
+                },
+                {
+                    "seq": 21,
+                    "t_wall": 44.0,
+                    "vars": {
+                        "ext_refuel_probe_value": 65000,
+                        "launch_bar_switch_value": 1,
+                        "hook_handle_value": 1,
+                        "pitot_heat_on": True,
+                    },
+                },
+            ],
+        }
+    )
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+    telemetry_steps = [item["step_id"] for item in candidates if item["source"] == "telemetry_window"]
+
+    assert telemetry_steps[:4] == ["S21", "S23", "S25", "S27"]
+    assert all(item["supporting_evidence_refs"][0].startswith("TELEMETRY_WINDOW.") for item in candidates if item["source"] == "telemetry_window")
+
+
+def test_telemetry_window_sparse_delta_does_not_mark_first_frame_only_value() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {"power_available": True, "left_ddi_on": True},
+            "telemetry_window_frames": [
+                {"seq": 1, "t_wall": 1.0, "delta": {"battery_on": False}},
+                {"seq": 2, "t_wall": 2.0, "delta": {"left_ddi_on": True}},
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S01",
+                "missing_conditions": ["vars.battery_on==true"],
+            },
+        }
+    )
+
+    digest = packet.to_dict()["telemetry_window_digest"]
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+
+    assert digest["first_frame_only_values"] == []
+    assert "battery_on=false only in first frame but later downstream avionics evidence is present" not in digest["contradictions"]
+    assert not any(item["source"] == "telemetry_window" and item["step_id"] == "S08" for item in candidates)
+
+
+def test_telemetry_window_full_snapshot_none_counts_as_missing_not_stable_true() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {"power_available": True, "left_ddi_on": True, "battery_on": None},
+            "telemetry_window_frames": [
+                {
+                    "seq": 1,
+                    "t_wall": 1.0,
+                    "vars": {"battery_on": False, "power_available": False},
+                    "vars_is_full_snapshot": True,
+                },
+                {
+                    "seq": 2,
+                    "t_wall": 2.0,
+                    "vars": {"battery_on": None, "power_available": True, "left_ddi_on": True},
+                    "vars_is_full_snapshot": True,
+                },
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S01",
+                "missing_conditions": ["vars.battery_on==true"],
+            },
+        }
+    )
+
+    digest = packet.to_dict()["telemetry_window_digest"]
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+
+    assert digest["first_frame_only_values"] == [{"var": "battery_on", "value": False}]
+    assert "battery_on" not in digest["stable_false_vars"]
+    assert any(item["source"] == "telemetry_window" and item["step_id"] == "S08" for item in candidates)
+
+
+def test_telemetry_window_fcs_bit_release_does_not_generate_s19_candidate() -> None:
+    packet = build_evidence_packet(
+        {
+            "telemetry_window_frames": [
+                {"seq": 1, "t_wall": 1.0, "vars": {"fcs_bit_switch_up": True}},
+                {"seq": 2, "t_wall": 2.0, "vars": {"fcs_bit_switch_up": False}},
+            ],
+        }
+    )
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+
+    assert not any(item["source"] == "telemetry_window" and item["step_id"] == "S19" for item in candidates)

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -47,6 +47,7 @@ from live_dcs import (
     _sanitize_request_payload_for_event,
     _sanitize_response_payload_for_event,
     _sanitize_policy_error_for_user,
+    _telemetry_window_signature,
 )
 from simtutor.schemas import validate_instance
 from tools.index_docs import build_index
@@ -735,6 +736,10 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
         "nominal",
         "low_confidence_bootstrap",
     }
+    telemetry_window_digest = request.context["state_harness"]["telemetry_window_digest"]
+    assert telemetry_window_digest["frame_count"] >= 1
+    assert telemetry_window_digest["latest_seq"] == 1
+    assert "telemetry_window_digest" in request.context["evidence_packet_summary"]
     assert isinstance(request.context["evidence_packet_summary"]["blocked_gate_count"], int)
     assert request.metadata["evidence_packet_summary"] == request.context["evidence_packet_summary"]
     tutor_request_payload = next(event.payload for event in events if event.kind == "tutor_request")
@@ -746,6 +751,116 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
     assert len(executor.calls[0]) == 1
     assert executor.calls[0][0]["type"] == "overlay"
     assert executor.calls[0][0]["target"] == "apu_switch"
+
+
+def test_live_loop_telemetry_window_uses_canonical_vars_not_raw_delta_keys(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_fcs_bit_window.jsonl"
+    frame1 = _bios_frame(1, 10.0, apu_switch=0)
+    frame2 = _bios_frame(2, 11.0, apu_switch=0)
+    frame1["bios"]["FCS_BIT_SW"] = 0
+    frame1["delta"]["FCS_BIT_SW"] = 0
+    frame2["bios"]["FCS_BIT_SW"] = 1
+    frame2["delta"]["FCS_BIT_SW"] = 1
+    _write_replay(replay_path, [frame1, frame2])
+
+    model = RecordingModel()
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=model,
+        action_executor=RecordingExecutor(),
+        cooldown_s=0,
+        lang="en",
+    )
+    try:
+        loop.run(max_frames=2, auto_help_every_n_frames=2)
+    finally:
+        loop.close()
+
+    request = model.calls[0]["request"]
+    assert any(
+        candidate["source"] == "telemetry_window" and candidate["step_id"] == "S19"
+        for candidate in request.context["candidate_steps"]
+    )
+    digest = request.context["state_harness"]["telemetry_window_digest"]
+    assert any(item["var"] == "fcs_bit_switch_up" for item in digest["changed_vars"])
+
+
+def test_tutor_request_event_sanitizes_telemetry_window_digest_nested_values() -> None:
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "state_harness": {
+                "telemetry_window_digest": {
+                    "frame_count": 2,
+                    "latest_seq": 9,
+                    "unexpected": "drop-me",
+                    "changed_vars": [
+                        {
+                            "var": "debug_text",
+                            "first_value": "A" * 200,
+                            "last_value": "B" * 200,
+                            "extra": "drop-me",
+                        }
+                    ],
+                    "contradictions": ["recent telemetry transition conflicts with current blocked gate"],
+                }
+            }
+        },
+    )
+
+    payload = _sanitize_request_payload_for_event(request)
+    digest = payload["context"]["state_harness"]["telemetry_window_digest"]
+
+    assert digest["frame_count"] == 2
+    assert "unexpected" not in digest
+    assert "extra" not in digest["changed_vars"][0]
+    assert len(digest["changed_vars"][0]["first_value"]) <= 83
+    assert len(digest["changed_vars"][0]["last_value"]) <= 83
+
+
+def test_telemetry_window_signature_ignores_seq_churn_but_keeps_semantic_changes() -> None:
+    base = {
+        "telemetry_window_digest": {
+            "latest_seq": 1,
+            "latest_t_wall": 10.0,
+            "changed_vars": [
+                {
+                    "var": "fcs_bit_switch_up",
+                    "first_value": False,
+                    "last_value": True,
+                    "transition_count": 1,
+                    "latest_transition_age_s": 0.0,
+                }
+            ],
+            "contradictions": [],
+        }
+    }
+    churned = {
+        "telemetry_window_digest": {
+            **base["telemetry_window_digest"],
+            "latest_seq": 99,
+            "latest_t_wall": 99.0,
+        }
+    }
+    changed = {
+        "telemetry_window_digest": {
+            **base["telemetry_window_digest"],
+            "changed_vars": [
+                {
+                    "var": "fcs_bit_switch_up",
+                    "first_value": True,
+                    "last_value": False,
+                    "transition_count": 1,
+                    "latest_transition_age_s": 0.0,
+                }
+            ],
+        }
+    }
+
+    assert _telemetry_window_signature(base) == _telemetry_window_signature(churned)
+    assert _telemetry_window_signature(base) != _telemetry_window_signature(changed)
 
 
 def test_live_loop_sends_final_tutor_message_to_dcs_text_channel(tmp_path: Path) -> None:

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -70,6 +70,113 @@ def test_prompt_contains_enum_constraints_delta_summary_and_evidence_sources() -
     assert sample_evidence["type"] == infer_evidence_type_from_ref(sample_evidence["ref"])
 
 
+def test_prompt_exposes_telemetry_window_digest_for_sequence_adjudication() -> None:
+    ctx = _base_context()
+    ctx["state_harness"] = {
+        "telemetry_window_digest": {
+            "window_duration_s": 3.0,
+            "frame_count": 2,
+            "latest_seq": 12,
+            "changed_vars": [
+                {
+                    "var": "battery_on",
+                    "first_value": False,
+                    "last_value": True,
+                    "transition_count": 1,
+                    "latest_transition_age_s": 0.0,
+                }
+            ],
+            "stable_true_vars": ["power_available", "left_ddi_on"],
+            "stable_false_vars": [],
+            "unknown_or_missing_vars": ["fire_test_a_complete"],
+            "first_frame_only_values": [{"var": "battery_on", "value": False}],
+            "last_seen_true": [{"var": "left_ddi_on", "seq": 12, "age_s": 0.0}],
+            "contradictions": [
+                "battery_on=false only in first frame but later downstream avionics evidence is present"
+            ],
+        },
+        "telemetry_evidence": {"source_status": "nominal", "confidence": "medium"},
+        "vision_evidence": {"source_status": "vision_unavailable", "confidence": "medium"},
+        "deterministic_candidate": {"step_id": "S01", "role": "candidate_not_authoritative"},
+        "conflicts": [],
+    }
+    ctx["candidate_steps"] = [
+        {
+            "step_id": "S08",
+            "source": "telemetry_window",
+            "role": "candidate",
+            "supporting_evidence_refs": ["TELEMETRY_WINDOW.stable_true_vars.left_ddi_on"],
+            "refuting_evidence_refs": ["TELEMETRY_WINDOW.first_frame_only_values.battery_on"],
+            "confidence": 0.82,
+        }
+    ]
+
+    result = build_help_prompt_result(ctx, "en", max_prompt_chars=20000, max_prompt_tokens_est=6000)
+    payload = _extract_prompt_constraints_json(result.prompt)
+
+    digest = payload["state_harness"]["telemetry_window_digest"]
+    assert digest["frame_count"] == 2
+    assert digest["first_frame_only_values"] == [{"var": "battery_on", "value": False}]
+    assert "telemetry_window_digest" in payload["decision_priority"]
+    assert "raw full JSONL" in result.prompt
+    assert "telemetry sequence evidence may override" in result.prompt
+
+
+def test_prompt_compacts_long_telemetry_window_digest_values_without_hard_truncate() -> None:
+    ctx = _base_context()
+    ctx["state_harness"] = {
+        "telemetry_window_digest": {
+            "frame_count": 2,
+            "latest_seq": 2,
+            "changed_vars": [
+                {
+                    "var": "debug_text",
+                    "first_value": ["A" * 5000],
+                    "last_value": {"nested": "B" * 5000},
+                    "transition_count": 1,
+                    "latest_transition_age_s": 0.0,
+                }
+            ],
+            "contradictions": ["recent telemetry transition conflicts with current blocked gate"],
+        },
+        "telemetry_evidence": {"source_status": "nominal", "confidence": "medium"},
+        "vision_evidence": {"source_status": "vision_unavailable", "confidence": "medium"},
+        "deterministic_candidate": {"step_id": "S19", "role": "candidate_not_authoritative"},
+        "conflicts": ["telemetry_window_conflicts_with_single_frame_hint"],
+    }
+
+    result = build_help_prompt_result(ctx, "en", max_prompt_chars=7000, max_prompt_tokens_est=1400)
+    if "compact_template" in result.metadata.get("trim_reasons", []):
+        constraints_line = next(line for line in result.prompt.splitlines() if line.startswith("constraints="))
+        payload = json.loads(constraints_line[len("constraints=") :])
+    else:
+        payload = _extract_prompt_constraints_json(result.prompt)
+    changed = payload["state_harness"]["telemetry_window_digest"]["changed_vars"][0]
+
+    assert "hard_truncate" not in result.metadata.get("trim_reasons", [])
+    assert len(changed["first_value"]) <= 83
+    assert len(changed["last_value"]) <= 83
+
+
+def test_compact_prompt_omits_telemetry_window_priority_when_digest_absent() -> None:
+    ctx = _base_context()
+    ctx["state_harness"] = {
+        "conflicts": ["early_step_from_telemetry_vs_late_display_from_vlm"],
+        "telemetry_evidence": {"source_status": "low_confidence_bootstrap"},
+        "vision_evidence": {"late_display_anchors": ["tac_page_visible"]},
+        "deterministic_candidate": {"step_id": "S01"},
+    }
+
+    result = build_help_prompt_result(ctx, "en", max_prompt_chars=500, max_prompt_tokens_est=120)
+    constraints_line = next(line for line in result.prompt.splitlines() if line.startswith("constraints="))
+    payload = json.loads(constraints_line[len("constraints=") :])
+
+    assert "compact_template" in result.metadata.get("trim_reasons", [])
+    assert "state_harness" in payload
+    assert "telemetry_window_digest" not in payload["state_harness"]
+    assert "telemetry_window_digest" not in payload["decision_priority"]
+
+
 def test_prompt_accepts_structured_candidate_steps_and_keeps_allowed_step_ids() -> None:
     ctx = _base_context()
     ctx["candidate_steps"] = [


### PR DESCRIPTION
## Summary
- add a compact TelemetryWindowDigest to EvidencePacket/state_harness for recent telemetry sequence adjudication
- generate telemetry_window StepCandidate entries for bootstrap refutation, missing early latch/later evidence, recent control transitions, and S20-S27 telemetry progression
- feed canonical live vars snapshots into the digest, expose compact prompt/context metadata, sanitize event output, and keep cache keys stable except for semantic digest changes

## Review-fix loop
- subagent review found raw-delta/canonical-var mismatch, sparse-delta first-frame risk, transition direction, prompt budget, sanitizer, and cache-key issues
- fixed those findings and reran targeted tests plus full local suite
- final subagent review reported no findings

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_evidence_packet.py tests/test_prompting.py tests/test_base_help_model.py tests/test_live_dcs.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Fixes #280