### PR TITLE
Document live fixture extraction workflow

### DIFF
--- a/docs/wiki/dcs-live-operation.md
+++ b/docs/wiki/dcs-live-operation.md
@@ -70,6 +70,8 @@ python live_dcs.py \
   --output logs/live_dcs.jsonl
 ```
 
+If `--output` already exists, the live loop opens a unique timestamped or numeric-suffixed JSONL path instead of overwriting it. The final resolved path is printed to the console and recorded in the startup `system` event metadata as `resolved_output_path`.
+
 ## Run Vision Sidecar
 
 PowerShell example on the simulator host:
@@ -91,3 +93,16 @@ python -m simtutor record-vlm \
   --vision-saved-games-dir "<saved-games-dir>" \
   --max-frames 2000
 ```
+
+## Extract One Failed Help Cycle
+
+For a live failure reported as `request_id=<id>`, extract the relevant request, response, evidence, harness trace, vision facts, and final overlay targets into a compact fixture:
+
+```bash
+python -m simtutor extract-live-fixture \
+  --input logs/live_dcs.jsonl \
+  --request-id "<request-id>" \
+  --output-dir artifacts/live_fixtures
+```
+
+See [Replay and CLI reference](replay-and-cli-reference.md#extract-a-live-help-fixture) for the fixture shape and regression workflow.

--- a/docs/wiki/replay-and-cli-reference.md
+++ b/docs/wiki/replay-and-cli-reference.md
@@ -80,3 +80,57 @@ python -m simtutor replay-bios \
 ```
 
 Use `--print-model-io` only when you intentionally want to inspect full prompts and decoded model replies.
+
+## Extract a Live Help Fixture
+
+When a live run fails, copy the reported `request_id` or `help_cycle_id` and extract a compact replay/debug fixture from the JSONL runtime log:
+
+```bash
+python -m simtutor extract-live-fixture \
+  --input logs/live_dcs.jsonl \
+  --request-id "<request-id>" \
+  --output-dir artifacts/live_fixtures
+```
+
+This writes:
+
+```text
+artifacts/live_fixtures/<request-id>.fixture.json
+```
+
+Use `--output` instead of `--output-dir` when you want an exact file path:
+
+```bash
+python -m simtutor extract-live-fixture \
+  --input logs/live_dcs.jsonl \
+  --help-cycle-id "<help-cycle-id>" \
+  --output artifacts/live_fixtures/s19_failure.fixture.json
+```
+
+The generated fixture has schema version `live_help_replay_fixture.v1` and is intended for regression-test authoring and failure inspection. Important top-level sections:
+
+| Field | Purpose |
+|---|---|
+| `extraction_id` | The id supplied on the CLI. |
+| `request_id` | The real request id from the log when available. |
+| `help_cycle_id` | The normalized live help cycle id. |
+| `source_log` | Source path, event count, and malformed JSONL lines skipped during extraction. |
+| `cycle.tutor_request` | Sanitized tutor request payload for the selected help cycle. |
+| `cycle.tutor_response` | Sanitized tutor response payload for the selected help cycle. |
+| `cycle.events` | Compact cycle-related event bundle, including overlay events. |
+| `context.observations` | The request observation or nearby observation frames. |
+| `context.vision` | Vision frame ids, fact summary, and response-side vision metadata. |
+| `context.vision_fact_observations` | Matching raw/parsed vision fact observation events when present. |
+| `context.evidence_packet_summary` | Compact EvidencePacket summary from request context or harness trace. |
+| `context.telemetry_window_digest` | Telemetry window digest when present in the evidence summary. |
+| `model_io` | Logged model response objects and raw-text presence metadata. |
+| `harness` | Candidate steps, harness trace, model decision, validator result, repair result, and final action plan. |
+| `expectations` | Stable assertion seeds: final step id, overlay target ids, VLM call status, LLM decision status, and final response source. |
+
+Typical regression loop:
+
+```text
+live request_id -> extract fixture -> inspect expectations/harness trace -> write replay/eval assertion -> fix -> keep fixture with test
+```
+
+Malformed JSONL lines do not stop extraction; they are recorded under `source_log.malformed_lines`. If the id is not found, the command exits with an `[EXTRACT_LIVE_FIXTURE] error:` message.


### PR DESCRIPTION
## Summary
- document simtutor extract-live-fixture usage and fixture shape
- note live_dcs --output unique path behavior in DCS live operation docs

## Tests
- git diff --check

Docs-only update.