### PR TITLE
Add live help replay fixture extraction

### DIFF
--- a/core/live_replay_fixture.py
+++ b/core/live_replay_fixture.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+class LiveReplayFixtureError(ValueError):
+    pass
+
+
+class LiveReplayFixtureNotFound(LiveReplayFixtureError):
+    pass
+
+
+def _jsonable(raw: Any) -> Any:
+    try:
+        json.dumps(raw)
+    except TypeError:
+        return str(raw)
+    return raw
+
+
+def _as_mapping(raw: Any) -> Mapping[str, Any]:
+    return raw if isinstance(raw, Mapping) else {}
+
+
+def _as_dict(raw: Any) -> dict[str, Any]:
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _as_list(raw: Any) -> list[Any]:
+    return list(raw) if isinstance(raw, list) else []
+
+
+def _nonempty_text(raw: Any) -> str | None:
+    if not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    return text or None
+
+
+def _event_kind(event: Mapping[str, Any]) -> str | None:
+    return _nonempty_text(event.get("kind") or event.get("type"))
+
+
+def _payload(event: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _as_mapping(event.get("payload"))
+
+
+def _metadata(event: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _as_mapping(event.get("metadata"))
+
+
+def _payload_metadata(event: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _as_mapping(_payload(event).get("metadata"))
+
+
+def _event_help_cycle_id(event: Mapping[str, Any]) -> str | None:
+    for raw in (
+        _metadata(event).get("help_cycle_id"),
+        _payload_metadata(event).get("help_cycle_id"),
+    ):
+        text = _nonempty_text(raw)
+        if text is not None:
+            return text
+    kind = _event_kind(event)
+    payload = _payload(event)
+    if kind == "tutor_request":
+        return _nonempty_text(payload.get("request_id"))
+    if kind == "tutor_response":
+        return _nonempty_text(payload.get("in_reply_to"))
+    return None
+
+
+def _event_matches_request_id(event: Mapping[str, Any], request_id: str) -> bool:
+    payload = _payload(event)
+    metadata = _metadata(event)
+    payload_metadata = _payload_metadata(event)
+    return any(
+        raw == request_id
+        for raw in (
+            event.get("related_id"),
+            payload.get("request_id"),
+            payload.get("in_reply_to"),
+            metadata.get("help_cycle_id"),
+            payload_metadata.get("help_cycle_id"),
+        )
+    )
+
+
+def _load_jsonl_lenient(path: Path) -> tuple[list[tuple[int, dict[str, Any]]], list[dict[str, Any]]]:
+    events: list[tuple[int, dict[str, Any]]] = []
+    malformed: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for lineno, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                decoded = json.loads(text)
+            except json.JSONDecodeError as exc:
+                malformed.append({"lineno": lineno, "error": str(exc)})
+                continue
+            if not isinstance(decoded, dict):
+                malformed.append({"lineno": lineno, "error": "JSONL row is not an object"})
+                continue
+            events.append((lineno, decoded))
+    return events, malformed
+
+
+def _first_event(
+    events: Iterable[tuple[int, dict[str, Any]]],
+    *,
+    kind: str,
+    request_id: str,
+) -> tuple[int, dict[str, Any]] | None:
+    for lineno, event in events:
+        if _event_kind(event) == kind and _event_matches_request_id(event, request_id):
+            return lineno, event
+    return None
+
+
+def _event_belongs_to_cycle(event: Mapping[str, Any], *, request_id: str, help_cycle_id: str) -> bool:
+    if _event_matches_request_id(event, request_id):
+        return True
+    event_help_cycle_id = _event_help_cycle_id(event)
+    return event_help_cycle_id == help_cycle_id
+
+
+def _observation_id_from_event(event: Mapping[str, Any]) -> str | None:
+    payload = _payload(event)
+    return _nonempty_text(payload.get("observation_id") or payload.get("id"))
+
+
+def _is_vision_fact_observation_event(event: Mapping[str, Any]) -> bool:
+    if _event_kind(event) != "observation":
+        return False
+    payload = _payload(event)
+    payload_metadata = _as_mapping(payload.get("metadata"))
+    nested_payload_metadata = _as_mapping(_as_mapping(payload.get("payload")).get("metadata"))
+    return any(
+        raw == "vision_fact"
+        for raw in (
+            _metadata(event).get("observation_kind"),
+            payload_metadata.get("observation_kind"),
+            nested_payload_metadata.get("observation_kind"),
+        )
+    )
+
+
+def _event_frame_ids(event: Mapping[str, Any]) -> set[str]:
+    payload = _payload(event)
+    nested_payload = _as_mapping(payload.get("payload"))
+    candidates = [
+        event.get("vision_refs"),
+        _metadata(event).get("frame_ids"),
+        _as_mapping(payload.get("metadata")).get("frame_ids"),
+        payload.get("frame_ids"),
+        nested_payload.get("frame_ids"),
+    ]
+    out: set[str] = set()
+    for raw in candidates:
+        for item in _as_list(raw):
+            if isinstance(item, str) and item:
+                out.add(item)
+    return out
+
+
+def _nearby_events(
+    events: list[tuple[int, dict[str, Any]]],
+    *,
+    request_lineno: int,
+    before: int = 3,
+    after: int = 3,
+) -> list[tuple[int, dict[str, Any]]]:
+    request_index = next(
+        (idx for idx, item in enumerate(events) if item[0] == request_lineno),
+        -1,
+    )
+    if request_index < 0:
+        return []
+    return events[max(0, request_index - before): request_index + after + 1]
+
+
+def _extract_overlay_targets(response: Mapping[str, Any], trace: Mapping[str, Any]) -> list[str]:
+    response_metadata = _as_mapping(response.get("metadata"))
+    for raw in (
+        trace.get("final_overlay_targets"),
+        response_metadata.get("final_overlay_targets"),
+    ):
+        targets = [item for item in _as_list(raw) if isinstance(item, str) and item]
+        if targets:
+            return targets
+    out: list[str] = []
+    for action in _as_list(response.get("actions")):
+        if not isinstance(action, Mapping):
+            continue
+        target = action.get("target")
+        if isinstance(target, str) and target and target not in out:
+            out.append(target)
+    return out
+
+
+def _extract_final_step_id(response_metadata: Mapping[str, Any], trace: Mapping[str, Any]) -> str | None:
+    final_plan = _as_mapping(trace.get("final_action_plan") or response_metadata.get("final_action_plan"))
+    step_id = _nonempty_text(final_plan.get("step_id"))
+    if step_id is not None:
+        return step_id
+    final_public = _as_mapping(response_metadata.get("final_public_response"))
+    for key in ("next", "diagnosis"):
+        step_id = _nonempty_text(_as_mapping(final_public.get(key)).get("step_id"))
+        if step_id is not None:
+            return step_id
+    for key in ("next", "diagnosis"):
+        step_id = _nonempty_text(_as_mapping(response_metadata.get(key)).get("step_id"))
+        if step_id is not None:
+            return step_id
+    return None
+
+
+def _extract_vlm_call_status(response_metadata: Mapping[str, Any], trace: Mapping[str, Any]) -> str | None:
+    trace_status = _nonempty_text(_as_mapping(trace.get("vlm_call")).get("status"))
+    if trace_status is not None:
+        return trace_status
+    return _nonempty_text(response_metadata.get("vlm_call_status"))
+
+
+def _extract_llm_decision_status(trace: Mapping[str, Any], response_metadata: Mapping[str, Any]) -> str:
+    validator = _as_mapping(trace.get("validator_result"))
+    repair = _as_mapping(trace.get("repair_result"))
+    if (
+        bool(repair.get("applied"))
+        or bool(response_metadata.get("repair_applied"))
+        or response_metadata.get("generation_mode") == "repair"
+    ):
+        return "repaired"
+    if bool(validator.get("rejected")) or bool(response_metadata.get("validator_rejected")):
+        return "rejected"
+    return "accepted"
+
+
+def _extract_final_response_source(
+    response: Mapping[str, Any],
+    response_metadata: Mapping[str, Any],
+    trace: Mapping[str, Any],
+) -> str | None:
+    if response_metadata.get("cached_response_reused") is True:
+        return "cache"
+    provider = _nonempty_text(response_metadata.get("provider"))
+    generation_mode = _nonempty_text(response_metadata.get("generation_mode"))
+    final_plan_source = _nonempty_text(
+        _as_mapping(trace.get("final_action_plan")).get("source")
+        or _as_mapping(response_metadata.get("final_action_plan")).get("source")
+    )
+    if final_plan_source is not None and final_plan_source != "model":
+        return final_plan_source
+    repair_path = _nonempty_text(_as_mapping(trace.get("repair_result")).get("path"))
+    if repair_path is not None:
+        return repair_path
+    if response_metadata.get("fallback_overlay_used") is True:
+        fallback_reason = _nonempty_text(response_metadata.get("fallback_overlay_reason"))
+        if fallback_reason and fallback_reason.startswith("deterministic_step:"):
+            return "deterministic_fallback"
+        return fallback_reason or "fallback_overlay"
+    if provider == "fallback" or generation_mode == "fallback" or response.get("status") == "error":
+        return "fallback"
+    if generation_mode in {"model", "repair"}:
+        return generation_mode
+    return provider or generation_mode
+
+
+def _compact_event(lineno: int, event: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "lineno": lineno,
+        "kind": _event_kind(event),
+        "related_id": event.get("related_id"),
+        "help_cycle_id": _event_help_cycle_id(event),
+        "vision_refs": [item for item in _as_list(event.get("vision_refs")) if isinstance(item, str)],
+        "payload": _jsonable(event.get("payload")),
+        "metadata": _jsonable(event.get("metadata")),
+    }
+
+
+def extract_live_replay_fixture(
+    events: list[tuple[int, dict[str, Any]]],
+    *,
+    request_id: str,
+    source_path: str | None = None,
+    malformed_lines: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    normalized_request_id = _nonempty_text(request_id)
+    if normalized_request_id is None:
+        raise LiveReplayFixtureError("request_id must be a non-empty string")
+
+    request_match = _first_event(events, kind="tutor_request", request_id=normalized_request_id)
+    if request_match is None:
+        raise LiveReplayFixtureNotFound(f"request_id not found in live log: {normalized_request_id}")
+    request_lineno, request_event = request_match
+    request_payload = _as_dict(request_event.get("payload"))
+    help_cycle_id = (
+        _event_help_cycle_id(request_event)
+        or _nonempty_text(request_payload.get("request_id"))
+        or normalized_request_id
+    )
+
+    cycle_events = [
+        (lineno, event)
+        for lineno, event in events
+        if _event_belongs_to_cycle(event, request_id=normalized_request_id, help_cycle_id=help_cycle_id)
+    ]
+    response_match = _first_event(cycle_events, kind="tutor_response", request_id=normalized_request_id)
+    if response_match is None:
+        raise LiveReplayFixtureNotFound(f"tutor_response not found for request_id: {normalized_request_id}")
+    _response_lineno, response_event = response_match
+    response_payload = _as_dict(response_event.get("payload"))
+    response_metadata = _as_mapping(response_payload.get("metadata"))
+
+    request_context = _as_mapping(request_payload.get("context"))
+    evidence_packet_summary = _as_dict(request_context.get("evidence_packet_summary"))
+    trace = _as_mapping(response_metadata.get("harness_trace"))
+    if not evidence_packet_summary:
+        evidence_packet_summary = _as_dict(trace.get("evidence_packet_summary"))
+    telemetry_window_digest = _as_dict(evidence_packet_summary.get("telemetry_window_digest"))
+
+    observation_ref = _nonempty_text(request_payload.get("observation_ref"))
+    observations: list[Mapping[str, Any]] = []
+    if observation_ref is not None:
+        observations = [
+            _payload(event)
+            for _lineno, event in events
+            if _event_kind(event) == "observation"
+            and _observation_id_from_event(event) == observation_ref
+        ]
+    if not observations:
+        nearby = _nearby_events(events, request_lineno=request_lineno)
+        observations = [_payload(event) for _lineno, event in nearby if _event_kind(event) == "observation"]
+
+    frame_ids = set(
+        item
+        for item in _as_list(
+            response_metadata.get("vision_frame_ids")
+            or _as_mapping(request_payload.get("metadata")).get("vision_frame_ids")
+            or _as_mapping(trace.get("vlm_call")).get("frame_ids")
+        )
+        if isinstance(item, str) and item
+    )
+    nearby_line_numbers = {lineno for lineno, _event in _nearby_events(events, request_lineno=request_lineno, before=6, after=3)}
+    vision_fact_observations = [
+        _payload(event)
+        for lineno, event in events
+        if _is_vision_fact_observation_event(event)
+        and (
+            (frame_ids and bool(frame_ids & _event_frame_ids(event)))
+            or lineno in nearby_line_numbers
+        )
+    ]
+
+    final_overlay_targets = _extract_overlay_targets(response_payload, trace)
+    expectations = {
+        "expected_final_step_id": _extract_final_step_id(response_metadata, trace),
+        "expected_overlay_target_ids": final_overlay_targets,
+        "vlm_call_status": _extract_vlm_call_status(response_metadata, trace),
+        "llm_decision_status": _extract_llm_decision_status(trace, response_metadata),
+        "final_response_source": _extract_final_response_source(response_payload, response_metadata, trace),
+    }
+    actual_request_id = (
+        _nonempty_text(request_payload.get("request_id"))
+        or _nonempty_text(response_payload.get("in_reply_to"))
+    )
+
+    return {
+        "schema_version": "live_help_replay_fixture.v1",
+        "extraction_id": normalized_request_id,
+        "request_id": actual_request_id or normalized_request_id,
+        "request_id_missing": actual_request_id is None,
+        "help_cycle_id": help_cycle_id,
+        "source_log": {
+            "path": source_path,
+            "event_count": len(events),
+            "malformed_lines": list(malformed_lines or []),
+        },
+        "cycle": {
+            "tutor_request": request_payload,
+            "tutor_response": response_payload,
+            "events": [_compact_event(lineno, event) for lineno, event in cycle_events],
+        },
+        "context": {
+            "observation_ref": observation_ref,
+            "observations": [_jsonable(dict(item)) for item in observations if isinstance(item, Mapping)],
+            "vision": {
+                "request": _as_dict(request_payload.get("metadata")).get("vision"),
+                "response": response_metadata.get("vision"),
+                "frame_ids": _as_list(
+                    response_metadata.get("vision_frame_ids")
+                    or _as_mapping(request_payload.get("metadata")).get("vision_frame_ids")
+                ),
+                "vision_fact_summary": _as_dict(
+                    response_metadata.get("vision_fact_summary")
+                    or request_context.get("vision_fact_summary")
+                ),
+                "vision_facts": _as_list(response_metadata.get("vision_facts")),
+            },
+            "evidence_packet_summary": evidence_packet_summary,
+            "telemetry_window_digest": telemetry_window_digest,
+            "vision_fact_observations": [
+                _jsonable(dict(item)) for item in vision_fact_observations if isinstance(item, Mapping)
+            ],
+        },
+        "model_io": {
+            "model_raw_help_response": _jsonable(response_metadata.get("model_raw_help_response")),
+            "help_response": _jsonable(response_metadata.get("help_response")),
+            "raw_llm_text_present": isinstance(response_metadata.get("raw_llm_text"), str),
+            "raw_llm_text_attempt_count": len(_as_list(response_metadata.get("raw_llm_text_attempts"))),
+        },
+        "harness": {
+            "candidate_steps": _as_list(request_context.get("candidate_steps") or trace.get("candidates")),
+            "trace": _jsonable(dict(trace)),
+            "model_decision": _jsonable(_as_dict(trace.get("model_decision"))),
+            "validator_result": _jsonable(_as_dict(trace.get("validator_result"))),
+            "repair_result": _jsonable(_as_dict(trace.get("repair_result"))),
+            "final_action_plan": _jsonable(
+                _as_dict(trace.get("final_action_plan") or response_metadata.get("final_action_plan"))
+            ),
+        },
+        "expectations": expectations,
+    }
+
+
+def extract_live_replay_fixture_from_jsonl(path: str | Path, *, request_id: str) -> dict[str, Any]:
+    resolved_path = Path(path).expanduser().resolve()
+    events, malformed = _load_jsonl_lenient(resolved_path)
+    return extract_live_replay_fixture(
+        events,
+        request_id=request_id,
+        source_path=str(resolved_path),
+        malformed_lines=malformed,
+    )
+
+
+def default_fixture_output_path(output_dir: str | Path, *, request_id: str) -> Path:
+    safe_request_id = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in request_id)
+    if not safe_request_id:
+        safe_request_id = "request"
+    return Path(output_dir).expanduser() / f"{safe_request_id}.fixture.json"
+
+
+def write_live_replay_fixture(
+    fixture: Mapping[str, Any],
+    *,
+    output: str | Path | None = None,
+    output_dir: str | Path | None = None,
+) -> Path:
+    if output is None and output_dir is None:
+        raise LiveReplayFixtureError("either output or output_dir is required")
+    if output is not None and output_dir is not None:
+        raise LiveReplayFixtureError("output and output_dir are mutually exclusive")
+
+    if output_dir is not None:
+        request_id = _nonempty_text(fixture.get("request_id")) or "request"
+        path = default_fixture_output_path(output_dir, request_id=request_id)
+    else:
+        path = Path(str(output)).expanduser()
+        if path.exists() and path.is_dir():
+            request_id = _nonempty_text(fixture.get("request_id")) or "request"
+            path = default_fixture_output_path(path, request_id=request_id)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(fixture, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+__all__ = [
+    "LiveReplayFixtureError",
+    "LiveReplayFixtureNotFound",
+    "default_fixture_output_path",
+    "extract_live_replay_fixture",
+    "extract_live_replay_fixture_from_jsonl",
+    "write_live_replay_fixture",
+]

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -6544,6 +6544,27 @@ def _new_default_log_path() -> Path:
     return Path("logs") / f"live_dcs_{ts}.jsonl"
 
 
+def _unique_log_path_candidates(requested_path: str | Path) -> Iterable[Path]:
+    path = Path(requested_path).expanduser()
+    yield path
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    stem = path.stem or "live_dcs"
+    suffix = path.suffix
+    yield path.with_name(f"{stem}_{timestamp}{suffix}")
+    for index in range(2, 1000):
+        yield path.with_name(f"{stem}_{timestamp}_{index}{suffix}")
+
+
+def _open_unique_event_store(requested_path: str | Path) -> tuple[Path, JsonlEventStore]:
+    for candidate in _unique_log_path_candidates(requested_path):
+        try:
+            return candidate, JsonlEventStore(candidate, mode="x")
+        except FileExistsError:
+            continue
+    raise FileExistsError(f"could not resolve unique log path for {requested_path}")
+
+
 def _build_observation_source_from_args(args: argparse.Namespace) -> ObservationSource:
     if args.replay_bios:
         return ReplayBiosReceiver(args.replay_bios, speed=args.speed)
@@ -6919,27 +6940,41 @@ def build_arg_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_arg_parser().parse_args(list(argv) if argv is not None else None)
 
-    output = Path(args.output) if args.output else _new_default_log_path()
-    output.parent.mkdir(parents=True, exist_ok=True)
+    requested_output = Path(args.output) if args.output else _new_default_log_path()
+    output, store = _open_unique_event_store(requested_output)
+    print(f"[LIVE_DCS] resolved output path: {output}")
 
-    source = _build_observation_source_from_args(args)
+    with store:
+        source = _build_observation_source_from_args(args)
 
-    model = _build_model_from_args(args)
-    vision_port, vision_session_id, vision_sync_window_ms, vision_trigger_wait_ms = _build_vision_port_from_args(
-        args,
-        mode="live",
-    )
-    vision_capture_notifier = (
-        UdpVisionCaptureNotifier(
-            session_id=vision_session_id,
-            host=args.vision_capture_trigger_host,
-            port=args.vision_capture_trigger_port,
+        model = _build_model_from_args(args)
+        vision_port, vision_session_id, vision_sync_window_ms, vision_trigger_wait_ms = _build_vision_port_from_args(
+            args,
+            mode="live",
         )
-        if vision_session_id and int(args.vision_capture_trigger_port) > 0
-        else None
-    )
-
-    with JsonlEventStore(output, mode="w") as store:
+        vision_capture_notifier = (
+            UdpVisionCaptureNotifier(
+                session_id=vision_session_id,
+                host=args.vision_capture_trigger_host,
+                port=args.vision_capture_trigger_port,
+            )
+            if vision_session_id and int(args.vision_capture_trigger_port) > 0
+            else None
+        )
+        store.append(
+            Event(
+                kind="system",
+                payload={
+                    "event": "live_dcs_runtime_log",
+                    "requested_output_path": str(requested_output),
+                    "resolved_output_path": str(output),
+                },
+                metadata={
+                    "requested_output_path": str(requested_output),
+                    "resolved_output_path": str(output),
+                },
+            )
+        )
         executor = OverlayActionExecutor(
             ui_map_path=args.ui_map,
             pack_path=args.pack,

--- a/simtutor/__main__.py
+++ b/simtutor/__main__.py
@@ -356,6 +356,15 @@ def _run_replay_eval(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_extract_live_fixture(args: argparse.Namespace) -> int:
+    from core.live_replay_fixture import extract_live_replay_fixture_from_jsonl, write_live_replay_fixture
+
+    fixture = extract_live_replay_fixture_from_jsonl(args.input, request_id=args.request_id)
+    output_path = write_live_replay_fixture(fixture, output=args.output, output_dir=args.output_dir)
+    print(f"[EXTRACT_LIVE_FIXTURE] wrote {output_path}")
+    return 0
+
+
 def _sanitize_participant_slug(raw: str) -> str:
     """Return a safe directory name from a participant identifier."""
     # Discard any path component; only use the terminal name.
@@ -680,6 +689,22 @@ def main() -> int:
     )
     rec_vlm.set_defaults(merge_full_state=True)
 
+    extract_fixture = sub.add_parser(
+        "extract-live-fixture",
+        help="Extract one live help cycle from a JSONL log into a replay/debug fixture",
+    )
+    extract_fixture.add_argument("--input", required=True, help="Live JSONL runtime log path")
+    extract_fixture.add_argument(
+        "--request-id",
+        "--help-cycle-id",
+        dest="request_id",
+        required=True,
+        help="Live help request_id/help_cycle_id to extract",
+    )
+    extract_output = extract_fixture.add_mutually_exclusive_group(required=True)
+    extract_output.add_argument("--output", help="Fixture JSON output path")
+    extract_output.add_argument("--output-dir", help="Directory for <request_id>.fixture.json")
+
     rep_eval = sub.add_parser("replay-eval", help="Run fixed replay regression suite and emit a stable report")
     rep_eval.add_argument(
         "--suite",
@@ -775,6 +800,12 @@ def main() -> int:
             return _run_record_vlm(args)
         except Exception as exc:
             print(f"[RECORD_VLM] error: {exc}")
+            return 1
+    if args.command == "extract-live-fixture":
+        try:
+            return _run_extract_live_fixture(args)
+        except Exception as exc:
+            print(f"[EXTRACT_LIVE_FIXTURE] error: {exc}")
             return 1
     if args.command == "replay-eval":
         try:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -5738,6 +5738,81 @@ def test_live_dcs_main_wires_tutor_text_sender_into_loop(monkeypatch, tmp_path: 
     assert isinstance(captured["loop_kwargs"]["tutor_text_sender"], FakeTutorTextSender)
 
 
+def test_live_dcs_main_resolves_existing_output_path_and_logs_metadata(
+    monkeypatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import live_dcs
+
+    requested_output = tmp_path / "events.jsonl"
+    requested_output.write_text("previous run\n", encoding="utf-8")
+    captured: dict[str, Any] = {"events": []}
+
+    class FakeStore:
+        def __init__(self, path, *_args, mode: str = "a", **_kwargs) -> None:
+            attempted = captured.setdefault("attempted_paths", [])
+            attempted.append(Path(path))
+            assert mode == "x"
+            if len(attempted) <= 2:
+                raise FileExistsError(path)
+            captured["store_path"] = Path(path)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def append(self, event) -> None:
+            captured["events"].append(event)
+
+    class FakeTutorTextSender:
+        def __init__(self, **_kwargs) -> None:
+            return
+
+        def close(self) -> None:
+            return
+
+    class FakeLoop:
+        def __init__(self, **_kwargs) -> None:
+            return
+
+        def run(self, **_kwargs) -> dict[str, Any]:
+            return {"help_cycles": 0}
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setattr("live_dcs.JsonlEventStore", FakeStore)
+    monkeypatch.setattr("live_dcs.OverlayActionExecutor", lambda **_kwargs: object())
+    monkeypatch.setattr("live_dcs._build_observation_source_from_args", lambda _args: object())
+    monkeypatch.setattr("live_dcs._build_model_from_args", lambda _args: object())
+    monkeypatch.setattr("live_dcs._build_vision_port_from_args", lambda _args, mode: (None, None, None, None))
+    monkeypatch.setattr("live_dcs.DcsTutorTextSender", FakeTutorTextSender)
+    monkeypatch.setattr("live_dcs.LiveDcsTutorLoop", FakeLoop)
+
+    code = live_dcs.main(["--output", str(requested_output), "--duration", "0"])
+
+    assert code == 0
+    resolved_output = captured["store_path"]
+    assert resolved_output != requested_output
+    assert resolved_output.parent == requested_output.parent
+    assert resolved_output.name.startswith("events_")
+    assert len(captured["attempted_paths"]) == 3
+    assert requested_output.read_text(encoding="utf-8") == "previous run\n"
+    startup_events = [event for event in captured["events"] if event.kind == "system"]
+    assert startup_events
+    assert startup_events[0].payload["event"] == "live_dcs_runtime_log"
+    assert startup_events[0].payload["requested_output_path"] == str(requested_output)
+    assert startup_events[0].payload["resolved_output_path"] == str(resolved_output)
+    assert startup_events[0].metadata["requested_output_path"] == str(requested_output)
+    assert startup_events[0].metadata["resolved_output_path"] == str(resolved_output)
+    out = capsys.readouterr().out
+    assert f"[LIVE_DCS] resolved output path: {resolved_output}" in out
+    assert f"[LIVE_DCS] wrote events to {resolved_output}" in out
+
+
 def test_live_loop_request_context_and_metadata_include_scenario_profile(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_scenario_profile.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])

--- a/tests/test_live_replay_fixture.py
+++ b/tests/test_live_replay_fixture.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.live_replay_fixture import LiveReplayFixtureNotFound, extract_live_replay_fixture_from_jsonl
+from simtutor.__main__ import main
+
+
+def _event(
+    kind: str,
+    payload: dict[str, Any],
+    *,
+    related_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    vision_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "version": "v1",
+        "event_id": f"event-{kind}",
+        "timestamp": "2026-05-17T12:00:00+00:00",
+        "kind": kind,
+        "payload": payload,
+        "related_id": related_id,
+        "vision_refs": vision_refs or [],
+        "metadata": metadata or {},
+    }
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any] | str]) -> None:
+    path.write_text(
+        "".join(
+            (row if isinstance(row, str) else json.dumps(row, ensure_ascii=False)) + "\n"
+            for row in rows
+        ),
+        encoding="utf-8",
+    )
+
+
+def _sample_cycle_events(request_id: str = "req-288") -> list[dict[str, Any]]:
+    help_cycle_id = request_id
+    observation_id = "obs-1"
+    request_payload = {
+        "request_id": request_id,
+        "observation_ref": observation_id,
+        "message": "help",
+        "context": {
+            "candidate_steps": [
+                {"step_id": "S03", "rank": 0, "confidence": 0.8},
+                {"step_id": "S04", "rank": 1, "confidence": 0.5},
+            ],
+            "evidence_packet_summary": {
+                "step_id": "S03",
+                "telemetry_window_digest": {"frame_count": 2, "status": "ok"},
+            },
+            "vision_fact_summary": {"seen_fact_ids": ["apu_ready_light"], "frame_ids": ["frame-1"]},
+        },
+        "metadata": {
+            "help_cycle_id": help_cycle_id,
+            "vision_fact_status": "available",
+            "vision_frame_ids": ["frame-1"],
+        },
+    }
+    response_payload = {
+        "in_reply_to": request_id,
+        "status": "ok",
+        "message": "Turn on APU.",
+        "actions": [{"type": "overlay", "target": "apu_switch"}],
+        "metadata": {
+            "help_cycle_id": help_cycle_id,
+            "generation_mode": "model",
+            "final_overlay_targets": ["apu_switch"],
+            "final_action_plan": {"step_id": "S03", "targets": ["apu_switch"], "source": "model"},
+            "final_public_response": {
+                "message": "Turn on APU.",
+                "next": {"step_id": "S03"},
+                "actions": [{"type": "overlay", "target": "apu_switch"}],
+            },
+            "harness_trace": {
+                "schema_version": "v1",
+                "evidence_packet_summary": {
+                    "step_id": "S03",
+                    "telemetry_window_digest": {"frame_count": 2, "status": "ok"},
+                },
+                "candidates": [{"step_id": "S03", "rank": 0}],
+                "model_decision": {"step_id": "S03", "overlay_targets": ["apu_switch"]},
+                "validator_result": {"rejected": False, "reasons": []},
+                "repair_result": {"applied": False, "path": None},
+                "final_action_plan": {"step_id": "S03", "targets": ["apu_switch"], "source": "model"},
+                "final_overlay_targets": ["apu_switch"],
+                "message_category": "model",
+                "vlm_call": {"status": "called", "frame_ids": ["frame-1"]},
+            },
+        },
+    }
+    return [
+        _event(
+            "observation",
+            {"observation_id": observation_id, "payload": {"seq": 1, "vars": {"apu_on": False}}},
+            related_id=observation_id,
+        ),
+        _event("tutor_request", request_payload, related_id=request_id, metadata={"help_cycle_id": help_cycle_id}),
+        _event(
+            "overlay_dry_run",
+            {"help_cycle_id": help_cycle_id, "target": "apu_switch"},
+            related_id=request_id,
+            metadata={"help_cycle_id": help_cycle_id},
+        ),
+        _event("tutor_response", response_payload, related_id=request_id, metadata={"help_cycle_id": help_cycle_id}),
+    ]
+
+
+def test_extract_live_replay_fixture_from_request_id_includes_harness_path(tmp_path: Path) -> None:
+    log_path = tmp_path / "live.jsonl"
+    _write_jsonl(log_path, [_sample_cycle_events()[0], "{bad json", *_sample_cycle_events()[1:]])
+
+    fixture = extract_live_replay_fixture_from_jsonl(log_path, request_id="req-288")
+
+    assert fixture["schema_version"] == "live_help_replay_fixture.v1"
+    assert fixture["request_id"] == "req-288"
+    assert fixture["help_cycle_id"] == "req-288"
+    assert fixture["source_log"]["malformed_lines"][0]["lineno"] == 2
+    assert fixture["cycle"]["tutor_request"]["request_id"] == "req-288"
+    assert fixture["cycle"]["tutor_response"]["in_reply_to"] == "req-288"
+    assert fixture["context"]["evidence_packet_summary"]["step_id"] == "S03"
+    assert fixture["context"]["telemetry_window_digest"] == {"frame_count": 2, "status": "ok"}
+    assert fixture["harness"]["candidate_steps"][0]["step_id"] == "S03"
+    assert fixture["harness"]["trace"]["validator_result"]["rejected"] is False
+    assert fixture["expectations"] == {
+        "expected_final_step_id": "S03",
+        "expected_overlay_target_ids": ["apu_switch"],
+        "vlm_call_status": "called",
+        "llm_decision_status": "accepted",
+        "final_response_source": "model",
+    }
+
+
+def test_extract_live_replay_fixture_missing_request_id_raises(tmp_path: Path) -> None:
+    log_path = tmp_path / "live.jsonl"
+    _write_jsonl(log_path, _sample_cycle_events(request_id="other-req"))
+
+    with pytest.raises(LiveReplayFixtureNotFound, match="missing-req"):
+        extract_live_replay_fixture_from_jsonl(log_path, request_id="missing-req")
+
+
+def test_extract_live_replay_fixture_handles_cached_fallback_response(tmp_path: Path) -> None:
+    log_path = tmp_path / "live.jsonl"
+    events = _sample_cycle_events(request_id="cached-req")
+    response = events[-1]["payload"]
+    response["status"] = "error"
+    response["actions"] = []
+    response["metadata"].update(
+        {
+            "provider": "fallback",
+            "generation_mode": "fallback",
+            "cached_response_reused": True,
+            "final_overlay_targets": [],
+            "final_action_plan": {"step_id": "S03", "targets": [], "source": "fallback"},
+        }
+    )
+    response["metadata"]["harness_trace"].update(
+        {
+            "final_overlay_targets": [],
+            "message_category": "fallback",
+            "repair_result": {"applied": True, "path": "fallback_overlay"},
+            "vlm_call": {"status": "not_required", "frame_ids": []},
+        }
+    )
+    _write_jsonl(log_path, events)
+
+    fixture = extract_live_replay_fixture_from_jsonl(log_path, request_id="cached-req")
+
+    assert fixture["expectations"]["expected_overlay_target_ids"] == []
+    assert fixture["expectations"]["vlm_call_status"] == "not_required"
+    assert fixture["expectations"]["llm_decision_status"] == "repaired"
+    assert fixture["expectations"]["final_response_source"] == "cache"
+    assert fixture["cycle"]["tutor_response"]["metadata"]["cached_response_reused"] is True
+
+
+def test_extract_live_replay_fixture_uses_response_metadata_when_trace_missing(tmp_path: Path) -> None:
+    log_path = tmp_path / "live.jsonl"
+    events = _sample_cycle_events(request_id="legacy-req")
+    response_metadata = events[-1]["payload"]["metadata"]
+    response_metadata.pop("harness_trace")
+    response_metadata.update(
+        {
+            "generation_mode": "repair",
+            "final_overlay_targets": ["apu_switch"],
+            "final_action_plan": {
+                "step_id": "S03",
+                "targets": ["apu_switch"],
+                "source": "validator_action_hint",
+            },
+        }
+    )
+    _write_jsonl(log_path, events)
+
+    fixture = extract_live_replay_fixture_from_jsonl(log_path, request_id="legacy-req")
+
+    assert fixture["expectations"]["expected_final_step_id"] == "S03"
+    assert fixture["expectations"]["expected_overlay_target_ids"] == ["apu_switch"]
+    assert fixture["expectations"]["llm_decision_status"] == "repaired"
+    assert fixture["expectations"]["final_response_source"] == "validator_action_hint"
+
+
+def test_extract_live_replay_fixture_classifies_deterministic_fallback(tmp_path: Path) -> None:
+    log_path = tmp_path / "live.jsonl"
+    events = _sample_cycle_events(request_id="fallback-overlay-req")
+    response_metadata = events[-1]["payload"]["metadata"]
+    response_metadata.update(
+        {
+            "generation_mode": "model",
+            "fallback_overlay_used": True,
+            "fallback_overlay_reason": "deterministic_step:S03",
+        }
+    )
+    response_metadata["harness_trace"]["repair_result"] = {"applied": True, "path": "deterministic_step:S03"}
+    _write_jsonl(log_path, events)
+
+    fixture = extract_live_replay_fixture_from_jsonl(log_path, request_id="fallback-overlay-req")
+
+    assert fixture["expectations"]["llm_decision_status"] == "repaired"
+    assert fixture["expectations"]["final_response_source"] == "deterministic_step:S03"
+
+
+def test_extract_live_replay_fixture_includes_matching_vision_fact_observation(tmp_path: Path) -> None:
+    log_path = tmp_path / "live.jsonl"
+    events = _sample_cycle_events(request_id="vision-req")
+    vision_fact_event = _event(
+        "observation",
+        {
+            "observation_id": "vision-fact-1",
+            "source": "vision_fact",
+            "metadata": {"observation_kind": "vision_fact", "frame_ids": ["frame-1"]},
+            "payload": {
+                "frame_ids": ["frame-1"],
+                "metadata": {"raw_llm_text": "{\"facts\": []}"},
+                "facts": [{"fact_id": "apu_ready_light", "state": "seen"}],
+            },
+        },
+        metadata={"observation_kind": "vision_fact"},
+        vision_refs=["frame-1"],
+    )
+    _write_jsonl(log_path, [events[0], vision_fact_event, *events[1:]])
+
+    fixture = extract_live_replay_fixture_from_jsonl(log_path, request_id="vision-req")
+
+    vision_fact_observations = fixture["context"]["vision_fact_observations"]
+    assert len(vision_fact_observations) == 1
+    assert vision_fact_observations[0]["observation_id"] == "vision-fact-1"
+    assert vision_fact_observations[0]["payload"]["metadata"]["raw_llm_text"] == "{\"facts\": []}"
+
+
+def test_extract_live_replay_fixture_without_observation_ref_uses_nearby_observations(tmp_path: Path) -> None:
+    log_path = tmp_path / "live.jsonl"
+    events = _sample_cycle_events(request_id="no-obs-ref")
+    events[1]["payload"].pop("observation_ref")
+    far_observations = [
+        _event("observation", {"observation_id": f"far-{idx}", "payload": {"seq": idx}})
+        for idx in range(8)
+    ]
+    _write_jsonl(log_path, [*far_observations, *events])
+
+    fixture = extract_live_replay_fixture_from_jsonl(log_path, request_id="no-obs-ref")
+
+    observation_ids = [item["observation_id"] for item in fixture["context"]["observations"]]
+    assert "obs-1" in observation_ids
+    assert "far-0" not in observation_ids
+    assert len(observation_ids) < len(far_observations) + 1
+
+
+def test_cli_extract_live_fixture_writes_into_output_dir(monkeypatch, tmp_path: Path, capsys) -> None:
+    log_path = tmp_path / "live.jsonl"
+    _write_jsonl(log_path, _sample_cycle_events())
+    output_dir = tmp_path / "fixtures"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "simtutor",
+            "extract-live-fixture",
+            "--input",
+            str(log_path),
+            "--request-id",
+            "req-288",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    code = main()
+
+    assert code == 0
+    fixture_path = output_dir / "req-288.fixture.json"
+    assert fixture_path.exists()
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    assert fixture["request_id"] == "req-288"
+    assert f"[EXTRACT_LIVE_FIXTURE] wrote {fixture_path}" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add a pure JSONL live help fixture extractor for request_id/help_cycle_id debugging
- expose simtutor extract-live-fixture CLI with stable JSON fixture output
- prevent live_dcs --output overwrite by atomically opening a unique JSONL path and recording it in runtime metadata

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_replay_fixture.py tests/test_live_dcs.py -k 'live_replay_fixture or resolves_existing_output_path or wires_tutor_text_sender'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s

## Review
- subagent fixture/CLI review: no blocking issues after fixes
- subagent live output review: no blocking issues after fixes

Closes #288