### PR TITLE
Enforce S08 VLM visual navigation hints

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -26,6 +26,7 @@ class HarnessActionPlan:
     validator_rejected: bool
     repair_applied: bool
     rejected_model_step_id: str | None
+    rejected_model_targets: tuple[str, ...]
     final_action_plan_source: str
     reasons: tuple[str, ...]
 
@@ -261,6 +262,7 @@ def plan_harness_action(
             validator_rejected=True,
             repair_applied=True,
             rejected_model_step_id=rejected_model_step_id,
+            rejected_model_targets=(),
             final_action_plan_source=text_guidance.source,
             reasons=tuple((*reasons, f"text_only_guidance:{text_guidance.target}")),
         )
@@ -295,6 +297,14 @@ def plan_harness_action(
         max_overlay_targets=max_overlay_targets,
     )
     reasons.extend(target_reasons)
+    rejected_model_targets: tuple[str, ...] = ()
+    if use_hint and proposed_targets:
+        hinted_target_set = set(hinted_targets)
+        rejected_model_targets = tuple(
+            target for target in proposed_targets
+            if target not in hinted_target_set
+        )
+        reasons.extend(f"action_hint_target_mismatch:{target}" for target in rejected_model_targets)
 
     if not targets and spec is not None and spec.allowed_overlay_targets and max_overlay_targets > 0:
         repaired_targets, repair_reasons = _filter_targets(
@@ -340,6 +350,7 @@ def plan_harness_action(
         validator_rejected=rejected,
         repair_applied=repaired,
         rejected_model_step_id=rejected_model_step_id,
+        rejected_model_targets=rejected_model_targets,
         final_action_plan_source=source,
         reasons=tuple(reasons),
     )

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2290,6 +2290,33 @@ def _s19_final_go_seen_or_fresh(summary: Mapping[str, Any] | None) -> bool:
     return _vision_summary_seen_or_fresh(summary, "fcsmc_final_go_result_visible")
 
 
+def _s08_visual_hint_fact_id_for_target(target: str | None) -> str | None:
+    if target == "left_mdi_pb15":
+        return "supt_page_visible"
+    if target == "left_mdi_pb18":
+        return "tac_page_visible"
+    return None
+
+
+def _visual_fact_ref_from_context(context: Mapping[str, Any], fact_id: str | None) -> str | None:
+    if not isinstance(fact_id, str) or not fact_id:
+        return None
+    vision_facts = context.get("vision_facts")
+    if isinstance(vision_facts, list):
+        for item in vision_facts:
+            if not isinstance(item, Mapping) or item.get("fact_id") != fact_id:
+                continue
+            frame_id = item.get("source_frame_id")
+            return (
+                f"VISION_FACTS.{fact_id}@{frame_id}"
+                if isinstance(frame_id, str) and frame_id
+                else f"VISION_FACTS.{fact_id}"
+            )
+    if _vision_summary_seen_or_fresh(context.get("vision_fact_summary"), fact_id):
+        return f"VISION_FACTS.{fact_id}"
+    return None
+
+
 def _build_procedural_action_hint(
     *,
     inferred_step_id: str | None,
@@ -4966,6 +4993,22 @@ class LiveDcsTutorLoop:
                 vision_fresh_fact_ids = [item for item in raw_fresh if isinstance(item, str) and item]
 
         action_hint = hint.get("action_hint")
+        visual_action_hint = hint.get("visual_action_hint")
+        s08_visual_hint_target: str | None = None
+        s08_visual_hint_ref: str | None = None
+        s08_visual_hint_used = False
+        if inferred_step_id == "S08" and isinstance(visual_action_hint, Mapping):
+            visual_target = visual_action_hint.get("target")
+            if isinstance(visual_target, str) and visual_target:
+                action_hint = visual_action_hint
+                s08_visual_hint_target = visual_target
+                s08_visual_hint_used = True
+                s08_visual_hint_ref = _visual_fact_ref_from_context(
+                    context,
+                    _s08_visual_hint_fact_id_for_target(visual_target),
+                )
+                if isinstance(s08_visual_hint_ref, str) and s08_visual_hint_ref:
+                    evidence_refs = [s08_visual_hint_ref]
         manual_text_guidance_rules: list[HarnessTextGuidanceRule] = []
         missing_conditions = hint.get("missing_conditions")
         missing_set = {
@@ -5059,6 +5102,15 @@ class LiveDcsTutorLoop:
             "text_only": plan.text_only,
             "source": plan.final_action_plan_source,
         }
+        if s08_visual_hint_used:
+            response.metadata["visual_hint_target"] = s08_visual_hint_target
+            if isinstance(s08_visual_hint_ref, str) and s08_visual_hint_ref:
+                response.metadata["visual_hint_evidence_ref"] = s08_visual_hint_ref
+            if plan.repair_applied:
+                response.metadata["s08_visual_hint_repair_applied"] = True
+            if plan.rejected_model_targets:
+                response.metadata["rejected_model_targets"] = list(plan.rejected_model_targets)
+                response.metadata["rejected_model_target"] = plan.rejected_model_targets[0]
         if isinstance(plan.rejected_model_step_id, str) and plan.rejected_model_step_id:
             response.metadata["rejected_model_step_id"] = plan.rejected_model_step_id
         elif "rejected_model_step_id" in response.metadata:

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -233,3 +233,33 @@ def test_plan_harness_action_rejects_overlay_for_disabled_spec_even_with_unrelat
     assert plan.targets == ()
     assert plan.validator_rejected is True
     assert "target_not_allowed:battery_switch" in plan.reasons
+
+
+def test_plan_harness_action_records_rejected_target_when_action_hint_repairs_s08() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S08": _spec(
+                "S08",
+                ("left_mdi_brightness_selector", "left_mdi_pb18", "left_mdi_pb15"),
+            )
+        },
+        inferred_step_id="S08",
+        model_step_id="S08",
+        proposed_overlay_targets=["left_mdi_brightness_selector"],
+        candidate_step_ids=["S08"],
+        runtime_overlay_targets=["left_mdi_brightness_selector", "left_mdi_pb18", "left_mdi_pb15"],
+        request_overlay_targets=["left_mdi_brightness_selector", "left_mdi_pb18", "left_mdi_pb15"],
+        allowed_evidence_refs=["VISION_FACTS.supt_page_visible@frame-1"],
+        evidence_refs=["VISION_FACTS.supt_page_visible@frame-1"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["supt_page_visible", "bit_root_page_visible"],
+        action_hint={"target": "left_mdi_pb15", "reason": "SUPT is visible; press PB15."},
+        action_hint_step_ids=["S08"],
+    )
+
+    assert plan.targets == ("left_mdi_pb15",)
+    assert plan.repair_applied is True
+    assert plan.validator_rejected is True
+    assert plan.final_action_plan_source == "validator_action_hint"
+    assert plan.rejected_model_targets == ("left_mdi_brightness_selector",)
+    assert "action_hint_target_mismatch:left_mdi_brightness_selector" in plan.reasons

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -3752,6 +3752,200 @@ def test_visual_action_hint_does_not_override_existing_model_action(tmp_path: Pa
         loop.close()
 
 
+def test_harness_validation_repairs_s08_selector_to_supt_visual_hint(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s08_visual_hint_repairs_selector_to_pb15.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "overlay_target_allowlist": list(loop.overlay_allowlist),
+                "gates": [
+                    {"gate_id": "S08.completion", "status": "blocked", "reason": "FCS page is not visible."},
+                    {"gate_id": "S08.precondition", "status": "allowed"},
+                ],
+                "vision_facts": [
+                    {"fact_id": "supt_page_visible", "state": "seen", "source_frame_id": "frame-supt"},
+                    {"fact_id": "bit_root_page_visible", "state": "seen", "source_frame_id": "frame-bit"},
+                    {"fact_id": "fcs_page_visible", "state": "not_seen", "source_frame_id": "frame-fcs"},
+                ],
+                "vision_fact_summary": {
+                    "status": "available",
+                    "seen_fact_ids": ["bit_root_page_visible", "supt_page_visible"],
+                    "fresh_fact_ids": ["bit_root_page_visible", "supt_page_visible"],
+                    "not_seen_fact_ids": ["fcs_page_visible"],
+                    "uncertain_fact_ids": [],
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S08",
+                    "overlay_step_id": "S08",
+                    "missing_conditions": ["vision_facts.fcs_page_visible==seen"],
+                    "gate_blockers": [],
+                    "observability_status": "observable",
+                    "step_evidence_requirements": ["visual", "gate"],
+                    "visual_action_hint": {
+                        "target": "left_mdi_pb15",
+                        "reason": "SUPT is visible; press PB15 to enter FCS.",
+                    },
+                },
+                "rag_topk": [],
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="Use the left MDI to navigate to FCS.",
+            actions=[
+                {
+                    "type": "overlay",
+                    "intent": "highlight",
+                    "target": "left_mdi_brightness_selector",
+                    "element_id": "pnt_51",
+                }
+            ],
+            explanations=["Use the left MDI to navigate to FCS."],
+            metadata={
+                "help_response": {
+                    "diagnosis": {"step_id": "S08", "error_category": "OM"},
+                    "next": {"step_id": "S08"},
+                    "overlay": {
+                        "targets": ["left_mdi_brightness_selector"],
+                        "evidence": [
+                            {
+                                "target": "left_mdi_brightness_selector",
+                                "type": "visual",
+                                "ref": "VISION_FACTS.supt_page_visible@frame-supt",
+                                "quote": "SUPT visible.",
+                                "grounding_confidence": 0.9,
+                            }
+                        ],
+                    },
+                    "explanations": ["Use the left MDI to navigate to FCS."],
+                }
+            },
+        )
+
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "deterministic_step:S08"
+        assert [action["target"] for action in response.actions] == ["left_mdi_pb15"]
+        assert response.metadata["s08_visual_hint_repair_applied"] is True
+        assert response.metadata["rejected_model_target"] == "left_mdi_brightness_selector"
+        assert response.metadata["visual_hint_target"] == "left_mdi_pb15"
+        assert response.metadata["final_action_plan_source"] == "validator_action_hint"
+        assert response.metadata["help_response"]["overlay"]["evidence"][0]["ref"] == (
+            "VISION_FACTS.supt_page_visible@frame-supt"
+        )
+    finally:
+        loop.close()
+
+
+def test_harness_validation_repairs_s08_selector_to_tac_visual_hint(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s08_visual_hint_repairs_selector_to_pb18.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "overlay_target_allowlist": list(loop.overlay_allowlist),
+                "gates": [
+                    {"gate_id": "S08.completion", "status": "blocked", "reason": "FCS page is not visible."},
+                    {"gate_id": "S08.precondition", "status": "allowed"},
+                ],
+                "vision_facts": [
+                    {"fact_id": "tac_page_visible", "state": "seen", "source_frame_id": "frame-tac"},
+                    {"fact_id": "bit_root_page_visible", "state": "seen", "source_frame_id": "frame-bit"},
+                    {"fact_id": "fcs_page_visible", "state": "not_seen", "source_frame_id": "frame-fcs"},
+                ],
+                "vision_fact_summary": {
+                    "status": "available",
+                    "seen_fact_ids": ["bit_root_page_visible", "tac_page_visible"],
+                    "fresh_fact_ids": ["bit_root_page_visible", "tac_page_visible"],
+                    "not_seen_fact_ids": ["fcs_page_visible"],
+                    "uncertain_fact_ids": ["supt_page_visible"],
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S08",
+                    "overlay_step_id": "S08",
+                    "missing_conditions": ["vision_facts.fcs_page_visible==seen"],
+                    "gate_blockers": [],
+                    "observability_status": "observable",
+                    "step_evidence_requirements": ["visual", "gate"],
+                    "visual_action_hint": {
+                        "target": "left_mdi_pb18",
+                        "reason": "TAC is visible; press PB18 to reach SUPT.",
+                    },
+                },
+                "rag_topk": [],
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="Use the left MDI to navigate to FCS.",
+            actions=[
+                {
+                    "type": "overlay",
+                    "intent": "highlight",
+                    "target": "left_mdi_brightness_selector",
+                    "element_id": "pnt_51",
+                }
+            ],
+            explanations=["Use the left MDI to navigate to FCS."],
+            metadata={
+                "help_response": {
+                    "diagnosis": {"step_id": "S08", "error_category": "OM"},
+                    "next": {"step_id": "S08"},
+                    "overlay": {
+                        "targets": ["left_mdi_brightness_selector"],
+                        "evidence": [
+                            {
+                                "target": "left_mdi_brightness_selector",
+                                "type": "visual",
+                                "ref": "VISION_FACTS.tac_page_visible@frame-tac",
+                                "quote": "TAC visible.",
+                                "grounding_confidence": 0.9,
+                            }
+                        ],
+                    },
+                    "explanations": ["Use the left MDI to navigate to FCS."],
+                }
+            },
+        )
+
+        used, _reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert [action["target"] for action in response.actions] == ["left_mdi_pb18"]
+        assert response.metadata["s08_visual_hint_repair_applied"] is True
+        assert response.metadata["rejected_model_target"] == "left_mdi_brightness_selector"
+        assert response.metadata["visual_hint_target"] == "left_mdi_pb18"
+        assert response.metadata["help_response"]["overlay"]["evidence"][0]["ref"] == (
+            "VISION_FACTS.tac_page_visible@frame-tac"
+        )
+    finally:
+        loop.close()
+
+
 def test_s08_dual_visual_missing_overrides_model_left_nav_to_right_display_recovery(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_s08_dual_visual_missing_model_left_nav.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])


### PR DESCRIPTION
## Summary
- enforce S08 visual_action_hint through the harness validator/action planner
- repair conflicting model overlay targets to PB15/PB18 for SUPT/TAC page states
- record rejected model targets and visual hint metadata for audit traces

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k "s08 or visual_action_hint or harness_validation"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_evidence_refs.py tests/test_prompting.py -k "visual_action_hint or evidence_refs or s08"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #293