### PR TITLE
Add harness validator action planner

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -1,0 +1,354 @@
+"""
+Validator and action planner for harness decisions.
+
+This module stays in core on purpose: it only consumes the stable
+StepHarnessSpec contract plus plain decision/context data, then returns a
+small plan that adapters can map to their transport-specific actions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from core.step_harness import StepHarnessSpec
+
+
+@dataclass(frozen=True)
+class HarnessActionPlan:
+    step_id: str | None
+    overlay_step_id: str | None
+    targets: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    guidance: str | None
+    text_only: bool
+    validator_rejected: bool
+    repair_applied: bool
+    rejected_model_step_id: str | None
+    final_action_plan_source: str
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HarnessCompletionAdvance:
+    step_id: str
+    fact_id: str
+    next_step_id: str
+    source: str
+
+
+@dataclass(frozen=True)
+class HarnessActionHintFactRule:
+    step_id: str
+    fact_id: str
+
+
+@dataclass(frozen=True)
+class HarnessTextGuidanceRule:
+    step_id: str
+    target: str
+    guidance: str
+    source: str = "validator_text_only_guidance"
+
+
+def _strings(raw: Sequence[str] | set[str] | tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
+    if not isinstance(raw, (list, tuple, set)):
+        return ()
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, str) or not item or item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return tuple(out)
+
+
+def _hint_targets(action_hint: Mapping[str, Any] | None) -> tuple[str, ...]:
+    if not isinstance(action_hint, Mapping):
+        return ()
+    raw_targets = action_hint.get("targets")
+    targets = _strings(raw_targets if isinstance(raw_targets, (list, tuple, set)) else None)
+    if targets:
+        return targets
+    target = action_hint.get("target")
+    return (target,) if isinstance(target, str) and target else ()
+
+
+def _seen_or_fresh(
+    fact_id: str,
+    *,
+    vision_seen_fact_ids: Sequence[str] | None,
+    vision_fresh_fact_ids: Sequence[str] | None,
+) -> bool:
+    return fact_id in set(_strings(vision_seen_fact_ids)) or fact_id in set(_strings(vision_fresh_fact_ids))
+
+
+def _completion_advance_for_seen_fact(
+    step_id: str | None,
+    *,
+    completion_advancements: Sequence[HarnessCompletionAdvance] | None,
+    vision_seen_fact_ids: Sequence[str] | None,
+    vision_fresh_fact_ids: Sequence[str] | None,
+) -> HarnessCompletionAdvance | None:
+    if not isinstance(step_id, str) or not step_id:
+        return None
+    for rule in completion_advancements or ():
+        if rule.step_id != step_id:
+            continue
+        if _seen_or_fresh(
+            rule.fact_id,
+            vision_seen_fact_ids=vision_seen_fact_ids,
+            vision_fresh_fact_ids=vision_fresh_fact_ids,
+        ):
+            return rule
+    return None
+
+
+def _text_guidance_for_targets(
+    step_id: str | None,
+    targets: Sequence[str],
+    *,
+    text_guidance_rules: Sequence[HarnessTextGuidanceRule] | None,
+) -> HarnessTextGuidanceRule | None:
+    if not isinstance(step_id, str) or not step_id:
+        return None
+    target_set = set(_strings(targets))
+    for rule in text_guidance_rules or ():
+        if rule.step_id == step_id and (rule.target == "*" or rule.target in target_set):
+            return rule
+    return None
+
+
+def _hint_allowed_by_fact_rule(
+    step_id: str | None,
+    *,
+    action_hint_fact_rules: Sequence[HarnessActionHintFactRule] | None,
+    vision_seen_fact_ids: Sequence[str] | None,
+    vision_fresh_fact_ids: Sequence[str] | None,
+) -> bool:
+    if not isinstance(step_id, str) or not step_id:
+        return False
+    for rule in action_hint_fact_rules or ():
+        if rule.step_id != step_id:
+            continue
+        if _seen_or_fresh(
+            rule.fact_id,
+            vision_seen_fact_ids=vision_seen_fact_ids,
+            vision_fresh_fact_ids=vision_fresh_fact_ids,
+        ):
+            return True
+    return False
+
+
+def _filter_targets(
+    targets: Sequence[str],
+    *,
+    spec: StepHarnessSpec | None,
+    runtime_overlay_targets: Sequence[str] | None,
+    request_overlay_targets: Sequence[str] | None,
+    max_overlay_targets: int,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    allowed_by_spec = set(spec.allowed_overlay_targets) if spec is not None else set()
+    runtime_allowset = set(_strings(runtime_overlay_targets))
+    request_allowset = set(_strings(request_overlay_targets))
+    limit = max(0, int(max_overlay_targets))
+    out: list[str] = []
+    reasons: list[str] = []
+    for target in _strings(list(targets)):
+        if spec is not None and target not in allowed_by_spec:
+            reasons.append(f"target_not_allowed:{target}")
+            continue
+        if runtime_allowset and target not in runtime_allowset:
+            reasons.append(f"target_not_in_runtime_allowlist:{target}")
+            continue
+        if request_allowset and target not in request_allowset:
+            reasons.append(f"target_not_in_request_allowlist:{target}")
+            continue
+        if target in out:
+            continue
+        if len(out) >= limit:
+            reasons.append(f"target_dropped_by_max_overlay_targets:{target}")
+            continue
+        out.append(target)
+    return tuple(out), tuple(reasons)
+
+
+def _valid_evidence_refs(
+    evidence_refs: Sequence[str] | None,
+    allowed_evidence_refs: Sequence[str] | None,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    refs = _strings(evidence_refs)
+    allowed = set(_strings(allowed_evidence_refs))
+    if not allowed:
+        return refs, ()
+    valid = tuple(ref for ref in refs if ref in allowed)
+    invalid = tuple(ref for ref in refs if ref not in allowed)
+    return valid, tuple(f"unknown_evidence_ref:{ref}" for ref in invalid)
+
+
+def plan_harness_action(
+    *,
+    step_specs: Mapping[str, StepHarnessSpec],
+    inferred_step_id: str | None,
+    model_step_id: str | None = None,
+    overlay_step_id: str | None = None,
+    proposed_overlay_targets: Sequence[str] | None = None,
+    candidate_step_ids: Sequence[str] | None = None,
+    runtime_overlay_targets: Sequence[str] | None = None,
+    request_overlay_targets: Sequence[str] | None = None,
+    allowed_evidence_refs: Sequence[str] | None = None,
+    evidence_refs: Sequence[str] | None = None,
+    max_overlay_targets: int = 1,
+    vision_seen_fact_ids: Sequence[str] | None = None,
+    vision_fresh_fact_ids: Sequence[str] | None = None,
+    action_hint: Mapping[str, Any] | None = None,
+    completion_advancements: Sequence[HarnessCompletionAdvance] | None = None,
+    action_hint_step_ids: Sequence[str] | None = None,
+    action_hint_fact_rules: Sequence[HarnessActionHintFactRule] | None = None,
+    text_guidance_rules: Sequence[HarnessTextGuidanceRule] | None = None,
+) -> HarnessActionPlan:
+    reasons: list[str] = []
+    rejected_model_step_id: str | None = None
+    selected_step_id = inferred_step_id if isinstance(inferred_step_id, str) and inferred_step_id else None
+    if isinstance(model_step_id, str) and model_step_id and selected_step_id is None:
+        selected_step_id = model_step_id
+
+    selected_overlay_step_id = (
+        overlay_step_id if isinstance(overlay_step_id, str) and overlay_step_id else selected_step_id
+    )
+    source = "model"
+
+    completion_advance = _completion_advance_for_seen_fact(
+        selected_step_id,
+        completion_advancements=completion_advancements,
+        vision_seen_fact_ids=vision_seen_fact_ids,
+        vision_fresh_fact_ids=vision_fresh_fact_ids,
+    )
+    if completion_advance is not None:
+        if isinstance(model_step_id, str) and model_step_id != completion_advance.next_step_id:
+            rejected_model_step_id = model_step_id
+        selected_step_id = completion_advance.next_step_id
+        selected_overlay_step_id = completion_advance.next_step_id
+        source = completion_advance.source
+        reasons.append(f"known_completion_fact:{completion_advance.fact_id}")
+
+    candidate_set = set(_strings(candidate_step_ids))
+    if isinstance(model_step_id, str) and model_step_id:
+        if candidate_set and model_step_id not in candidate_set:
+            rejected_model_step_id = model_step_id
+            reasons.append(f"model_step_not_candidate:{model_step_id}")
+        elif selected_step_id is not None and model_step_id != selected_step_id:
+            rejected_model_step_id = model_step_id
+            reasons.append(f"model_step_mismatch:{model_step_id}")
+
+    spec = step_specs.get(selected_overlay_step_id or "") if selected_overlay_step_id else None
+    proposed_targets = _strings(proposed_overlay_targets)
+    text_guidance = _text_guidance_for_targets(
+        selected_step_id,
+        proposed_targets,
+        text_guidance_rules=text_guidance_rules,
+    )
+    if text_guidance is not None:
+        return HarnessActionPlan(
+            step_id=selected_step_id,
+            overlay_step_id=selected_overlay_step_id,
+            targets=(),
+            evidence_refs=(),
+            guidance=text_guidance.guidance,
+            text_only=True,
+            validator_rejected=True,
+            repair_applied=True,
+            rejected_model_step_id=rejected_model_step_id,
+            final_action_plan_source=text_guidance.source,
+            reasons=tuple((*reasons, f"text_only_guidance:{text_guidance.target}")),
+        )
+
+    hinted_targets = _hint_targets(action_hint)
+    use_hint = False
+    action_hint_step_set = set(_strings(action_hint_step_ids))
+    if hinted_targets:
+        if selected_step_id in action_hint_step_set:
+            use_hint = True
+        if _hint_allowed_by_fact_rule(
+            selected_step_id,
+            action_hint_fact_rules=action_hint_fact_rules,
+            vision_seen_fact_ids=vision_seen_fact_ids,
+            vision_fresh_fact_ids=vision_fresh_fact_ids,
+        ):
+            use_hint = True
+
+    if completion_advance is not None:
+        base_targets = spec.allowed_overlay_targets if spec is not None else ()
+    elif use_hint:
+        base_targets = hinted_targets
+        source = "validator_action_hint"
+    else:
+        base_targets = proposed_targets
+
+    targets, target_reasons = _filter_targets(
+        base_targets,
+        spec=spec,
+        runtime_overlay_targets=runtime_overlay_targets,
+        request_overlay_targets=request_overlay_targets,
+        max_overlay_targets=max_overlay_targets,
+    )
+    reasons.extend(target_reasons)
+
+    if not targets and spec is not None and spec.allowed_overlay_targets and max_overlay_targets > 0:
+        repaired_targets, repair_reasons = _filter_targets(
+            spec.allowed_overlay_targets,
+            spec=spec,
+            runtime_overlay_targets=runtime_overlay_targets,
+            request_overlay_targets=request_overlay_targets,
+            max_overlay_targets=max_overlay_targets,
+        )
+        if repaired_targets:
+            targets = repaired_targets
+            source = "validator_repair" if source == "model" else source
+            reasons.extend(repair_reasons)
+
+    valid_refs, ref_reasons = _valid_evidence_refs(evidence_refs, allowed_evidence_refs)
+    reasons.extend(ref_reasons)
+
+    proposed_set = set(proposed_targets)
+    target_set = set(targets)
+    repaired = (
+        source != "model"
+        or bool(target_reasons)
+        or bool(ref_reasons)
+        or (bool(targets) and proposed_set != target_set)
+    )
+    rejected = bool(reasons) or rejected_model_step_id is not None or repaired
+    if source == "model" and repaired:
+        source = "validator_repair"
+
+    guidance = None
+    if use_hint and isinstance(action_hint, Mapping):
+        hint_reason = action_hint.get("reason")
+        if isinstance(hint_reason, str) and hint_reason:
+            guidance = hint_reason
+
+    return HarnessActionPlan(
+        step_id=selected_step_id,
+        overlay_step_id=selected_overlay_step_id,
+        targets=targets,
+        evidence_refs=valid_refs,
+        guidance=guidance,
+        text_only=False,
+        validator_rejected=rejected,
+        repair_applied=repaired,
+        rejected_model_step_id=rejected_model_step_id,
+        final_action_plan_source=source,
+        reasons=tuple(reasons),
+    )
+
+
+__all__ = [
+    "HarnessActionHintFactRule",
+    "HarnessActionPlan",
+    "HarnessCompletionAdvance",
+    "HarnessTextGuidanceRule",
+    "plan_harness_action",
+]

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -83,6 +83,12 @@ from core.help_failure import (
     merge_failure_metadata,
     overlay_rejection_payload,
 )
+from core.harness_validation import (
+    HarnessActionHintFactRule,
+    HarnessCompletionAdvance,
+    HarnessTextGuidanceRule,
+    plan_harness_action,
+)
 from core.security import (
     redact_sensitive_text,
     sanitize_help_response_for_log,
@@ -3714,18 +3720,19 @@ class LiveDcsTutorLoop:
         metadata = response.metadata if isinstance(response.metadata, Mapping) else {}
         raw_help_response = metadata.get("help_response")
         if isinstance(raw_help_response, Mapping):
-            response.metadata["model_raw_help_response"] = copy.deepcopy(dict(raw_help_response))
+            response.metadata.setdefault("model_raw_help_response", copy.deepcopy(dict(raw_help_response)))
             raw_explanations = raw_help_response.get("explanations")
             if isinstance(raw_explanations, list):
-                response.metadata["model_raw_explanations"] = [
-                    item for item in raw_explanations if isinstance(item, str)
-                ]
+                response.metadata.setdefault(
+                    "model_raw_explanations",
+                    [item for item in raw_explanations if isinstance(item, str)],
+                )
             raw_next = raw_help_response.get("next")
             if isinstance(raw_next, Mapping):
-                response.metadata["model_raw_next"] = dict(raw_next)
+                response.metadata.setdefault("model_raw_next", dict(raw_next))
             raw_diagnosis = raw_help_response.get("diagnosis")
             if isinstance(raw_diagnosis, Mapping):
-                response.metadata["model_raw_diagnosis"] = dict(raw_diagnosis)
+                response.metadata.setdefault("model_raw_diagnosis", dict(raw_diagnosis))
 
         final_public_response: dict[str, Any] = {
             "message": response.message,
@@ -4460,6 +4467,372 @@ class LiveDcsTutorLoop:
         response.message = guidance
         response.explanations = [guidance]
         return True, HARNESS_LATE_VLM_CONFLICT
+
+    def _apply_harness_validation_action_plan(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> tuple[bool, str]:
+        context = request.context if isinstance(request.context, Mapping) else {}
+        hint = context.get("deterministic_step_hint")
+        if not isinstance(hint, Mapping):
+            return False, "missing_deterministic_hint"
+
+        inferred_step_id = hint.get("inferred_step_id")
+        overlay_step_id = hint.get("overlay_step_id")
+        if response.metadata.get("completion_conflict_rewritten") is True:
+            return False, "completion_conflict_already_rewritten"
+        response_mapping_meta = response.metadata.get("response_mapping")
+        if (
+            response.actions
+            and isinstance(response_mapping_meta, Mapping)
+            and response_mapping_meta.get("rejected_targets_by_request_allowlist")
+        ):
+            return False, "response_mapping_already_repaired_allowlist"
+        if inferred_step_id == "S18":
+            return False, "legacy_s18_action_hint_guardrail"
+        if _state_harness_has_late_vlm_conflict(context.get("state_harness")):
+            return False, "late_vlm_conflict_guardrail"
+        model_step_id = _extract_model_next_step_id(response.metadata)
+        if not isinstance(model_step_id, str) or not model_step_id:
+            diagnosis = response.metadata.get("diagnosis")
+            if isinstance(diagnosis, Mapping):
+                raw_step_id = diagnosis.get("step_id")
+                if isinstance(raw_step_id, str) and raw_step_id:
+                    model_step_id = raw_step_id
+
+        proposed_targets: list[str] = []
+        evidence_refs: list[str] = []
+        help_response = response.metadata.get("help_response")
+        original_help_response = copy.deepcopy(help_response) if isinstance(help_response, Mapping) else None
+        if isinstance(help_response, Mapping):
+            overlay = help_response.get("overlay")
+            if isinstance(overlay, Mapping):
+                raw_targets = overlay.get("targets")
+                if isinstance(raw_targets, list):
+                    proposed_targets = [item for item in raw_targets if isinstance(item, str) and item]
+                raw_evidence = overlay.get("evidence")
+                if isinstance(raw_evidence, list):
+                    for item in raw_evidence:
+                        if not isinstance(item, Mapping):
+                            continue
+                        ref = item.get("ref")
+                        if isinstance(ref, str) and ref:
+                            evidence_refs.append(ref)
+        if not proposed_targets:
+            proposed_targets = [
+                target
+                for target in (
+                    action.get("target") if isinstance(action, Mapping) else None
+                    for action in response.actions
+                )
+                if isinstance(target, str) and target
+            ]
+
+        candidate_step_ids: list[str] = []
+        raw_candidates = context.get("candidate_steps")
+        if isinstance(raw_candidates, list):
+            for candidate in raw_candidates:
+                if isinstance(candidate, Mapping):
+                    step_id = candidate.get("step_id")
+                    if isinstance(step_id, str) and step_id:
+                        candidate_step_ids.append(step_id)
+                elif isinstance(candidate, str) and candidate:
+                    candidate_step_ids.append(candidate)
+        if not candidate_step_ids:
+            candidate_step_ids = list(self.candidate_steps)
+
+        vision_summary = context.get("vision_fact_summary")
+        vision_seen_fact_ids: list[str] = []
+        vision_fresh_fact_ids: list[str] = []
+        if isinstance(vision_summary, Mapping):
+            raw_seen = vision_summary.get("seen_fact_ids")
+            if isinstance(raw_seen, (list, tuple, set)):
+                vision_seen_fact_ids = [item for item in raw_seen if isinstance(item, str) and item]
+            raw_fresh = vision_summary.get("fresh_fact_ids")
+            if isinstance(raw_fresh, (list, tuple, set)):
+                vision_fresh_fact_ids = [item for item in raw_fresh if isinstance(item, str) and item]
+
+        action_hint = hint.get("action_hint")
+        manual_text_guidance_rules: list[HarnessTextGuidanceRule] = []
+        missing_conditions = hint.get("missing_conditions")
+        missing_set = {
+            item for item in missing_conditions
+            if isinstance(item, str) and item
+        } if isinstance(missing_conditions, (list, tuple)) else set()
+        include_s05_manual_guidance = (
+            "vars.throttle_r_not_off==true" in missing_set
+            or "vars.throttle_r_idle_complete==true" in missing_set
+        )
+        include_s11_manual_guidance = (
+            "vars.throttle_l_not_off==true" in missing_set
+            or "vars.throttle_l_idle_complete==true" in missing_set
+        )
+        if self.lang == "zh":
+            if include_s05_manual_guidance:
+                manual_text_guidance_rules.append(HarnessTextGuidanceRule(
+                    step_id="S05",
+                    target="*",
+                    guidance=(
+                        "当前处于 S05（右发油门推进到 IDLE）阶段。右油门杆还没有移出 OFF 卡位。"
+                        "该动作不在当前 overlay 布局内，请按 Right Shift+Home 将右油门杆推至 IDLE 位置。"
+                    ),
+                ))
+            if include_s11_manual_guidance:
+                manual_text_guidance_rules.append(HarnessTextGuidanceRule(
+                    step_id="S11",
+                    target="*",
+                    guidance=(
+                        "当前处于 S11（左发油门推进到 IDLE）阶段。左油门杆还没有移出 OFF 卡位。"
+                        "该动作不在当前 overlay 布局内，请按 Right Alt+Home 将左油门杆推至 IDLE 位置。"
+                    ),
+                ))
+        else:
+            if include_s05_manual_guidance:
+                manual_text_guidance_rules.append(HarnessTextGuidanceRule(
+                    step_id="S05",
+                    target="*",
+                    guidance=(
+                        "You are on S05 (move the right throttle to IDLE). The right throttle is still in the OFF detent. "
+                        "This control is outside the current overlay layout; press Right Shift+Home to move the right throttle to IDLE."
+                    ),
+                ))
+            if include_s11_manual_guidance:
+                manual_text_guidance_rules.append(HarnessTextGuidanceRule(
+                    step_id="S11",
+                    target="*",
+                    guidance=(
+                        "You are on S11 (move the left throttle to IDLE). The left throttle is still in the OFF detent. "
+                        "This control is outside the current overlay layout; press Right Alt+Home to move the left throttle to IDLE."
+                    ),
+                ))
+        plan = plan_harness_action(
+            step_specs=self.step_harness_specs,
+            inferred_step_id=inferred_step_id if isinstance(inferred_step_id, str) else None,
+            model_step_id=model_step_id if isinstance(model_step_id, str) else None,
+            overlay_step_id=overlay_step_id if isinstance(overlay_step_id, str) else None,
+            proposed_overlay_targets=proposed_targets,
+            candidate_step_ids=candidate_step_ids,
+            runtime_overlay_targets=self.overlay_allowlist,
+            request_overlay_targets=context.get("overlay_target_allowlist"),
+            allowed_evidence_refs=sorted(_collect_request_evidence_refs(context)),
+            evidence_refs=evidence_refs,
+            max_overlay_targets=self.max_overlay_targets,
+            vision_seen_fact_ids=vision_seen_fact_ids,
+            vision_fresh_fact_ids=vision_fresh_fact_ids,
+            action_hint=action_hint if isinstance(action_hint, Mapping) else None,
+            completion_advancements=[
+                HarnessCompletionAdvance(
+                    step_id="S19",
+                    fact_id="fcsmc_final_go_result_visible",
+                    next_step_id="S20",
+                    source="validator_s19_final_go",
+                )
+            ],
+            action_hint_step_ids=["S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
+            action_hint_fact_rules=[
+                HarnessActionHintFactRule(step_id="S19", fact_id="fcsmc_intermediate_result_visible")
+            ],
+            text_guidance_rules=manual_text_guidance_rules,
+        )
+
+        response.metadata["validator_rejected"] = bool(plan.validator_rejected)
+        response.metadata["repair_applied"] = bool(response.metadata.get("repair_applied")) or bool(plan.repair_applied)
+        response.metadata["final_action_plan_source"] = plan.final_action_plan_source
+        response.metadata["harness_validation_reasons"] = list(plan.reasons)
+        response.metadata["harness_action_plan"] = {
+            "step_id": plan.step_id,
+            "overlay_step_id": plan.overlay_step_id,
+            "targets": list(plan.targets),
+            "text_only": plan.text_only,
+            "source": plan.final_action_plan_source,
+        }
+        if isinstance(plan.rejected_model_step_id, str) and plan.rejected_model_step_id:
+            response.metadata["rejected_model_step_id"] = plan.rejected_model_step_id
+        elif "rejected_model_step_id" in response.metadata:
+            response.metadata.pop("rejected_model_step_id", None)
+        if original_help_response is not None:
+            response.metadata.setdefault("model_raw_help_response", original_help_response)
+
+        if plan.text_only:
+            original_actions = copy.deepcopy([dict(action) for action in response.actions if isinstance(action, Mapping)])
+            if original_actions:
+                response.metadata["harness_validator_original_actions"] = original_actions
+            response.actions = []
+            if isinstance(plan.guidance, str) and plan.guidance:
+                original_message = response.message
+                original_explanations = list(response.explanations)
+                response.message = plan.guidance
+                response.explanations = [plan.guidance]
+                if original_message != response.message:
+                    response.metadata["harness_validator_original_message"] = original_message
+                    response.metadata["manual_throttle_guidance_original_message"] = original_message
+                if original_explanations and original_explanations != response.explanations:
+                    response.metadata["harness_validator_original_explanations"] = original_explanations
+                    response.metadata["manual_throttle_guidance_original_explanations"] = original_explanations
+            if plan.step_id in {"S05", "S11"}:
+                response.metadata["manual_throttle_guidance_rewritten"] = True
+                response.metadata["manual_throttle_guidance_step_id"] = plan.step_id
+                response.metadata["manual_throttle_guidance_original_actions"] = original_actions
+                response.metadata["help_response"] = {
+                    "diagnosis": {"step_id": plan.step_id, "error_category": "OM"},
+                    "next": {"step_id": plan.step_id},
+                    "overlay": {"targets": [], "evidence": []},
+                    "explanations": [response.message],
+                }
+                return True, "manual_throttle_keyboard_guidance"
+            return True, plan.final_action_plan_source
+
+        current_targets = [
+            target
+            for target in (
+                action.get("target") if isinstance(action, Mapping) else None
+                for action in response.actions
+            )
+            if isinstance(target, str) and target
+        ]
+        current_next = response.metadata.get("next")
+        current_next_step_id = current_next.get("step_id") if isinstance(current_next, Mapping) else None
+        current_diagnosis = response.metadata.get("diagnosis")
+        current_diagnosis_step_id = (
+            current_diagnosis.get("step_id") if isinstance(current_diagnosis, Mapping) else None
+        )
+        only_target_repair = bool(plan.repair_applied) and all(
+            isinstance(reason, str)
+            and (
+                reason.startswith("target_not_allowed:")
+                or reason.startswith("target_not_in_request_allowlist:")
+                or reason.startswith("target_dropped_by_max_overlay_targets:")
+            )
+            for reason in plan.reasons
+        )
+        if (
+            response.actions
+            and tuple(current_targets) == plan.targets
+            and (
+                (
+                    not plan.repair_applied
+                    and plan.rejected_model_step_id is None
+                )
+                or (
+                    only_target_repair
+                    and plan.rejected_model_step_id is None
+                    and current_next_step_id == plan.step_id
+                    and current_diagnosis_step_id == plan.step_id
+                )
+            )
+        ):
+            return False, "already_valid"
+        if not plan.targets:
+            if plan.validator_rejected and response.actions:
+                response.metadata["harness_validator_original_actions"] = copy.deepcopy(
+                    [dict(action) for action in response.actions if isinstance(action, Mapping)]
+                )
+                response.actions = []
+                if isinstance(original_help_response, Mapping):
+                    cleaned_help_response = copy.deepcopy(dict(original_help_response))
+                    cleaned_help_response["diagnosis"] = {"step_id": plan.step_id, "error_category": "OM"}
+                    cleaned_help_response["next"] = {"step_id": plan.step_id}
+                    cleaned_help_response["overlay"] = {"targets": [], "evidence": []}
+                    response.metadata["help_response"] = cleaned_help_response
+                return True, "validator_rejected_no_action"
+            return False, "no_planned_targets"
+
+        original_actions = copy.deepcopy([dict(action) for action in response.actions if isinstance(action, Mapping)])
+        if original_actions:
+            response.metadata["harness_validator_original_actions"] = original_actions
+
+        fallback_help_obj, fallback_reason = self._build_safe_fallback_overlay_help_obj(
+            request,
+            override_inferred_step_id=plan.step_id,
+            override_overlay_step_id=plan.overlay_step_id,
+            ignore_request_allowlist=True,
+        )
+        if isinstance(fallback_help_obj, Mapping):
+            planned_help_obj = copy.deepcopy(dict(fallback_help_obj))
+        else:
+            planned_help_obj = {
+                "diagnosis": {"step_id": plan.step_id, "error_category": "OM"},
+                "next": {"step_id": plan.step_id},
+                "overlay": {"targets": [], "evidence": []},
+                "explanations": list(response.explanations) or ([response.message] if response.message else []),
+            }
+        planned_help_obj["diagnosis"] = {"step_id": plan.step_id, "error_category": "OM"}
+        planned_help_obj["next"] = {"step_id": plan.step_id}
+        evidence_source = None
+        for ref in plan.evidence_refs:
+            evidence_type = infer_evidence_type_from_ref(ref)
+            if evidence_type is None:
+                continue
+            evidence_source = {
+                "type": evidence_type,
+                "ref": ref,
+                "quote": "Harness validator planned target.",
+                "grounding_confidence": 0.51,
+            }
+            break
+        fallback_overlay = fallback_help_obj.get("overlay") if isinstance(fallback_help_obj, Mapping) else None
+        if evidence_source is None and isinstance(fallback_overlay, Mapping):
+            fallback_evidence = fallback_overlay.get("evidence")
+            if isinstance(fallback_evidence, list):
+                for item in fallback_evidence:
+                    if not isinstance(item, Mapping):
+                        continue
+                    ref = item.get("ref")
+                    evidence_type = item.get("type")
+                    if isinstance(ref, str) and isinstance(evidence_type, str):
+                        evidence_source = {
+                            "type": evidence_type,
+                            "ref": ref,
+                            "quote": item.get("quote") if isinstance(item.get("quote"), str) else "Harness validator planned target.",
+                            "grounding_confidence": item.get("grounding_confidence", 0.51),
+                        }
+                        break
+        if evidence_source is None:
+            return False, "fallback_failed:no_verifiable_evidence_ref"
+        planned_help_obj["overlay"] = {
+            "targets": list(plan.targets),
+            "evidence": [
+                {
+                    "target": target,
+                    "type": evidence_source["type"],
+                    "ref": evidence_source["ref"],
+                    "quote": evidence_source["quote"],
+                    "grounding_confidence": evidence_source["grounding_confidence"],
+                }
+                for target in plan.targets
+            ],
+        }
+        if isinstance(plan.guidance, str) and plan.guidance:
+            planned_help_obj["explanations"] = [plan.guidance]
+
+        mapped = map_help_response_to_tutor_response(
+            planned_help_obj,
+            request=request,
+            status=response.status,
+            max_overlay_targets=self.max_overlay_targets,
+            ui_map_path=self.ui_map_path,
+            lang=self.lang,
+        )
+        mapped_meta = dict(mapped.metadata)
+        response.metadata["harness_validator_mapping"] = mapped_meta
+        if not mapped.actions:
+            mapping_errors = mapped_meta.get("mapping_errors")
+            if isinstance(mapping_errors, list) and mapping_errors:
+                return False, f"mapping_failed:{'|'.join(str(item) for item in mapping_errors[:3])}"
+            return False, "mapping_failed"
+        response.actions = list(mapped.actions)
+        response.metadata["diagnosis"] = {"step_id": plan.step_id, "error_category": "OM"}
+        response.metadata["next"] = {"step_id": plan.step_id}
+        response.metadata["help_response"] = planned_help_obj
+        response.metadata["harness_validator_fallback_reason"] = fallback_reason
+        if isinstance(plan.guidance, str) and plan.guidance:
+            response.message = plan.guidance
+            response.explanations = [plan.guidance]
+        elif mapped.explanations and response.metadata.get("procedural_guidance_rewritten") is not True:
+            response.message = mapped.explanations[0]
+            response.explanations = list(mapped.explanations)
+        return True, fallback_reason
 
     def _rewrite_manual_throttle_guidance_response(
         self,
@@ -5498,6 +5871,13 @@ class LiveDcsTutorLoop:
 
             fallback_overlay_used = False
             fallback_overlay_reason = "all_steps_complete" if terminal_state_short_circuited else "not_needed"
+            harness_validation_used, harness_validation_reason = self._apply_harness_validation_action_plan(
+                response,
+                request,
+            )
+            if harness_validation_used:
+                fallback_overlay_used = bool(response.actions)
+                fallback_overlay_reason = harness_validation_reason
             harness_guardrail_used, harness_guardrail_reason = self._apply_harness_conflict_guardrail(
                 response,
                 request,
@@ -5524,7 +5904,7 @@ class LiveDcsTutorLoop:
                 request,
                 mapped_meta,
             )
-            if should_apply_safe_fallback and not action_hint_override_used:
+            if should_apply_safe_fallback and not action_hint_override_used and not harness_validation_used:
                 fallback_overlay_used, fallback_overlay_reason = self._apply_safe_fallback_overlay(
                     response,
                     request,

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from core.harness_validation import (
+    HarnessActionHintFactRule,
+    HarnessCompletionAdvance,
+    HarnessTextGuidanceRule,
+    plan_harness_action,
+)
+from core.step_harness import RecoveryActionPolicy, SignalQualityRequirement, StepHarnessSpec
+
+
+def _spec(
+    step_id: str,
+    targets: tuple[str, ...],
+    *,
+    overlay_enabled: bool = True,
+    recovery_kind: str = "retry_allowed_targets",
+) -> StepHarnessSpec:
+    return StepHarnessSpec(
+        step_id=step_id,
+        required_observables=("gate",),
+        optional_observables=(),
+        telemetry_facts=(f"VARS.{step_id.lower()}_done",),
+        vision_facts=(),
+        recent_action_facts=tuple(f"RECENT_ACTIONS.{target}" for target in targets),
+        completion_predicates=(f"GATES.{step_id}.completion",),
+        latch_semantics="none",
+        allowed_overlay_targets=targets if overlay_enabled else (),
+        forbidden_overlay_targets=() if overlay_enabled else targets,
+        recovery_policy=RecoveryActionPolicy(kind=recovery_kind, allowed_targets=targets),
+        observability_status="observable",
+        signal_quality=SignalQualityRequirement(),
+        requires_visual_confirmation=False,
+        declared_ui_targets=targets,
+        overlay_enabled=overlay_enabled,
+    )
+
+
+def test_plan_harness_action_repairs_invalid_target_to_step_spec_target() -> None:
+    plan = plan_harness_action(
+        step_specs={"S20": _spec("S20", ("refuel_probe_switch",))},
+        inferred_step_id="S20",
+        model_step_id="S20",
+        proposed_overlay_targets=["launch_bar_switch", "refuel_probe_switch"],
+        candidate_step_ids=["S20", "S21"],
+        runtime_overlay_targets=["refuel_probe_switch", "launch_bar_switch"],
+        request_overlay_targets=["refuel_probe_switch", "launch_bar_switch"],
+        allowed_evidence_refs=["GATES.S20.completion"],
+        evidence_refs=["GATES.S20.completion"],
+        max_overlay_targets=1,
+    )
+
+    assert plan.targets == ("refuel_probe_switch",)
+    assert plan.validator_rejected is True
+    assert plan.repair_applied is True
+    assert plan.final_action_plan_source == "validator_repair"
+    assert "target_not_allowed:launch_bar_switch" in plan.reasons
+
+
+def test_plan_harness_action_advances_s19_final_go_to_s20() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S19": _spec("S19", ("fcs_bit_switch", "right_mdi_pb5"), recovery_kind="visual_confirmation"),
+            "S20": _spec("S20", ("refuel_probe_switch",)),
+        },
+        inferred_step_id="S19",
+        model_step_id="S19",
+        proposed_overlay_targets=["fcs_bit_switch"],
+        candidate_step_ids=["S19", "S20"],
+        runtime_overlay_targets=["fcs_bit_switch", "right_mdi_pb5", "refuel_probe_switch"],
+        request_overlay_targets=["fcs_bit_switch", "right_mdi_pb5", "refuel_probe_switch"],
+        allowed_evidence_refs=["VISION_FACTS.fcsmc_final_go_result_visible@frame-1"],
+        evidence_refs=["VISION_FACTS.fcsmc_final_go_result_visible@frame-1"],
+        max_overlay_targets=2,
+        vision_seen_fact_ids=["fcsmc_final_go_result_visible"],
+        completion_advancements=[
+            HarnessCompletionAdvance(
+                step_id="S19",
+                fact_id="fcsmc_final_go_result_visible",
+                next_step_id="S20",
+                source="validator_s19_final_go",
+            )
+        ],
+    )
+
+    assert plan.step_id == "S20"
+    assert plan.overlay_step_id == "S20"
+    assert plan.targets == ("refuel_probe_switch",)
+    assert plan.rejected_model_step_id == "S19"
+    assert plan.validator_rejected is True
+    assert plan.repair_applied is True
+    assert plan.final_action_plan_source == "validator_s19_final_go"
+
+
+def test_plan_harness_action_keeps_s19_intermediate_multi_target_guidance() -> None:
+    plan = plan_harness_action(
+        step_specs={"S19": _spec("S19", ("fcs_bit_switch", "right_mdi_pb5"), recovery_kind="visual_confirmation")},
+        inferred_step_id="S19",
+        model_step_id="S19",
+        proposed_overlay_targets=["right_mdi_pb5"],
+        candidate_step_ids=["S19"],
+        runtime_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        request_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        allowed_evidence_refs=["VISION_FACTS.fcsmc_intermediate_result_visible@frame-1"],
+        evidence_refs=["VISION_FACTS.fcsmc_intermediate_result_visible@frame-1"],
+        max_overlay_targets=2,
+        vision_seen_fact_ids=["fcsmc_intermediate_result_visible"],
+        action_hint={"targets": ["fcs_bit_switch", "right_mdi_pb5"]},
+        action_hint_fact_rules=[
+            HarnessActionHintFactRule(step_id="S19", fact_id="fcsmc_intermediate_result_visible")
+        ],
+    )
+
+    assert plan.step_id == "S19"
+    assert plan.targets == ("fcs_bit_switch", "right_mdi_pb5")
+    assert plan.repair_applied is True
+    assert plan.final_action_plan_source == "validator_action_hint"
+
+
+def test_plan_harness_action_uses_single_current_target_for_s20_to_s27() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S26": _spec("S26", ("pitot_heater_switch",)),
+            "S20": _spec("S20", ("refuel_probe_switch",)),
+        },
+        inferred_step_id="S26",
+        model_step_id="S26",
+        proposed_overlay_targets=["refuel_probe_switch"],
+        candidate_step_ids=["S26", "S27"],
+        runtime_overlay_targets=["refuel_probe_switch", "pitot_heater_switch"],
+        request_overlay_targets=["refuel_probe_switch", "pitot_heater_switch"],
+        allowed_evidence_refs=["GATES.S26.completion"],
+        evidence_refs=["GATES.S26.completion"],
+        max_overlay_targets=2,
+        action_hint={"target": "pitot_heater_switch"},
+        action_hint_step_ids=["S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
+    )
+
+    assert plan.targets == ("pitot_heater_switch",)
+    assert plan.validator_rejected is True
+    assert plan.repair_applied is True
+    assert plan.final_action_plan_source == "validator_action_hint"
+
+
+def test_plan_harness_action_returns_text_only_for_unhighlightable_manual_control() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S11": _spec(
+                "S11",
+                ("throttle_quadrant_reference",),
+                overlay_enabled=False,
+                recovery_kind="manual_guidance",
+            )
+        },
+        inferred_step_id="S11",
+        model_step_id="S11",
+        proposed_overlay_targets=["throttle_quadrant_reference"],
+        candidate_step_ids=["S11"],
+        runtime_overlay_targets=["throttle_quadrant_reference"],
+        request_overlay_targets=["throttle_quadrant_reference"],
+        allowed_evidence_refs=["GATES.S11.completion"],
+        evidence_refs=["GATES.S11.completion"],
+        max_overlay_targets=1,
+        text_guidance_rules=[
+            HarnessTextGuidanceRule(
+                step_id="S11",
+                target="throttle_quadrant_reference",
+                guidance="Press Right Alt+Home.",
+            )
+        ],
+    )
+
+    assert plan.text_only is True
+    assert plan.targets == ()
+    assert "Right Alt+Home" in plan.guidance
+    assert plan.validator_rejected is True
+    assert plan.repair_applied is True
+    assert plan.final_action_plan_source == "validator_text_only_guidance"
+
+
+def test_plan_harness_action_does_not_reject_model_step_that_already_advanced_to_completion_next() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S19": _spec("S19", ("fcs_bit_switch", "right_mdi_pb5"), recovery_kind="visual_confirmation"),
+            "S20": _spec("S20", ("refuel_probe_switch",)),
+        },
+        inferred_step_id="S19",
+        model_step_id="S20",
+        proposed_overlay_targets=["refuel_probe_switch"],
+        candidate_step_ids=["S19", "S20"],
+        runtime_overlay_targets=["fcs_bit_switch", "right_mdi_pb5", "refuel_probe_switch"],
+        request_overlay_targets=["fcs_bit_switch", "right_mdi_pb5", "refuel_probe_switch"],
+        allowed_evidence_refs=["VISION_FACTS.fcsmc_final_go_result_visible@frame-1"],
+        evidence_refs=["VISION_FACTS.fcsmc_final_go_result_visible@frame-1"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["fcsmc_final_go_result_visible"],
+        completion_advancements=[
+            HarnessCompletionAdvance(
+                step_id="S19",
+                fact_id="fcsmc_final_go_result_visible",
+                next_step_id="S20",
+                source="validator_s19_final_go",
+            )
+        ],
+    )
+
+    assert plan.step_id == "S20"
+    assert plan.rejected_model_step_id is None
+    assert "model_step_mismatch:S20" not in plan.reasons
+
+
+def test_plan_harness_action_rejects_overlay_for_disabled_spec_even_with_unrelated_target() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S11": _spec(
+                "S11",
+                ("throttle_quadrant_reference",),
+                overlay_enabled=False,
+                recovery_kind="manual_guidance",
+            )
+        },
+        inferred_step_id="S11",
+        model_step_id="S11",
+        proposed_overlay_targets=["battery_switch"],
+        candidate_step_ids=["S11"],
+        runtime_overlay_targets=["battery_switch", "throttle_quadrant_reference"],
+        request_overlay_targets=["battery_switch", "throttle_quadrant_reference"],
+        allowed_evidence_refs=["GATES.S11.completion"],
+        evidence_refs=["GATES.S11.completion"],
+        max_overlay_targets=1,
+    )
+
+    assert plan.targets == ()
+    assert plan.validator_rejected is True
+    assert "target_not_allowed:battery_switch" in plan.reasons

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -4879,6 +4879,153 @@ def test_action_hint_overlay_override_uses_split_s26_pitot_target() -> None:
         loop.close()
 
 
+def test_harness_validation_action_plan_records_s26_repair_metadata() -> None:
+    response = TutorResponse(
+        message="Extend the refuel probe.",
+        explanations=["Extend the refuel probe."],
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "refuel_probe_switch",
+                "element_id": "pnt_341",
+            }
+        ],
+        metadata={
+            "next": {"step_id": "S26"},
+            "diagnosis": {"step_id": "S26", "error_category": "OM"},
+            "help_response": {
+                "diagnosis": {"step_id": "S26", "error_category": "OM"},
+                "next": {"step_id": "S26"},
+                "overlay": {
+                    "targets": ["refuel_probe_switch"],
+                    "evidence": [
+                        {
+                            "target": "refuel_probe_switch",
+                            "type": "gate",
+                            "ref": "GATES.S26.completion",
+                            "quote": "blocked",
+                        }
+                    ],
+                },
+                "explanations": ["Extend the refuel probe."],
+            },
+        },
+    )
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "overlay_target_allowlist": ["refuel_probe_switch", "pitot_heater_switch"],
+            "gates": [
+                {"gate_id": "S26.completion", "status": "blocked"},
+                {"gate_id": "S26.precondition", "status": "allowed"},
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S26",
+                "overlay_step_id": "S26",
+                "requires_visual_confirmation": False,
+                "step_evidence_requirements": ["gate"],
+                "action_hint": {"target": "pitot_heater_switch", "reason": "Turn pitot heat ON."},
+            },
+            "rag_topk": [],
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(Path("/dev/null")),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+        max_overlay_targets=2,
+    )
+    try:
+        request.context["overlay_target_allowlist"] = list(loop.overlay_allowlist)
+
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "deterministic_step:S26"
+        assert response.actions[0]["target"] == "pitot_heater_switch"
+        assert response.metadata["validator_rejected"] is True
+        assert response.metadata["repair_applied"] is True
+        assert response.metadata["final_action_plan_source"] == "validator_action_hint"
+        assert response.metadata["harness_validator_fallback_reason"] == "deterministic_step:S26"
+    finally:
+        loop.close()
+
+
+def test_harness_validation_action_plan_rewrites_manual_throttle_to_text_only() -> None:
+    response = TutorResponse(
+        message="Highlight throttle.",
+        explanations=["Highlight throttle."],
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "throttle_quadrant_reference",
+                "element_id": "pnt_throttle",
+            }
+        ],
+        metadata={
+            "next": {"step_id": "S11"},
+            "diagnosis": {"step_id": "S11", "error_category": "OM"},
+            "help_response": {
+                "diagnosis": {"step_id": "S11", "error_category": "OM"},
+                "next": {"step_id": "S11"},
+                "overlay": {
+                    "targets": ["throttle_quadrant_reference"],
+                    "evidence": [
+                        {
+                            "target": "throttle_quadrant_reference",
+                            "type": "gate",
+                            "ref": "GATES.S11.completion",
+                            "quote": "blocked",
+                        }
+                    ],
+                },
+                "explanations": ["Highlight throttle."],
+            },
+        },
+    )
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "overlay_target_allowlist": ["throttle_quadrant_reference"],
+            "gates": [{"gate_id": "S11.completion", "status": "blocked"}],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S11",
+                "overlay_step_id": "S11",
+                "missing_conditions": ["vars.throttle_l_idle_complete==true"],
+            },
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(Path("/dev/null")),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+    )
+    try:
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "manual_throttle_keyboard_guidance"
+        assert response.actions == []
+        assert "Right Alt+Home" in response.message
+        assert response.metadata["validator_rejected"] is True
+        assert response.metadata["repair_applied"] is True
+        assert response.metadata["final_action_plan_source"] == "validator_text_only_guidance"
+    finally:
+        loop.close()
+
+
 def test_resolve_overlay_step_id_does_not_advance_partial_visual_hold_steps() -> None:
     assert _resolve_overlay_step_id(
         "S18",


### PR DESCRIPTION
Closes #273

Summary:
- Add core HarnessActionPlan validator/repair/action-planning contract driven by StepHarnessSpec plus adapter-provided policy rules.
- Wire live_dcs through the validator before legacy fallback execution, preserving raw model audit metadata and final action-plan metadata.
- Cover invalid target repair, S19 final GO advancement, S19 intermediate multi-target planning, S20-S27 action hints, and manual throttle text-only guidance.

Validation:
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_harness_decision.py tests/test_step_harness_specs.py tests/test_response_mapping.py tests/test_live_dcs.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Review:
- Subagent review loop completed; final pass reported no blockers.