### PR TITLE
Add harness replay trace metrics

### DIFF
--- a/core/help_cycle_audit.py
+++ b/core/help_cycle_audit.py
@@ -18,6 +18,10 @@ HELP_CYCLE_AUDIT_FIELDS: tuple[str, ...] = (
     "fused_missing_conditions",
     "vision_fallback_reason",
     "layout_id",
+    "message_category",
+    "vlm_call_status",
+    "vlm_call_reason",
+    "final_overlay_targets",
 )
 
 

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -1657,9 +1657,265 @@ def _attach_help_cycle_trace_to_actions(
         for key, value in normalized_trace.items():
             if key == "help_cycle_id":
                 continue
-            item.setdefault(key, value)
+            item[key] = value
         traced.append(item)
     return traced
+
+
+def _compact_candidate_for_trace(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, Mapping):
+        return None
+    step_id = raw.get("step_id")
+    if not isinstance(step_id, str) or not step_id:
+        return None
+    out: dict[str, Any] = {"step_id": step_id}
+    for key in (
+        "source",
+        "role",
+        "observability",
+        "requires_visual_confirmation",
+        "confidence",
+        "rank",
+    ):
+        if key in raw:
+            out[key] = _copy_event_field(raw.get(key))
+    for key in ("supporting_evidence_refs", "blocking_evidence_refs", "proposed_next_action_target_ids"):
+        value = raw.get(key)
+        if isinstance(value, (list, tuple)):
+            out[key] = [item for item in value if isinstance(item, str) and item][:8]
+    return out
+
+
+def _overlay_targets_from_actions(actions: Sequence[Mapping[str, Any] | Any]) -> list[str]:
+    out: list[str] = []
+    for action in actions:
+        if not isinstance(action, Mapping):
+            continue
+        target = action.get("target")
+        if isinstance(target, str) and target and target not in out:
+            out.append(target)
+    return out
+
+
+def _step_id_from_payload(raw: Any) -> str | None:
+    if not isinstance(raw, Mapping):
+        return None
+    step_id = raw.get("step_id")
+    return step_id if isinstance(step_id, str) and step_id else None
+
+
+def _help_response_overlay_targets(raw: Any) -> list[str]:
+    if not isinstance(raw, Mapping):
+        return []
+    overlay = raw.get("overlay")
+    if not isinstance(overlay, Mapping):
+        return []
+    targets = overlay.get("targets")
+    if not isinstance(targets, (list, tuple)):
+        return []
+    return [item for item in targets if isinstance(item, str) and item]
+
+
+def _help_response_evidence_refs(raw: Any) -> list[str]:
+    if not isinstance(raw, Mapping):
+        return []
+    overlay = raw.get("overlay")
+    if not isinstance(overlay, Mapping):
+        return []
+    evidence = overlay.get("evidence")
+    if not isinstance(evidence, (list, tuple)):
+        return []
+    refs: list[str] = []
+    for item in evidence:
+        if not isinstance(item, Mapping):
+            continue
+        ref = item.get("ref")
+        if isinstance(ref, str) and ref:
+            refs.append(ref)
+    return refs
+
+
+def _help_response_step_id(raw: Any) -> str | None:
+    if not isinstance(raw, Mapping):
+        return None
+    next_step = _step_id_from_payload(raw.get("next"))
+    if next_step is not None:
+        return next_step
+    return _step_id_from_payload(raw.get("diagnosis"))
+
+
+def _message_category_from_response(response: TutorResponse) -> str:
+    metadata = response.metadata if isinstance(response.metadata, Mapping) else {}
+    if metadata.get("terminal_state_rewritten") is True:
+        return "terminal_completed"
+    if metadata.get("manual_throttle_guidance_rewritten") is True:
+        return "manual_text_guidance"
+    if metadata.get("completion_conflict_rewritten") is True:
+        return "completion_conflict_repair"
+    if metadata.get("harness_guardrail_applied") is True:
+        return "harness_guardrail_repair"
+    if metadata.get("validator_rejected") is True or metadata.get("repair_applied") is True:
+        return "harness_validator_repair"
+    if metadata.get("fallback_overlay_used") is True:
+        return "fallback_overlay"
+    generation_mode = metadata.get("generation_mode")
+    if generation_mode == "repair":
+        return "llm_repair"
+    if generation_mode == "fallback" or response.status == "error":
+        return "fallback"
+    return "model"
+
+
+def _vlm_call_trace(
+    *,
+    vision_selection: HelpCycleVisionSelection,
+    vision_fact_context: Mapping[str, Any],
+) -> dict[str, Any]:
+    status = vision_fact_context.get("status")
+    metadata = vision_fact_context.get("metadata")
+    extractor_used = bool(metadata.get("extractor_used")) if isinstance(metadata, Mapping) else False
+    reason = metadata.get("reason") if isinstance(metadata, Mapping) else None
+    if not isinstance(reason, str) or not reason:
+        reason = vision_selection.sync_miss_reason if isinstance(vision_selection.sync_miss_reason, str) else None
+
+    if status == VISION_NOT_REQUIRED:
+        call_status = "not_required"
+    elif status == "extractor_failed":
+        call_status = "failed"
+    elif extractor_used:
+        call_status = "called"
+    else:
+        call_status = "skipped"
+
+    return {
+        "status": call_status,
+        "reason": reason,
+        "vision_status": vision_selection.status,
+        "vision_fact_status": status,
+        "extractor_used": extractor_used,
+        "frame_ids": list(vision_selection.frame_ids),
+        "sync_status": vision_selection.sync_status,
+        "sync_delta_ms": vision_selection.sync_delta_ms,
+    }
+
+
+def _build_harness_trace_metadata(
+    *,
+    request: TutorRequest,
+    response: TutorResponse,
+    vision_selection: HelpCycleVisionSelection,
+    vision_fact_context: Mapping[str, Any],
+) -> dict[str, Any]:
+    context = request.context if isinstance(request.context, Mapping) else {}
+    response_metadata = response.metadata if isinstance(response.metadata, Mapping) else {}
+    raw_candidates = context.get("candidate_steps")
+    candidates = [
+        candidate
+        for candidate in (
+            _compact_candidate_for_trace(item)
+            for item in (raw_candidates if isinstance(raw_candidates, list) else [])
+        )
+        if candidate is not None
+    ]
+
+    model_help_response = response_metadata.get("model_raw_help_response")
+    if not isinstance(model_help_response, Mapping):
+        model_help_response = response_metadata.get("help_response")
+    model_step_id = _help_response_step_id(model_help_response)
+    if model_step_id is None:
+        model_step_id = _extract_model_next_step_id(response_metadata)
+
+    final_plan_raw = response_metadata.get("harness_action_plan")
+    final_plan = dict(final_plan_raw) if isinstance(final_plan_raw, Mapping) else {}
+    final_targets = _overlay_targets_from_actions(response.actions)
+    if not final_plan:
+        final_plan = {
+            "step_id": _step_id_from_payload(response_metadata.get("next"))
+            or _step_id_from_payload(response_metadata.get("diagnosis")),
+            "overlay_step_id": None,
+            "targets": list(final_targets),
+            "text_only": not bool(final_targets),
+            "source": response_metadata.get("final_action_plan_source") or response_metadata.get("generation_mode"),
+        }
+    else:
+        final_plan.setdefault("targets", list(final_targets))
+        final_plan.setdefault("source", response_metadata.get("final_action_plan_source"))
+
+    chosen_step_id = final_plan.get("step_id")
+    chosen_candidate = None
+    if isinstance(chosen_step_id, str) and chosen_step_id:
+        chosen_candidate = next((dict(item) for item in candidates if item.get("step_id") == chosen_step_id), None)
+        if chosen_candidate is None:
+            chosen_candidate = {"step_id": chosen_step_id, "source": "final_action_plan"}
+
+    rejected_candidate_ids: list[str] = []
+    rejected_model_step_id = response_metadata.get("rejected_model_step_id")
+    if isinstance(rejected_model_step_id, str) and rejected_model_step_id:
+        rejected_candidate_ids.append(rejected_model_step_id)
+    for reason in response_metadata.get("harness_validation_reasons", []):
+        if not isinstance(reason, str):
+            continue
+        prefix = "model_step_not_candidate:"
+        if reason.startswith(prefix):
+            rejected_candidate_ids.append(reason[len(prefix):])
+    rejected_candidates = [
+        {"step_id": step_id}
+        for step_id in _dedupe_strings(rejected_candidate_ids)
+    ]
+
+    final_source = final_plan.get("source")
+    repair_path = final_source if isinstance(final_source, str) and final_source != "model" else None
+    repair_applied = bool(response_metadata.get("repair_applied"))
+    if repair_path is None and repair_applied:
+        repair_path = "response_repair"
+    if repair_path is None and response_metadata.get("fallback_overlay_used") is True:
+        fallback_reason = response_metadata.get("fallback_overlay_reason")
+        repair_path = fallback_reason if isinstance(fallback_reason, str) and fallback_reason else "fallback_overlay"
+
+    message_category = _message_category_from_response(response)
+    vlm_call = _vlm_call_trace(vision_selection=vision_selection, vision_fact_context=vision_fact_context)
+    trace = {
+        "schema_version": "v1",
+        "evidence_packet_summary": dict(context.get("evidence_packet_summary", {})),
+        "candidates": candidates,
+        "chosen_candidate": chosen_candidate,
+        "rejected_candidates": rejected_candidates,
+        "model_decision": {
+            "step_id": model_step_id,
+            "overlay_targets": _help_response_overlay_targets(model_help_response),
+            "evidence_refs": _help_response_evidence_refs(model_help_response),
+            "status": response.status,
+            "generation_mode": response_metadata.get("generation_mode"),
+        },
+        "validator_result": {
+            "rejected": bool(response_metadata.get("validator_rejected")),
+            "reasons": list(response_metadata.get("harness_validation_reasons", []))
+            if isinstance(response_metadata.get("harness_validation_reasons"), list)
+            else [],
+            "rejected_model_step_id": rejected_model_step_id if isinstance(rejected_model_step_id, str) else None,
+            "fallback_overlay_used": bool(response_metadata.get("fallback_overlay_used")),
+            "fallback_overlay_reason": response_metadata.get("fallback_overlay_reason"),
+        },
+        "repair_result": {
+            "applied": repair_applied or repair_path is not None or response_metadata.get("generation_mode") == "repair",
+            "path": repair_path,
+            "json_repaired": bool(response_metadata.get("json_repaired")),
+            "evidence_ref_repair": dict(response_metadata.get("evidence_ref_repair", {}))
+            if isinstance(response_metadata.get("evidence_ref_repair"), Mapping)
+            else {},
+        },
+        "final_action_plan": final_plan,
+        "final_overlay_targets": final_targets,
+        "message_category": message_category,
+        "vlm_call": vlm_call,
+    }
+    response.metadata["message_category"] = message_category
+    response.metadata["vlm_call_status"] = vlm_call["status"]
+    response.metadata["vlm_call_reason"] = vlm_call["reason"]
+    response.metadata["final_overlay_targets"] = list(final_targets)
+    response.metadata["final_action_plan"] = dict(final_plan)
+    response.metadata["harness_trace"] = trace
+    return trace
 
 
 def _dedupe_strings(items: Iterable[str]) -> list[str]:
@@ -3774,23 +4030,27 @@ class LiveDcsTutorLoop:
             },
         )
 
-    def _annotate_response_audit_metadata(self, response: TutorResponse) -> None:
+    def _capture_model_raw_help_response(self, response: TutorResponse) -> None:
         metadata = response.metadata if isinstance(response.metadata, Mapping) else {}
         raw_help_response = metadata.get("help_response")
-        if isinstance(raw_help_response, Mapping):
-            response.metadata.setdefault("model_raw_help_response", copy.deepcopy(dict(raw_help_response)))
-            raw_explanations = raw_help_response.get("explanations")
-            if isinstance(raw_explanations, list):
-                response.metadata.setdefault(
-                    "model_raw_explanations",
-                    [item for item in raw_explanations if isinstance(item, str)],
-                )
-            raw_next = raw_help_response.get("next")
-            if isinstance(raw_next, Mapping):
-                response.metadata.setdefault("model_raw_next", dict(raw_next))
-            raw_diagnosis = raw_help_response.get("diagnosis")
-            if isinstance(raw_diagnosis, Mapping):
-                response.metadata.setdefault("model_raw_diagnosis", dict(raw_diagnosis))
+        if not isinstance(raw_help_response, Mapping):
+            return
+        response.metadata.setdefault("model_raw_help_response", copy.deepcopy(dict(raw_help_response)))
+        raw_explanations = raw_help_response.get("explanations")
+        if isinstance(raw_explanations, list):
+            response.metadata.setdefault(
+                "model_raw_explanations",
+                [item for item in raw_explanations if isinstance(item, str)],
+            )
+        raw_next = raw_help_response.get("next")
+        if isinstance(raw_next, Mapping):
+            response.metadata.setdefault("model_raw_next", dict(raw_next))
+        raw_diagnosis = raw_help_response.get("diagnosis")
+        if isinstance(raw_diagnosis, Mapping):
+            response.metadata.setdefault("model_raw_diagnosis", dict(raw_diagnosis))
+
+    def _annotate_response_audit_metadata(self, response: TutorResponse) -> None:
+        self._capture_model_raw_help_response(response)
 
         final_public_response: dict[str, Any] = {
             "message": response.message,
@@ -5738,6 +5998,7 @@ class LiveDcsTutorLoop:
         response.metadata["vision_fact_summary"] = dict(vision_fact_context["vision_fact_summary"])
         response.metadata["vision_facts"] = list(vision_fact_context["vision_facts"])
         response.metadata["generation_mode"] = _normalize_generation_mode(response)
+        self._capture_model_raw_help_response(response)
 
         mapped_actions, mapped_meta = self._map_response_actions(response, request)
         response.actions = mapped_actions
@@ -5814,6 +6075,12 @@ class LiveDcsTutorLoop:
         response.metadata["fallback_overlay_reason"] = fallback_overlay_reason
         self._annotate_response_audit_metadata(response)
         _normalize_cached_response_metadata(response.metadata)
+        _build_harness_trace_metadata(
+            request=request,
+            response=response,
+            vision_selection=vision_selection,
+            vision_fact_context=vision_fact_context,
+        )
         response_audit_fields = _build_help_cycle_audit_fields(
             request=request,
             vision_selection=vision_selection,
@@ -5830,7 +6097,7 @@ class LiveDcsTutorLoop:
         trace_metadata = {
             "help_cycle_id": help_cycle_id,
             "generation_mode": response.metadata["generation_mode"],
-            **response_audit_fields,
+            **normalize_help_cycle_audit_fields(response.metadata),
         }
         response.actions = _attach_help_cycle_trace_to_actions(
             response.actions,
@@ -6025,10 +6292,16 @@ class LiveDcsTutorLoop:
                     response_audit_fields["vision_fallback_reason"],
                     stage="vision",
                 )
+            _build_harness_trace_metadata(
+                request=request,
+                response=response,
+                vision_selection=vision_selection,
+                vision_fact_context=vision_fact_context,
+            )
             trace_metadata = {
                 "help_cycle_id": help_cycle_id,
                 "generation_mode": response.metadata["generation_mode"],
-                **response_audit_fields,
+                **normalize_help_cycle_audit_fields(response.metadata),
             }
             response.actions = _attach_help_cycle_trace_to_actions(
                 response.actions,

--- a/simtutor/replay_eval.py
+++ b/simtutor/replay_eval.py
@@ -117,6 +117,8 @@ class ReplayEvalExpectation:
     sync_status: str | None
     sync_delta_ms: int | None
     frame_ids: tuple[str, ...]
+    message_category: str | None = None
+    repair_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -380,6 +382,16 @@ def load_replay_eval_suite(path: str | Path) -> ReplayEvalSuite:
             ),
             sync_delta_ms=_ensure_optional_int(expected.get("sync_delta_ms"), field_name=f"{case_id}.expected.sync_delta_ms"),
             frame_ids=_normalize_string_list(expected.get("frame_ids"), field_name=f"{case_id}.expected.frame_ids"),
+            message_category=(
+                _ensure_text(expected.get("message_category"), field_name=f"{case_id}.expected.message_category")
+                if expected.get("message_category") is not None
+                else None
+            ),
+            repair_path=(
+                _ensure_text(expected.get("repair_path"), field_name=f"{case_id}.expected.repair_path")
+                if expected.get("repair_path") is not None
+                else None
+            ),
         )
 
         vision = item.get("vision")
@@ -480,6 +492,9 @@ def _extract_case_outcome(events: Sequence[Mapping[str, Any]], *, case: ReplayEv
     help_response = response_meta.get("help_response")
     if not isinstance(help_response, Mapping):
         help_response = {}
+    harness_trace = response_meta.get("harness_trace")
+    if not isinstance(harness_trace, Mapping):
+        harness_trace = {}
 
     diagnosis = response_meta.get("diagnosis")
     if not isinstance(diagnosis, Mapping):
@@ -505,6 +520,16 @@ def _extract_case_outcome(events: Sequence[Mapping[str, Any]], *, case: ReplayEv
 
     diagnosis_step_id = _extract_optional_text(diagnosis.get("step_id"))
     next_step_id = _extract_optional_text(next_step.get("step_id"))
+    repair_result = harness_trace.get("repair_result")
+    if not isinstance(repair_result, Mapping):
+        repair_result = {}
+    vlm_call = harness_trace.get("vlm_call")
+    if not isinstance(vlm_call, Mapping):
+        vlm_call = {}
+    message_category = _extract_optional_text(response_meta.get("message_category"))
+    if message_category is None:
+        message_category = _extract_optional_text(harness_trace.get("message_category"))
+    repair_path = _extract_optional_text(repair_result.get("path"))
 
     actual = {
         "step_id": diagnosis_step_id or next_step_id,
@@ -521,6 +546,11 @@ def _extract_case_outcome(events: Sequence[Mapping[str, Any]], *, case: ReplayEv
         else (),
         "generation_mode": response_meta.get("generation_mode"),
         "multimodal_fallback_to_text": _extract_optional_bool(response_meta.get("multimodal_fallback_to_text")),
+        "message_category": message_category,
+        "repair_path": repair_path,
+        "harness_trace_present": bool(harness_trace),
+        "vlm_call_status": _extract_optional_text(vlm_call.get("status")),
+        "vlm_call_reason": _extract_optional_text(vlm_call.get("reason")),
     }
     checks = {
         "step_match": actual["step_id"] == case.expectation.step_id,
@@ -532,6 +562,16 @@ def _extract_case_outcome(events: Sequence[Mapping[str, Any]], *, case: ReplayEv
         "sync_status_match": actual["sync_status"] == case.expectation.sync_status,
         "sync_delta_ms_match": actual["sync_delta_ms"] == case.expectation.sync_delta_ms,
         "frame_ids_match": tuple(actual["frame_ids"]) == tuple(case.expectation.frame_ids),
+        "message_category_match": (
+            True
+            if case.expectation.message_category is None
+            else actual["message_category"] == case.expectation.message_category
+        ),
+        "repair_path_match": (
+            True
+            if case.expectation.repair_path is None
+            else actual["repair_path"] == case.expectation.repair_path
+        ),
     }
     fallback_used = bool(
         actual["generation_mode"] == "fallback" or actual["multimodal_fallback_to_text"] is True
@@ -546,6 +586,8 @@ def _extract_case_outcome(events: Sequence[Mapping[str, Any]], *, case: ReplayEv
             "sync_status": case.expectation.sync_status,
             "sync_delta_ms": case.expectation.sync_delta_ms,
             "frame_ids": list(case.expectation.frame_ids),
+            "message_category": case.expectation.message_category,
+            "repair_path": case.expectation.repair_path,
         },
         "actual": {
             "step_id": actual["step_id"],
@@ -557,6 +599,11 @@ def _extract_case_outcome(events: Sequence[Mapping[str, Any]], *, case: ReplayEv
             "frame_ids": list(actual["frame_ids"]),
             "generation_mode": actual["generation_mode"],
             "multimodal_fallback_to_text": actual["multimodal_fallback_to_text"],
+            "message_category": actual["message_category"],
+            "repair_path": actual["repair_path"],
+            "harness_trace_present": actual["harness_trace_present"],
+            "vlm_call_status": actual["vlm_call_status"],
+            "vlm_call_reason": actual["vlm_call_reason"],
         },
         "checks": checks,
         "vision_sidecar_configured": case.vision is not None,
@@ -579,6 +626,11 @@ def _build_summary(case_results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
             "fallback_rate": 0.0,
             "vision_unavailable_rate": 0.0,
             "sync_failure_rate": 0.0,
+            "message_category_accuracy": 0.0,
+            "repair_path_accuracy": 0.0,
+            "harness_trace_coverage": 0.0,
+            "message_category_evaluated_count": 0,
+            "repair_path_evaluated_count": 0,
         }
 
     def _count(check: Callable[[Mapping[str, Any]], bool]) -> int:
@@ -591,6 +643,21 @@ def _build_summary(case_results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     fallback_count = _count(lambda item: bool(item.get("fallback_used")))
     vision_unavailable_count = _count(lambda item: bool(item.get("vision_unavailable")))
     sync_failure_count = _count(lambda item: bool(item.get("sync_failed")))
+    message_category_evaluated = _count(
+        lambda item: item.get("expected", {}).get("message_category") is not None
+    )
+    repair_path_evaluated = _count(
+        lambda item: item.get("expected", {}).get("repair_path") is not None
+    )
+    message_category_hits = _count(
+        lambda item: item.get("expected", {}).get("message_category") is not None
+        and bool(item.get("checks", {}).get("message_category_match"))
+    )
+    repair_path_hits = _count(
+        lambda item: item.get("expected", {}).get("repair_path") is not None
+        and bool(item.get("checks", {}).get("repair_path_match"))
+    )
+    harness_trace_count = _count(lambda item: bool(item.get("actual", {}).get("harness_trace_present")))
     return {
         "case_count": total,
         "passed_case_count": passed,
@@ -600,6 +667,19 @@ def _build_summary(case_results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
         "fallback_rate": round(fallback_count / total, 4),
         "vision_unavailable_rate": round(vision_unavailable_count / total, 4),
         "sync_failure_rate": round(sync_failure_count / total, 4),
+        "message_category_accuracy": (
+            round(message_category_hits / message_category_evaluated, 4)
+            if message_category_evaluated
+            else None
+        ),
+        "repair_path_accuracy": (
+            round(repair_path_hits / repair_path_evaluated, 4)
+            if repair_path_evaluated
+            else None
+        ),
+        "harness_trace_coverage": round(harness_trace_count / total, 4),
+        "message_category_evaluated_count": message_category_evaluated,
+        "repair_path_evaluated_count": repair_path_evaluated,
     }
 
 
@@ -626,6 +706,8 @@ def _error_case_result(
             "sync_status": case.expectation.sync_status,
             "sync_delta_ms": case.expectation.sync_delta_ms,
             "frame_ids": list(case.expectation.frame_ids),
+            "message_category": case.expectation.message_category,
+            "repair_path": case.expectation.repair_path,
         },
         "actual": {
             "step_id": None,
@@ -637,6 +719,11 @@ def _error_case_result(
             "frame_ids": [],
             "generation_mode": None,
             "multimodal_fallback_to_text": None,
+            "message_category": None,
+            "repair_path": None,
+            "harness_trace_present": False,
+            "vlm_call_status": None,
+            "vlm_call_reason": None,
         },
         "checks": {
             "step_match": False,
@@ -646,6 +733,8 @@ def _error_case_result(
             "sync_status_match": False,
             "sync_delta_ms_match": False,
             "frame_ids_match": False,
+            "message_category_match": False,
+            "repair_path_match": False,
         },
         "vision_sidecar_configured": case.vision is not None,
         "fallback_used": False,

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -18,6 +18,7 @@ from adapters.action_executor import OverlayActionExecutor
 from adapters.dcs.overlay.sender import DcsOverlaySender
 from adapters.openai_compat_model import OpenAICompatModel
 from adapters.step_inference import StepInferenceResult
+from adapters.vision_sync import HelpCycleVisionSelection
 from adapters.vision_fact_extractor import VisionFactExtractionResult
 from adapters.source_chunk_refs import build_source_chunk_ref
 from core.help_failure import ALLOWLIST_FAIL, EVIDENCE_FAIL
@@ -30,6 +31,7 @@ from live_dcs import (
     UdpHelpTrigger,
     _build_model_from_args,
     _build_observation_source_from_args,
+    _build_harness_trace_metadata,
     _build_procedural_action_hint,
     build_arg_parser,
     _build_vision_fact_extractor_from_model,
@@ -747,6 +749,18 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
     assert tutor_request_payload["metadata"]["evidence_packet_summary"] == request.context["evidence_packet_summary"]
     assert request.context["overlay_target_allowlist"] == ["apu_switch"]
 
+    tutor_response_payload = next(event.payload for event in events if event.kind == "tutor_response")
+    response_meta = tutor_response_payload["metadata"]
+    trace = response_meta["harness_trace"]
+    assert trace["schema_version"] == "v1"
+    assert trace["evidence_packet_summary"] == request.context["evidence_packet_summary"]
+    assert trace["candidates"][0]["step_id"] == candidate_steps[0]["step_id"]
+    assert trace["model_decision"]["step_id"] == "S03"
+    assert trace["final_overlay_targets"] == ["apu_switch"]
+    assert trace["vlm_call"]["status"] in {"not_required", "skipped"}
+    assert response_meta["final_overlay_targets"] == ["apu_switch"]
+    assert response_meta["vlm_call_status"] == trace["vlm_call"]["status"]
+
     assert len(executor.calls) == 1
     assert len(executor.calls[0]) == 1
     assert executor.calls[0][0]["type"] == "overlay"
@@ -1414,12 +1428,23 @@ def test_live_loop_help_cycle_id_links_request_response_and_overlay_events(monke
         assert response_payload["metadata"]["help_cycle_id"] == help_cycle_id
         generation_mode = response_payload["metadata"]["generation_mode"]
         observed_generation_modes.append(generation_mode)
+        harness_trace = response_payload["metadata"]["harness_trace"]
+        assert harness_trace["schema_version"] == "v1"
+        assert harness_trace["final_overlay_targets"] == [
+            action["target"]
+            for action in response_payload["actions"]
+            if isinstance(action, dict) and isinstance(action.get("target"), str)
+        ]
+        assert harness_trace["validator_result"]["fallback_overlay_reason"]
+        assert response_payload["metadata"]["message_category"] == harness_trace["message_category"]
         assert response_events[0].metadata["generation_mode"] == generation_mode
         for event in cycle_events:
             if event.kind.startswith("overlay_"):
                 overlay_event_kinds.add(event.kind)
                 assert event.payload["help_cycle_id"] == help_cycle_id
                 assert event.metadata["generation_mode"] == generation_mode
+                assert event.metadata["final_overlay_targets"]
+                assert "harness_trace" not in event.metadata
 
     assert observed_generation_modes == ["model", "repair", "fallback"]
     assert "overlay_requested" in overlay_event_kinds
@@ -2051,6 +2076,15 @@ def test_live_loop_reuses_cached_result_for_same_state_within_cooldown(tmp_path:
     assert second_response_meta["request_prompt_hash"] == second_request_meta["prompt_hash"]
     assert second_response_meta["request_prompt_tokens_est"] == second_request_meta["prompt_tokens_est"]
     assert second_response_meta["request_prompt_trimmed"] == second_request_meta["prompt_trimmed"]
+    assert first_response_meta["harness_trace"]["schema_version"] == "v1"
+    assert second_response_meta["harness_trace"]["schema_version"] == "v1"
+    assert first_response_meta["help_cycle_id"] != second_response_meta["help_cycle_id"]
+    assert first_response_meta["harness_trace"]["final_overlay_targets"] == ["apu_switch"]
+    assert second_response_meta["harness_trace"]["final_overlay_targets"] == ["apu_switch"]
+    assert executor.calls[0][0]["help_cycle_id"] == first_response_meta["help_cycle_id"]
+    assert executor.calls[1][0]["help_cycle_id"] == second_response_meta["help_cycle_id"]
+    assert "harness_trace" not in executor.calls[0][0]
+    assert "harness_trace" not in executor.calls[1][0]
 
 
 def test_live_loop_filters_help_overlay_targets_by_request_allowlist(tmp_path: Path) -> None:
@@ -4729,6 +4763,111 @@ def test_s19_final_go_fresh_fact_suppresses_s19_fallback(tmp_path: Path) -> None
             "pitot_heater_switch",
         }
         assert loop._should_use_deterministic_overlay_fallback(response, request, None) is False
+    finally:
+        loop.close()
+
+
+def test_s19_final_go_trace_preserves_raw_model_step_before_guardrail(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s19_final_go_trace.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=0,
+        lang="en",
+    )
+    try:
+        request = TutorRequest(
+            request_id="cycle-s19-final-go",
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "candidate_steps": [
+                    {"step_id": "S19", "source": "deterministic"},
+                    {"step_id": "S20", "source": "visual_completion"},
+                ],
+                "evidence_packet_summary": {"vision_status": "available"},
+                "vision_fact_summary": {
+                    "seen_fact_ids": ["fcsmc_final_go_result_visible"],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                },
+                "vars": {"probe_cycle_complete": True},
+                "gates": [
+                    {"gate_id": "S20.completion", "status": "blocked"},
+                    {"gate_id": "S20.precondition", "status": "allowed"},
+                ],
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S19",
+                    "missing_conditions": ["vision_facts.fcsmc_final_go_result_visible==seen"],
+                    "observability_status": "partial",
+                    "requires_visual_confirmation": True,
+                    "action_hint": {"targets": ["fcs_bit_switch", "right_mdi_pb5"]},
+                },
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="Keep holding FCS BIT.",
+            actions=[],
+            explanations=["Keep holding FCS BIT."],
+            metadata={
+                "generation_mode": "model",
+                "next": {"step_id": "S19"},
+                "help_response": {
+                    "diagnosis": {"step_id": "S19", "error_category": "CO"},
+                    "next": {"step_id": "S19"},
+                    "overlay": {"targets": ["fcs_bit_switch"], "evidence": []},
+                    "explanations": ["Keep holding FCS BIT."],
+                },
+            },
+        )
+
+        loop._capture_model_raw_help_response(response)
+        rewritten, reason = loop._rewrite_procedural_guidance_response(response, request)
+        loop._annotate_response_audit_metadata(response)
+        trace = _build_harness_trace_metadata(
+            request=request,
+            response=response,
+            vision_selection=HelpCycleVisionSelection(
+                status="available",
+                observation_ref=None,
+                observation_seq=None,
+                observation_t_wall_s=None,
+                observation_t_wall_ms=10000,
+                trigger_wall_ms=10000,
+                sync_window_ms=100,
+                vision_used=True,
+                frame_id="frame-s19-final-go",
+                sync_status="matched_exact",
+                sync_delta_ms=0,
+                frame_stale=False,
+                frame_ids=["frame-s19-final-go"],
+                selected_frames=[],
+                pre_trigger_frame=None,
+                trigger_frame=None,
+                sync_miss_reason=None,
+            ),
+            vision_fact_context={
+                "status": "available",
+                "vision_fact_summary": {
+                    "seen_fact_ids": ["fcsmc_final_go_result_visible"],
+                    "fresh_fact_ids": [],
+                    "frame_ids": ["frame-s19-final-go"],
+                },
+                "vision_facts": [],
+                "metadata": {"extractor_used": True},
+            },
+        )
+
+        assert rewritten is True
+        assert reason == "s19_final_go_complete"
+        assert response.metadata["next"]["step_id"] == "S20"
+        assert response.metadata["model_raw_help_response"]["next"]["step_id"] == "S19"
+        assert trace["model_decision"]["step_id"] == "S19"
+        assert trace["final_action_plan"]["step_id"] == "S20"
     finally:
         loop.close()
 

--- a/tests/test_replay_eval.py
+++ b/tests/test_replay_eval.py
@@ -50,6 +50,11 @@ def test_run_replay_eval_suite_oracle_emits_fixed_summary(tmp_path: Path) -> Non
     assert 0.0 <= summary["requires_visual_confirmation_accuracy"] <= 1.0
     assert summary["vision_unavailable_rate"] == 0.6
     assert summary["sync_failure_rate"] == 0.2
+    assert summary["message_category_evaluated_count"] == 0
+    assert summary["message_category_accuracy"] is None
+    assert summary["repair_path_evaluated_count"] == 0
+    assert summary["repair_path_accuracy"] is None
+    assert summary["harness_trace_coverage"] == 1.0
     assert len(report["cases"]) == 5
     assert {case["status"] for case in report["cases"]}.issubset({"passed", "failed"})
 
@@ -564,6 +569,184 @@ def test_extract_case_outcome_ignores_blank_diagnosis_step_id_and_falls_back_to_
 
     assert outcome["actual"]["step_id"] == "S04"
     assert outcome["checks"]["step_match"] is True
+
+
+def test_extract_case_outcome_checks_harness_trace_message_and_repair_path() -> None:
+    case = ReplayEvalCase(
+        case_id="trace-c1",
+        input_path=REPO_ROOT / "replay_eval" / "fa18c_startup_v04" / "cases" / "noop_2min" / "dcs_bios_raw.jsonl",
+        session_id="sess-trace-c1",
+        scenario_profile="airfield",
+        max_frames=2,
+        expectation=ReplayEvalExpectation(
+            step_id="S08",
+            overlay_target="left_mdi_pb15",
+            requires_visual_confirmation=True,
+            vision_status="ok",
+            sync_status="matched",
+            sync_delta_ms=12,
+            frame_ids=("frame-1",),
+            message_category="harness_validator_repair",
+            repair_path="validator_repair",
+        ),
+    )
+    events = [
+        {
+            "kind": "tutor_request",
+            "payload": {
+                "context": {
+                    "vision": {
+                        "status": "ok",
+                        "sync_status": "matched",
+                        "sync_delta_ms": 12,
+                        "frame_ids": ["frame-1"],
+                    }
+                }
+            },
+        },
+        {
+            "kind": "tutor_response",
+            "payload": {
+                "actions": [{"target": "left_mdi_pb15"}],
+                "metadata": {
+                    "diagnosis": {"step_id": "S08"},
+                    "requires_visual_confirmation": True,
+                    "generation_mode": "repair",
+                    "message_category": "harness_validator_repair",
+                    "harness_trace": {
+                        "schema_version": "v1",
+                        "message_category": "harness_validator_repair",
+                        "repair_result": {
+                            "applied": True,
+                            "path": "validator_repair",
+                        },
+                        "final_action_plan": {
+                            "source": "validator_repair",
+                            "targets": ["left_mdi_pb15"],
+                        },
+                        "vlm_call": {"status": "called", "reason": None},
+                    },
+                },
+            },
+        },
+    ]
+
+    outcome = _extract_case_outcome(events, case=case)
+
+    assert outcome["actual"]["message_category"] == "harness_validator_repair"
+    assert outcome["actual"]["repair_path"] == "validator_repair"
+    assert outcome["actual"]["harness_trace_present"] is True
+    assert outcome["actual"]["vlm_call_status"] == "called"
+    assert outcome["checks"]["message_category_match"] is True
+    assert outcome["checks"]["repair_path_match"] is True
+    assert outcome["status"] == "passed"
+
+
+def test_extract_case_outcome_keeps_legacy_event_without_trace_passed() -> None:
+    case = ReplayEvalCase(
+        case_id="legacy-c1",
+        input_path=REPO_ROOT / "replay_eval" / "fa18c_startup_v04" / "cases" / "noop_2min" / "dcs_bios_raw.jsonl",
+        session_id="sess-legacy-c1",
+        scenario_profile="airfield",
+        max_frames=2,
+        expectation=ReplayEvalExpectation(
+            step_id="S03",
+            overlay_target="apu_switch",
+            requires_visual_confirmation=False,
+            vision_status="vision_unavailable",
+            sync_status=None,
+            sync_delta_ms=None,
+            frame_ids=(),
+        ),
+    )
+    events = [
+        {
+            "kind": "tutor_request",
+            "payload": {
+                "context": {
+                    "vision": {
+                        "status": "vision_unavailable",
+                        "sync_status": None,
+                        "sync_delta_ms": None,
+                        "frame_ids": [],
+                    }
+                }
+            },
+        },
+        {
+            "kind": "tutor_response",
+            "payload": {
+                "actions": [{"target": "apu_switch"}],
+                "metadata": {
+                    "diagnosis": {"step_id": "S03"},
+                    "requires_visual_confirmation": False,
+                    "generation_mode": "model",
+                },
+            },
+        },
+    ]
+
+    outcome = _extract_case_outcome(events, case=case)
+
+    assert outcome["actual"]["harness_trace_present"] is False
+    assert outcome["status"] == "passed"
+
+
+def test_extract_case_outcome_fails_when_expected_message_category_mismatches() -> None:
+    case = ReplayEvalCase(
+        case_id="trace-mismatch-c1",
+        input_path=REPO_ROOT / "replay_eval" / "fa18c_startup_v04" / "cases" / "noop_2min" / "dcs_bios_raw.jsonl",
+        session_id="sess-trace-mismatch-c1",
+        scenario_profile="airfield",
+        max_frames=2,
+        expectation=ReplayEvalExpectation(
+            step_id="S08",
+            overlay_target="left_mdi_pb15",
+            requires_visual_confirmation=True,
+            vision_status="ok",
+            sync_status="matched",
+            sync_delta_ms=12,
+            frame_ids=("frame-1",),
+            message_category="harness_validator_repair",
+            repair_path="validator_repair",
+        ),
+    )
+    events = [
+        {
+            "kind": "tutor_request",
+            "payload": {
+                "context": {
+                    "vision": {
+                        "status": "ok",
+                        "sync_status": "matched",
+                        "sync_delta_ms": 12,
+                        "frame_ids": ["frame-1"],
+                    }
+                }
+            },
+        },
+        {
+            "kind": "tutor_response",
+            "payload": {
+                "actions": [{"target": "left_mdi_pb15"}],
+                "metadata": {
+                    "diagnosis": {"step_id": "S08"},
+                    "requires_visual_confirmation": True,
+                    "message_category": "model",
+                    "harness_trace": {
+                        "message_category": "model",
+                        "repair_result": {"path": "validator_repair"},
+                    },
+                },
+            },
+        },
+    ]
+
+    outcome = _extract_case_outcome(events, case=case)
+
+    assert outcome["checks"]["message_category_match"] is False
+    assert outcome["checks"]["repair_path_match"] is True
+    assert outcome["status"] == "failed"
 
 
 def test_run_replay_eval_suite_continues_after_case_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add compact harness trace metadata for evidence packets, candidates, model decision, validator/repair result, final action plan, overlay targets, and VLM call status
- extend replay eval outcomes with optional message category and repair path checks plus trace coverage metrics
- keep overlay events on lightweight audit fields and preserve raw model decisions through guardrail repairs

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py tests/test_replay_eval.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #275