### PR TITLE
Fix core orchestrator CI guard marker

### DIFF
--- a/core/help_orchestrator.py
+++ b/core/help_orchestrator.py
@@ -1,9 +1,9 @@
 """
 Application-level help-cycle orchestration ports.
 
-The concrete live DCS loop wires these ports to adapters. Tests can wire fake
-ports, which keeps harness orchestration verifiable without DCS, model servers,
-or overlay transport.
+The concrete live runtime wires these ports to adapters. Tests can wire fake
+ports, which keeps harness orchestration verifiable without simulator runtime,
+model servers, or overlay transport.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- remove the forbidden uppercase simulator marker from the core orchestrator docstring
- keep the wording architecture-neutral so core purity guard passes

## Tests
- python3 tools/ci_guard.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_help_orchestrator.py