### PR TITLE
Refactor live help orchestration ports

### DIFF
--- a/core/help_orchestrator.py
+++ b/core/help_orchestrator.py
@@ -1,0 +1,270 @@
+"""
+Application-level help-cycle orchestration ports.
+
+The concrete live DCS loop wires these ports to adapters. Tests can wire fake
+ports, which keeps harness orchestration verifiable without DCS, model servers,
+or overlay transport.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Protocol, Sequence
+from uuid import uuid4
+
+from core.types import Observation, TutorRequest, TutorResponse
+
+
+@dataclass(frozen=True)
+class HelpCycleRequestBundle:
+    request: TutorRequest
+    prompt_metadata: Mapping[str, Any] = field(default_factory=dict)
+    state_key: str | None = None
+
+
+@dataclass(frozen=True)
+class HelpCycleDecisionResult:
+    response: TutorResponse
+    fallback_overlay_used: bool = False
+    fallback_overlay_reason: str = "not_needed"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HelpCycleRunResult:
+    observation: Observation
+    request: TutorRequest
+    response: TutorResponse
+    action_report: Mapping[str, Any]
+    vision_context: Mapping[str, Any]
+    active_step_ids: tuple[str, ...]
+    prompt_metadata: Mapping[str, Any]
+    state_key: str | None
+    help_cycle_id: str
+
+
+@dataclass(frozen=True)
+class PreparedHelpCycle:
+    observation: Observation
+    request: TutorRequest
+    prompt_metadata: Mapping[str, Any] = field(default_factory=dict)
+    state_key: str | None = None
+    vision_context: Mapping[str, Any] = field(default_factory=dict)
+    active_step_ids: Sequence[str] = ()
+    help_cycle_id: str | None = None
+
+
+class TelemetryEvidenceInputPort(Protocol):
+    def current_observation(self) -> Observation | None:
+        ...
+
+
+class VisionFactExtractionPort(Protocol):
+    def active_step_ids(self, observation: Observation) -> Sequence[str]:
+        ...
+
+    def extract(
+        self,
+        observation: Observation,
+        *,
+        help_cycle_id: str,
+        active_step_ids: Sequence[str],
+    ) -> Mapping[str, Any]:
+        ...
+
+
+class CandidateGenerationPort(Protocol):
+    def build_request(
+        self,
+        observation: Observation,
+        *,
+        vision_context: Mapping[str, Any],
+        help_cycle_id: str,
+    ) -> HelpCycleRequestBundle:
+        ...
+
+
+class LlmAdjudicationPort(Protocol):
+    def adjudicate(self, observation: Observation, request: TutorRequest) -> TutorResponse:
+        ...
+
+
+class DecisionValidationRepairPort(Protocol):
+    def validate_and_repair(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> HelpCycleDecisionResult:
+        ...
+
+
+class ActionPlanningPort(Protocol):
+    def execute(self, actions: Sequence[Mapping[str, Any] | Any]) -> Mapping[str, Any]:
+        ...
+
+
+class TraceAuditSinkPort(Protocol):
+    def record(self, stage: str, payload: Mapping[str, Any]) -> None:
+        ...
+
+
+class NoopTraceAuditSink:
+    def record(self, stage: str, payload: Mapping[str, Any]) -> None:
+        return None
+
+
+def _string_tuple(raw: Sequence[str] | None) -> tuple[str, ...]:
+    if not isinstance(raw, (list, tuple, set)):
+        return ()
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, str) or not item or item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return tuple(out)
+
+
+def _request_id(request: TutorRequest) -> str | None:
+    request_id = getattr(request, "request_id", None)
+    return request_id if isinstance(request_id, str) and request_id else None
+
+
+class HelpCycleOrchestrator:
+    def __init__(
+        self,
+        *,
+        telemetry: TelemetryEvidenceInputPort | None = None,
+        vision: VisionFactExtractionPort | None = None,
+        candidates: CandidateGenerationPort | None = None,
+        llm: LlmAdjudicationPort,
+        validator: DecisionValidationRepairPort,
+        actions: ActionPlanningPort,
+        audit: TraceAuditSinkPort | None = None,
+        id_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self.telemetry = telemetry
+        self.vision = vision
+        self.candidates = candidates
+        self.llm = llm
+        self.validator = validator
+        self.actions = actions
+        self.audit = audit if audit is not None else NoopTraceAuditSink()
+        self.id_factory = id_factory if id_factory is not None else lambda: str(uuid4())
+
+    def run(self) -> HelpCycleRunResult | None:
+        if self.telemetry is None or self.vision is None or self.candidates is None:
+            raise ValueError("telemetry, vision, and candidates ports are required for run()")
+
+        observation = self.telemetry.current_observation()
+        if observation is None:
+            return None
+
+        help_cycle_id = self.id_factory()
+        self.audit.record("telemetry", {"observation_id": observation.observation_id})
+
+        active_step_ids = _string_tuple(self.vision.active_step_ids(observation))
+        vision_context = self.vision.extract(
+            observation,
+            help_cycle_id=help_cycle_id,
+            active_step_ids=active_step_ids,
+        )
+        self.audit.record(
+            "vision",
+            {
+                "help_cycle_id": help_cycle_id,
+                "active_step_ids": list(active_step_ids),
+                "status": vision_context.get("status"),
+            },
+        )
+
+        bundle = self.candidates.build_request(
+            observation,
+            vision_context=vision_context,
+            help_cycle_id=help_cycle_id,
+        )
+        self.audit.record(
+            "request",
+            {
+                "help_cycle_id": help_cycle_id,
+                "request_id": _request_id(bundle.request),
+                "state_key": bundle.state_key,
+            },
+        )
+        return self.run_prepared(
+            PreparedHelpCycle(
+                observation=observation,
+                request=bundle.request,
+                prompt_metadata=bundle.prompt_metadata,
+                state_key=bundle.state_key,
+                vision_context=vision_context,
+                active_step_ids=active_step_ids,
+                help_cycle_id=help_cycle_id,
+            )
+        )
+
+    def run_prepared(self, prepared: PreparedHelpCycle) -> HelpCycleRunResult:
+        help_cycle_id = prepared.help_cycle_id or _request_id(prepared.request) or self.id_factory()
+        response = self.llm.adjudicate(prepared.observation, prepared.request)
+        self.audit.record(
+            "llm_adjudication",
+            {
+                "help_cycle_id": help_cycle_id,
+                "request_id": _request_id(prepared.request),
+                "status": response.status,
+            },
+        )
+
+        decision = self.validator.validate_and_repair(response, prepared.request)
+        decision.response.metadata = dict(decision.response.metadata)
+        decision.response.metadata["fallback_overlay_used"] = bool(decision.fallback_overlay_used)
+        decision.response.metadata["fallback_overlay_reason"] = decision.fallback_overlay_reason
+        for key, value in decision.metadata.items():
+            if isinstance(key, str) and key:
+                decision.response.metadata[key] = value
+        self.audit.record(
+            "decision_validation",
+            {
+                "help_cycle_id": help_cycle_id,
+                "fallback_overlay_used": decision.fallback_overlay_used,
+                "fallback_overlay_reason": decision.fallback_overlay_reason,
+            },
+        )
+
+        action_report = self.actions.execute(decision.response.actions)
+        self.audit.record(
+            "action_planning",
+            {
+                "help_cycle_id": help_cycle_id,
+                "action_count": len(decision.response.actions),
+            },
+        )
+
+        return HelpCycleRunResult(
+            observation=prepared.observation,
+            request=prepared.request,
+            response=decision.response,
+            action_report=action_report,
+            vision_context=dict(prepared.vision_context),
+            active_step_ids=_string_tuple(prepared.active_step_ids),
+            prompt_metadata=dict(prepared.prompt_metadata),
+            state_key=prepared.state_key,
+            help_cycle_id=help_cycle_id,
+        )
+
+
+__all__ = [
+    "ActionPlanningPort",
+    "CandidateGenerationPort",
+    "DecisionValidationRepairPort",
+    "HelpCycleDecisionResult",
+    "HelpCycleOrchestrator",
+    "HelpCycleRequestBundle",
+    "HelpCycleRunResult",
+    "LlmAdjudicationPort",
+    "PreparedHelpCycle",
+    "TelemetryEvidenceInputPort",
+    "TraceAuditSinkPort",
+    "VisionFactExtractionPort",
+]

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -89,6 +89,11 @@ from core.harness_validation import (
     HarnessTextGuidanceRule,
     plan_harness_action,
 )
+from core.help_orchestrator import (
+    HelpCycleDecisionResult,
+    HelpCycleOrchestrator,
+    PreparedHelpCycle,
+)
 from core.security import (
     redact_sensitive_text,
     sanitize_help_response_for_log,
@@ -385,6 +390,59 @@ class ActionExecutorLike(Protocol):
 
     def close(self) -> None:
         ...
+
+
+@dataclass
+class _StaticHelpAdjudicator:
+    response: TutorResponse
+
+    def adjudicate(self, observation: Observation, request: TutorRequest) -> TutorResponse:
+        return self.response
+
+
+@dataclass
+class _StaticDecisionValidator:
+    fallback_overlay_used: bool
+    fallback_overlay_reason: str
+
+    def validate_and_repair(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> HelpCycleDecisionResult:
+        return HelpCycleDecisionResult(
+            response=response,
+            fallback_overlay_used=self.fallback_overlay_used,
+            fallback_overlay_reason=self.fallback_overlay_reason,
+        )
+
+
+@dataclass
+class _CallableHelpAdjudicator:
+    adjudicate_response: Callable[[Observation, TutorRequest], TutorResponse]
+
+    def adjudicate(self, observation: Observation, request: TutorRequest) -> TutorResponse:
+        return self.adjudicate_response(observation, request)
+
+
+@dataclass
+class _CallableDecisionValidator:
+    validate_response: Callable[[TutorResponse, TutorRequest], HelpCycleDecisionResult]
+
+    def validate_and_repair(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> HelpCycleDecisionResult:
+        return self.validate_response(response, request)
+
+
+@dataclass
+class _CallableActionPlanner:
+    execute_actions: Callable[[Sequence[Mapping[str, Any] | Any]], Mapping[str, Any]]
+
+    def execute(self, actions: Sequence[Mapping[str, Any] | Any]) -> Mapping[str, Any]:
+        return self.execute_actions(actions)
 
 
 class TutorTextSenderLike(Protocol):
@@ -5612,6 +5670,212 @@ class LiveDcsTutorLoop:
         overlay_raw_report = self.action_executor.execute_actions(actions)
         return _normalize_help_report(overlay_raw_report)
 
+    def _adjudicate_live_help_response(
+        self,
+        obs: Observation,
+        request: TutorRequest,
+        *,
+        terminal_state_short_circuited: bool,
+        inferred_step_id: str | None,
+        fallback_conditions: Sequence[str],
+    ) -> TutorResponse:
+        if terminal_state_short_circuited:
+            return self._build_terminal_state_response(request)
+        self._stats.model_calls += 1
+        try:
+            return self.model.explain_error(obs, request)
+        except Exception as exc:
+            return TutorResponse(
+                status="error",
+                in_reply_to=request.request_id,
+                message=self._fallback_message(inferred_step_id, fallback_conditions),
+                actions=[],
+                metadata={
+                    "provider": "fallback",
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                },
+            )
+
+    def _validate_and_repair_live_help_response(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+        *,
+        prompt_meta: Mapping[str, Any],
+        state_key: str,
+        help_cycle_id: str,
+        vision_selection: HelpCycleVisionSelection,
+        vision_fact_context: Mapping[str, Any],
+        vision_fact_active_step_ids: Sequence[str],
+        terminal_state_short_circuited: bool,
+    ) -> HelpCycleDecisionResult:
+        response.metadata = dict(response.metadata)
+        response.metadata.setdefault("provider", "fallback" if response.status == "error" else "unknown")
+        response.metadata["prompt_hash"] = request.metadata.get("prompt_hash")
+        response.metadata["prompt_tokens_est"] = request.metadata.get("prompt_tokens_est")
+        response.metadata["prompt_trimmed"] = request.metadata.get("prompt_trimmed")
+        response.metadata.setdefault("generation_prompt_hash", response.metadata.get("prompt_hash"))
+        response.metadata.setdefault(
+            "generation_prompt_tokens_est",
+            response.metadata.get("prompt_tokens_est"),
+        )
+        response.metadata.setdefault(
+            "generation_prompt_trimmed",
+            response.metadata.get("prompt_trimmed"),
+        )
+        response.metadata["request_prompt_hash"] = request.metadata.get("prompt_hash")
+        response.metadata["request_prompt_tokens_est"] = request.metadata.get("prompt_tokens_est")
+        response.metadata["request_prompt_trimmed"] = request.metadata.get("prompt_trimmed")
+        response.metadata["state_key"] = state_key
+        response.metadata["prompt_build"] = dict(prompt_meta)
+        response.metadata["help_cycle_id"] = help_cycle_id
+        response.metadata["vision"] = vision_selection.to_dict()
+        response.metadata["vision_status"] = vision_selection.status
+        response.metadata["vision_frame_ids"] = list(vision_selection.frame_ids)
+        response.metadata["vision_fact_status"] = vision_fact_context["status"]
+        response.metadata["vision_fact_active_step_ids"] = list(vision_fact_active_step_ids)
+        response.metadata["vision_fact_summary"] = dict(vision_fact_context["vision_fact_summary"])
+        response.metadata["vision_facts"] = list(vision_fact_context["vision_facts"])
+        response.metadata["generation_mode"] = _normalize_generation_mode(response)
+
+        mapped_actions, mapped_meta = self._map_response_actions(response, request)
+        response.actions = mapped_actions
+        if mapped_meta:
+            response.metadata["response_mapping"] = mapped_meta
+        self._normalize_observable_text_only_response(response, request)
+        self._rewrite_low_confidence_bootstrap_response(response, request)
+        self._rewrite_conflicting_step_completion_response(response, request)
+        self._rewrite_terminal_state_conflict_response(response, request)
+        self._rewrite_procedural_guidance_response(response, request)
+
+        fallback_overlay_used = False
+        fallback_overlay_reason = "all_steps_complete" if terminal_state_short_circuited else "not_needed"
+        harness_validation_used, harness_validation_reason = self._apply_harness_validation_action_plan(
+            response,
+            request,
+        )
+        if harness_validation_used:
+            fallback_overlay_used = bool(response.actions)
+            fallback_overlay_reason = harness_validation_reason
+        harness_guardrail_used, harness_guardrail_reason = self._apply_harness_conflict_guardrail(
+            response,
+            request,
+        )
+        if harness_guardrail_used:
+            fallback_overlay_used = True
+            fallback_overlay_reason = harness_guardrail_reason
+        s08_visual_override_used, s08_visual_override_reason = self._apply_s08_visual_recovery_overlay_override(
+            response,
+            request,
+        )
+        if s08_visual_override_used:
+            fallback_overlay_used = True
+            fallback_overlay_reason = s08_visual_override_reason
+        action_hint_override_used, action_hint_override_reason = self._apply_action_hint_overlay_override(
+            response,
+            request,
+        )
+        if action_hint_override_used:
+            fallback_overlay_used = True
+            fallback_overlay_reason = action_hint_override_reason
+        should_apply_safe_fallback = self._should_use_deterministic_overlay_fallback(
+            response,
+            request,
+            mapped_meta,
+        )
+        if should_apply_safe_fallback and not action_hint_override_used and not harness_validation_used:
+            fallback_overlay_used, fallback_overlay_reason = self._apply_safe_fallback_overlay(
+                response,
+                request,
+            )
+        manual_throttle_rewritten, manual_throttle_reason = self._rewrite_manual_throttle_guidance_response(
+            response,
+            request,
+        )
+        if manual_throttle_rewritten:
+            fallback_overlay_used = False
+            fallback_overlay_reason = manual_throttle_reason
+
+        if mapped_meta:
+            mapping_failure_codes = classify_mapping_failure(mapped_meta)
+            if mapping_failure_codes:
+                response.metadata["response_mapping_failure_codes"] = list(mapping_failure_codes)
+                response.metadata["response_mapping_failure_code"] = mapping_failure_codes[0]
+                response.metadata.setdefault("response_mapping_failure_stage", "response_mapping")
+                if not fallback_overlay_used:
+                    response.metadata = merge_failure_metadata(
+                        response.metadata,
+                        *mapping_failure_codes,
+                        stage="response_mapping",
+                    )
+
+        response.metadata["fallback_overlay_used"] = fallback_overlay_used
+        response.metadata["fallback_overlay_reason"] = fallback_overlay_reason
+        self._annotate_response_audit_metadata(response)
+        _normalize_cached_response_metadata(response.metadata)
+        response_audit_fields = _build_help_cycle_audit_fields(
+            request=request,
+            vision_selection=vision_selection,
+            vision_fact_context=vision_fact_context,
+            response_metadata=response.metadata,
+        )
+        _apply_help_cycle_audit_fields(response.metadata, response_audit_fields)
+        if isinstance(response_audit_fields.get("vision_fallback_reason"), str):
+            response.metadata = merge_failure_metadata(
+                response.metadata,
+                response_audit_fields["vision_fallback_reason"],
+                stage="vision",
+            )
+        trace_metadata = {
+            "help_cycle_id": help_cycle_id,
+            "generation_mode": response.metadata["generation_mode"],
+            **response_audit_fields,
+        }
+        response.actions = _attach_help_cycle_trace_to_actions(
+            response.actions,
+            trace_metadata=trace_metadata,
+        )
+        return HelpCycleDecisionResult(
+            response=response,
+            fallback_overlay_used=fallback_overlay_used,
+            fallback_overlay_reason=fallback_overlay_reason,
+        )
+
+    def _execute_final_action_plan_via_orchestrator(
+        self,
+        *,
+        obs: Observation,
+        request: TutorRequest,
+        response: TutorResponse,
+        prompt_meta: Mapping[str, Any],
+        state_key: str,
+        vision_fact_context: Mapping[str, Any],
+        vision_fact_active_step_ids: Sequence[str],
+        help_cycle_id: str,
+        fallback_overlay_used: bool,
+        fallback_overlay_reason: str,
+    ) -> tuple[TutorResponse, dict[str, Any]]:
+        result = HelpCycleOrchestrator(
+            llm=_StaticHelpAdjudicator(response),
+            validator=_StaticDecisionValidator(
+                fallback_overlay_used=fallback_overlay_used,
+                fallback_overlay_reason=fallback_overlay_reason,
+            ),
+            actions=_CallableActionPlanner(self._execute_or_dry_run_actions),
+        ).run_prepared(
+            PreparedHelpCycle(
+                observation=obs,
+                request=request,
+                prompt_metadata=prompt_meta,
+                state_key=state_key,
+                vision_context=vision_fact_context,
+                active_step_ids=vision_fact_active_step_ids,
+                help_cycle_id=help_cycle_id,
+            )
+        )
+        return result.response, _normalize_help_report(result.action_report)
+
     def _send_tutor_text(self, response: TutorResponse) -> None:
         if self.tutor_text_sender is None:
             response.metadata["dcs_tutor_text"] = {
@@ -5770,7 +6034,21 @@ class LiveDcsTutorLoop:
                 response.actions,
                 trace_metadata=trace_metadata,
             )
-            overlay_report = self._execute_or_dry_run_actions(response.actions)
+            cached_fallback_reason = response.metadata.get("fallback_overlay_reason")
+            response, overlay_report = self._execute_final_action_plan_via_orchestrator(
+                obs=obs,
+                request=request,
+                response=response,
+                prompt_meta=prompt_meta,
+                state_key=state_key,
+                vision_fact_context=vision_fact_context,
+                vision_fact_active_step_ids=vision_fact_active_step_ids,
+                help_cycle_id=help_cycle_id,
+                fallback_overlay_used=bool(response.metadata.get("fallback_overlay_used")),
+                fallback_overlay_reason=(
+                    cached_fallback_reason if isinstance(cached_fallback_reason, str) else "not_needed"
+                ),
+            )
         else:
             hint = request.context.get("deterministic_step_hint", {})
             inferred_step_id = hint.get("inferred_step_id") if isinstance(hint, Mapping) else None
@@ -5808,156 +6086,43 @@ class LiveDcsTutorLoop:
             terminal_state_short_circuited = _is_terminal_step_hint_complete(
                 hint if isinstance(hint, Mapping) else None
             )
-            if terminal_state_short_circuited:
-                response = self._build_terminal_state_response(request)
-            else:
-                self._stats.model_calls += 1
-                try:
-                    response = self.model.explain_error(obs, request)
-                except Exception as exc:
-                    response = TutorResponse(
-                        status="error",
-                        in_reply_to=request.request_id,
-                        message=self._fallback_message(
-                            inferred_step_id if isinstance(inferred_step_id, str) else None,
-                            fallback_conditions,
-                        ),
-                        actions=[],
-                        metadata={
-                            "provider": "fallback",
-                            "error_type": type(exc).__name__,
-                            "error": str(exc),
-                        },
+            orchestrated = HelpCycleOrchestrator(
+                llm=_CallableHelpAdjudicator(
+                    lambda observation, tutor_request: self._adjudicate_live_help_response(
+                        observation,
+                        tutor_request,
+                        terminal_state_short_circuited=terminal_state_short_circuited,
+                        inferred_step_id=inferred_step_id if isinstance(inferred_step_id, str) else None,
+                        fallback_conditions=fallback_conditions,
                     )
-
-            response.metadata = dict(response.metadata)
-            response.metadata.setdefault("provider", "fallback" if response.status == "error" else "unknown")
-            response.metadata["prompt_hash"] = request.metadata.get("prompt_hash")
-            response.metadata["prompt_tokens_est"] = request.metadata.get("prompt_tokens_est")
-            response.metadata["prompt_trimmed"] = request.metadata.get("prompt_trimmed")
-            response.metadata.setdefault("generation_prompt_hash", response.metadata.get("prompt_hash"))
-            response.metadata.setdefault(
-                "generation_prompt_tokens_est",
-                response.metadata.get("prompt_tokens_est"),
-            )
-            response.metadata.setdefault(
-                "generation_prompt_trimmed",
-                response.metadata.get("prompt_trimmed"),
-            )
-            response.metadata["request_prompt_hash"] = request.metadata.get("prompt_hash")
-            response.metadata["request_prompt_tokens_est"] = request.metadata.get("prompt_tokens_est")
-            response.metadata["request_prompt_trimmed"] = request.metadata.get("prompt_trimmed")
-            response.metadata["state_key"] = state_key
-            response.metadata["prompt_build"] = dict(prompt_meta)
-            response.metadata["help_cycle_id"] = help_cycle_id
-            response.metadata["vision"] = vision_selection.to_dict()
-            response.metadata["vision_status"] = vision_selection.status
-            response.metadata["vision_frame_ids"] = list(vision_selection.frame_ids)
-            response.metadata["vision_fact_status"] = vision_fact_context["status"]
-            response.metadata["vision_fact_active_step_ids"] = list(vision_fact_active_step_ids)
-            response.metadata["vision_fact_summary"] = dict(vision_fact_context["vision_fact_summary"])
-            response.metadata["vision_facts"] = list(vision_fact_context["vision_facts"])
-            response.metadata["generation_mode"] = _normalize_generation_mode(response)
-
-            mapped_actions, mapped_meta = self._map_response_actions(response, request)
-            response.actions = mapped_actions
-            if mapped_meta:
-                response.metadata["response_mapping"] = mapped_meta
-            self._normalize_observable_text_only_response(response, request)
-            self._rewrite_low_confidence_bootstrap_response(response, request)
-            self._rewrite_conflicting_step_completion_response(response, request)
-            self._rewrite_terminal_state_conflict_response(response, request)
-            self._rewrite_procedural_guidance_response(response, request)
-
-            fallback_overlay_used = False
-            fallback_overlay_reason = "all_steps_complete" if terminal_state_short_circuited else "not_needed"
-            harness_validation_used, harness_validation_reason = self._apply_harness_validation_action_plan(
-                response,
-                request,
-            )
-            if harness_validation_used:
-                fallback_overlay_used = bool(response.actions)
-                fallback_overlay_reason = harness_validation_reason
-            harness_guardrail_used, harness_guardrail_reason = self._apply_harness_conflict_guardrail(
-                response,
-                request,
-            )
-            if harness_guardrail_used:
-                fallback_overlay_used = True
-                fallback_overlay_reason = harness_guardrail_reason
-            s08_visual_override_used, s08_visual_override_reason = self._apply_s08_visual_recovery_overlay_override(
-                response,
-                request,
-            )
-            if s08_visual_override_used:
-                fallback_overlay_used = True
-                fallback_overlay_reason = s08_visual_override_reason
-            action_hint_override_used, action_hint_override_reason = self._apply_action_hint_overlay_override(
-                response,
-                request,
-            )
-            if action_hint_override_used:
-                fallback_overlay_used = True
-                fallback_overlay_reason = action_hint_override_reason
-            should_apply_safe_fallback = self._should_use_deterministic_overlay_fallback(
-                response,
-                request,
-                mapped_meta,
-            )
-            if should_apply_safe_fallback and not action_hint_override_used and not harness_validation_used:
-                fallback_overlay_used, fallback_overlay_reason = self._apply_safe_fallback_overlay(
-                    response,
-                    request,
+                ),
+                validator=_CallableDecisionValidator(
+                    lambda tutor_response, tutor_request: self._validate_and_repair_live_help_response(
+                        tutor_response,
+                        tutor_request,
+                        prompt_meta=prompt_meta,
+                        state_key=state_key,
+                        help_cycle_id=help_cycle_id,
+                        vision_selection=vision_selection,
+                        vision_fact_context=vision_fact_context,
+                        vision_fact_active_step_ids=vision_fact_active_step_ids,
+                        terminal_state_short_circuited=terminal_state_short_circuited,
+                    )
+                ),
+                actions=_CallableActionPlanner(self._execute_or_dry_run_actions),
+            ).run_prepared(
+                PreparedHelpCycle(
+                    observation=obs,
+                    request=request,
+                    prompt_metadata=prompt_meta,
+                    state_key=state_key,
+                    vision_context=vision_fact_context,
+                    active_step_ids=vision_fact_active_step_ids,
+                    help_cycle_id=help_cycle_id,
                 )
-            manual_throttle_rewritten, manual_throttle_reason = self._rewrite_manual_throttle_guidance_response(
-                response,
-                request,
             )
-            if manual_throttle_rewritten:
-                fallback_overlay_used = False
-                fallback_overlay_reason = manual_throttle_reason
-
-            if mapped_meta:
-                mapping_failure_codes = classify_mapping_failure(mapped_meta)
-                if mapping_failure_codes:
-                    response.metadata["response_mapping_failure_codes"] = list(mapping_failure_codes)
-                    response.metadata["response_mapping_failure_code"] = mapping_failure_codes[0]
-                    response.metadata.setdefault("response_mapping_failure_stage", "response_mapping")
-                    if not fallback_overlay_used:
-                        response.metadata = merge_failure_metadata(
-                            response.metadata,
-                            *mapping_failure_codes,
-                            stage="response_mapping",
-                        )
-
-            response.metadata["fallback_overlay_used"] = fallback_overlay_used
-            response.metadata["fallback_overlay_reason"] = fallback_overlay_reason
-            self._annotate_response_audit_metadata(response)
-            _normalize_cached_response_metadata(response.metadata)
-            response_audit_fields = _build_help_cycle_audit_fields(
-                request=request,
-                vision_selection=vision_selection,
-                vision_fact_context=vision_fact_context,
-                response_metadata=response.metadata,
-            )
-            _apply_help_cycle_audit_fields(response.metadata, response_audit_fields)
-            if isinstance(response_audit_fields.get("vision_fallback_reason"), str):
-                response.metadata = merge_failure_metadata(
-                    response.metadata,
-                    response_audit_fields["vision_fallback_reason"],
-                    stage="vision",
-                )
-            trace_metadata = {
-                "help_cycle_id": help_cycle_id,
-                "generation_mode": response.metadata["generation_mode"],
-                **response_audit_fields,
-            }
-            response.actions = _attach_help_cycle_trace_to_actions(
-                response.actions,
-                trace_metadata=trace_metadata,
-            )
-
-            overlay_report = self._execute_or_dry_run_actions(response.actions)
+            response = orchestrated.response
+            overlay_report = _normalize_help_report(orchestrated.action_report)
             provider = response.metadata.get("provider")
             cacheable = response.status == "ok" and provider != "fallback"
             if cacheable:

--- a/tests/test_help_orchestrator.py
+++ b/tests/test_help_orchestrator.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from core.help_orchestrator import (
+    HelpCycleDecisionResult,
+    HelpCycleOrchestrator,
+    HelpCycleRequestBundle,
+)
+from core.types import Observation, TutorRequest, TutorResponse
+
+
+class FakeTelemetryPort:
+    def __init__(self) -> None:
+        self.observation = Observation(
+            observation_id="obs-1",
+            source="fake-telemetry",
+            payload={"vars": {"battery_on": True}},
+        )
+
+    def current_observation(self) -> Observation | None:
+        return self.observation
+
+
+class FakeVisionPort:
+    def __init__(self, active_step_ids: Sequence[str]) -> None:
+        self.active_step_ids_seen: list[tuple[str, ...]] = []
+        self._active_step_ids = tuple(active_step_ids)
+
+    def active_step_ids(self, observation: Observation) -> Sequence[str]:
+        assert observation.observation_id == "obs-1"
+        return self._active_step_ids
+
+    def extract(
+        self,
+        observation: Observation,
+        *,
+        help_cycle_id: str,
+        active_step_ids: Sequence[str],
+    ) -> Mapping[str, Any]:
+        assert help_cycle_id
+        self.active_step_ids_seen.append(tuple(active_step_ids))
+        return {
+            "status": "available",
+            "vision_facts": [{"fact_id": "tac_page_visible", "state": "seen"}],
+            "vision_fact_summary": {
+                "status": "available",
+                "seen_fact_ids": ["tac_page_visible"],
+                "fresh_fact_ids": ["tac_page_visible"],
+            },
+        }
+
+
+class FakeCandidatePort:
+    def __init__(self) -> None:
+        self.vision_context_seen: Mapping[str, Any] | None = None
+
+    def build_request(
+        self,
+        observation: Observation,
+        *,
+        vision_context: Mapping[str, Any],
+        help_cycle_id: str,
+    ) -> HelpCycleRequestBundle:
+        self.vision_context_seen = vision_context
+        request = TutorRequest(
+            request_id=help_cycle_id,
+            actor="learner",
+            intent="help",
+            message="help",
+            observation_ref=observation.observation_id,
+            context={
+                "candidate_steps": [{"step_id": "S08", "source": "visual_anchor"}],
+                "vision_fact_summary": dict(vision_context["vision_fact_summary"]),
+                "deterministic_step_hint": {"inferred_step_id": "S08", "overlay_step_id": "S08"},
+            },
+            metadata={"prompt_hash": "abc"},
+        )
+        return HelpCycleRequestBundle(
+            request=request,
+            prompt_metadata={"prompt_tokens_est": 12},
+            state_key="state-1",
+        )
+
+
+class FakeLlmPort:
+    def __init__(self) -> None:
+        self.requests: list[TutorRequest] = []
+
+    def adjudicate(self, observation: Observation, request: TutorRequest) -> TutorResponse:
+        self.requests.append(request)
+        return TutorResponse(
+            status="ok",
+            in_reply_to=request.request_id,
+            message="Press PB.",
+            actions=[{"type": "overlay", "target": "left_mdi_pb18"}],
+            metadata={"provider": "fake-llm", "help_response": {"next": {"step_id": "S08"}}},
+        )
+
+
+class FakeValidatorPort:
+    def __init__(self) -> None:
+        self.responses_seen: list[TutorResponse] = []
+
+    def validate_and_repair(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> HelpCycleDecisionResult:
+        self.responses_seen.append(response)
+        response.metadata["validator_rejected"] = False
+        response.metadata["final_action_plan_source"] = "model"
+        return HelpCycleDecisionResult(
+            response=response,
+            fallback_overlay_used=False,
+            fallback_overlay_reason="not_needed",
+        )
+
+
+class FakeOverlayPort:
+    def __init__(self) -> None:
+        self.actions_seen: list[Mapping[str, Any]] = []
+
+    def execute(self, actions: Sequence[Mapping[str, Any] | Any]) -> Mapping[str, Any]:
+        self.actions_seen = [dict(action) for action in actions if isinstance(action, Mapping)]
+        return {"executed": list(self.actions_seen)}
+
+
+class FakeAuditSink:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, Mapping[str, Any]]] = []
+
+    def record(self, stage: str, payload: Mapping[str, Any]) -> None:
+        self.records.append((stage, payload))
+
+
+def test_help_cycle_orchestrator_runs_with_fake_ports_only() -> None:
+    telemetry = FakeTelemetryPort()
+    vision = FakeVisionPort(active_step_ids=["S08"])
+    candidates = FakeCandidatePort()
+    llm = FakeLlmPort()
+    validator = FakeValidatorPort()
+    overlay = FakeOverlayPort()
+    audit = FakeAuditSink()
+
+    result = HelpCycleOrchestrator(
+        telemetry=telemetry,
+        vision=vision,
+        candidates=candidates,
+        llm=llm,
+        validator=validator,
+        actions=overlay,
+        audit=audit,
+        id_factory=lambda: "cycle-1",
+    ).run()
+
+    assert result is not None
+    assert result.request.request_id == "cycle-1"
+    assert result.response.metadata["final_action_plan_source"] == "model"
+    assert result.action_report["executed"] == [{"type": "overlay", "target": "left_mdi_pb18"}]
+    assert llm.requests == [result.request]
+    assert validator.responses_seen == [result.response]
+    assert candidates.vision_context_seen is not None
+    assert [stage for stage, _ in audit.records] == [
+        "telemetry",
+        "vision",
+        "request",
+        "llm_adjudication",
+        "decision_validation",
+        "action_planning",
+    ]
+
+
+def test_help_cycle_orchestrator_passes_active_steps_to_vision_port() -> None:
+    vision = FakeVisionPort(active_step_ids=["S08", "S09"])
+
+    result = HelpCycleOrchestrator(
+        telemetry=FakeTelemetryPort(),
+        vision=vision,
+        candidates=FakeCandidatePort(),
+        llm=FakeLlmPort(),
+        validator=FakeValidatorPort(),
+        actions=FakeOverlayPort(),
+        audit=FakeAuditSink(),
+        id_factory=lambda: "cycle-visual",
+    ).run()
+
+    assert result is not None
+    assert vision.active_step_ids_seen == [("S08", "S09")]


### PR DESCRIPTION
## Summary
- add core HelpCycleOrchestrator application ports for telemetry, vision facts, candidate/request generation, LLM adjudication, decision validation/repair, action execution, and audit tracing
- wire live_dcs fresh help cycles through the orchestrator for LLM adjudication, validation/repair, and final action execution while preserving DCS transport/cache/event behavior
- add fake-port orchestrator tests covering telemetry, VLM, LLM, validator, overlay, audit, and active-step VLM gating inputs

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_help_orchestrator.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Fixes #274