### PR TITLE
Fix DCS multi-target overlay slots

### DIFF
--- a/DCS/Scripts/Hooks/SimTutorHighlight.lua
+++ b/DCS/Scripts/Hooks/SimTutorHighlight.lua
@@ -79,6 +79,9 @@ local function normalize_hilite_ids(raw, fallback_id)
   end
   if #ids == 0 and type(fallback_id) == "number" and fallback_id >= 0 then
     ids[1] = math.floor(fallback_id)
+    ids[2] = math.floor(fallback_id) + 1
+    ids[3] = math.floor(fallback_id) + 2
+    ids[4] = math.floor(fallback_id) + 3
   end
   return ids
 end

--- a/Doc/Vision/fa18c_composite_panel_ZH_v2.md
+++ b/Doc/Vision/fa18c_composite_panel_ZH_v2.md
@@ -134,6 +134,7 @@ VR 使用补充：
   - 这里是 v0.4 组合面板最小模板，包含 `caps.vlm_frame = true`
   - 也包含 `vision.output_root`、`layout_id`、`channel`、背景色和推荐输出分辨率
   - 现在也包含 `overlay.command_host/command_port/ack_host/ack_port`，默认仍是单机 `127.0.0.1`
+  - 启用多目标 overlay（例如 Python 使用 `--max-overlay-targets 2`）时，这里必须包含 `overlay.hilite_ids = {9101, 9102, 9103, 9104}` 或更多 ID；旧配置如果只有 `overlay.hilite_id = 9101`，请重新运行安装器更新 DCS hook/config
 - `Saved Games/<DCS variant>/Config/MonitorSetup/SimTutor_FA18C_CompositePanel_v1.lua`
   - 这是 DCS 原生视口导出排版文件
 
@@ -293,6 +294,7 @@ python live_dcs.py \
   - `vision.layout_id = "fa18c_composite_panel_v2"`
   - `overlay.command_host = "127.0.0.1"`（默认单机）
   - `overlay.ack_host = "127.0.0.1"`（默认单机）
+  - `overlay.hilite_ids = {9101, 9102, 9103, 9104}`（多目标高亮需要至少两个槽位）
 
 ### 2. DCS Options
 

--- a/adapters/dcs/overlay/config.py
+++ b/adapters/dcs/overlay/config.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DcsOverlayConfigInspection:
+    config_path: Path
+    exists: bool
+    hilite_id: int | None = None
+    hilite_ids: tuple[int, ...] = ()
+    hilite_ids_declared: bool = False
+
+    @property
+    def declared_slot_count(self) -> int:
+        if self.hilite_ids_declared:
+            return len(self.hilite_ids)
+        return 1 if self.hilite_id is not None else 0
+
+
+def default_simtutor_config_path(*, dcs_variant: str = "DCS") -> Path:
+    return Path.home() / "Saved Games" / dcs_variant / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
+
+
+def simtutor_config_path_from_saved_games_dir(saved_games_dir: str | Path | None) -> Path | None:
+    if saved_games_dir is None:
+        return None
+    return Path(saved_games_dir).expanduser() / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
+
+
+def _strip_line_comments(text: str) -> str:
+    return re.sub(r"--[^\r\n]*", "", text)
+
+
+def _find_named_table(text: str, name: str) -> str | None:
+    match = re.search(rf"\b{re.escape(name)}\s*=\s*{{", text)
+    if not match:
+        return None
+    start = text.find("{", match.start())
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for idx in range(start, len(text)):
+        char = text[idx]
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char == "{":
+            depth += 1
+            continue
+        if char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start + 1 : idx]
+    return None
+
+
+def _parse_nonnegative_int(value: str) -> int | None:
+    parsed = int(value)
+    return parsed if parsed >= 0 else None
+
+
+def _parse_hilite_id(overlay_block: str) -> int | None:
+    match = re.search(r"\bhilite_id\s*=\s*(-?\d+)", overlay_block)
+    if not match:
+        return None
+    return _parse_nonnegative_int(match.group(1))
+
+
+def _parse_hilite_ids(overlay_block: str) -> tuple[int, ...]:
+    raw_table = _find_named_table(overlay_block, "hilite_ids")
+    if raw_table is None:
+        return ()
+    seen: set[int] = set()
+    ids: list[int] = []
+    for raw_entry in raw_table.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        keyed_match = re.fullmatch(r"\[\s*-?\d+\s*\]\s*=\s*(-?\d+)", entry)
+        if keyed_match:
+            raw_value = keyed_match.group(1)
+        elif "=" in entry:
+            continue
+        else:
+            raw_value = entry
+        if not re.fullmatch(r"-?\d+", raw_value.strip()):
+            continue
+        value = _parse_nonnegative_int(raw_value.strip())
+        if value is not None and value not in seen:
+            seen.add(value)
+            ids.append(value)
+    return tuple(ids)
+
+
+def inspect_overlay_config(config_path: Path) -> DcsOverlayConfigInspection:
+    config_path = Path(config_path)
+    if not config_path.exists():
+        return DcsOverlayConfigInspection(config_path=config_path, exists=False)
+
+    try:
+        text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        return DcsOverlayConfigInspection(config_path=config_path, exists=True)
+
+    text = _strip_line_comments(text)
+    overlay_block = _find_named_table(text, "overlay")
+    if overlay_block is None:
+        return DcsOverlayConfigInspection(config_path=config_path, exists=True)
+
+    hilite_ids_declared = re.search(r"\bhilite_ids\s*=", overlay_block) is not None
+    return DcsOverlayConfigInspection(
+        config_path=config_path,
+        exists=True,
+        hilite_id=_parse_hilite_id(overlay_block),
+        hilite_ids=_parse_hilite_ids(overlay_block),
+        hilite_ids_declared=hilite_ids_declared,
+    )
+
+
+def build_multi_target_overlay_config_warning(
+    *,
+    max_overlay_targets: int,
+    config_path: Path | None = None,
+) -> str | None:
+    requested_slots = max(0, int(max_overlay_targets))
+    if requested_slots <= 1:
+        return None
+
+    effective_config_path = config_path or default_simtutor_config_path()
+    inspection = inspect_overlay_config(effective_config_path)
+    if not inspection.exists:
+        return None
+
+    declared_slots = inspection.declared_slot_count
+    if declared_slots >= requested_slots:
+        return None
+
+    slot_word = "slot" if declared_slots == 1 else "slots"
+    return (
+        f"--max-overlay-targets={requested_slots} requested, but {inspection.config_path} "
+        f"declares only {declared_slots} DCS highlight {slot_word}. "
+        "Update the installed DCS hook/config so overlay.hilite_ids contains enough IDs, "
+        "for example by rerunning python -m tools.install_dcs_hook --install-composite-panel."
+    )

--- a/docs/wiki/dcs-live-operation.md
+++ b/docs/wiki/dcs-live-operation.md
@@ -30,6 +30,12 @@ python -m tools.install_dcs_hook \
   --saved-games-dir "<saved-games-dir>"
 ```
 
+Re-run this installer after enabling multi-target overlay, for example when using
+`--max-overlay-targets 2`. The generated `SimTutorConfig.lua` must contain
+`overlay.hilite_ids = {9101, 9102, 9103, 9104}` or more IDs; legacy configs with only
+`overlay.hilite_id = 9101` expose a single DCS highlight slot and can make the
+last target replace the first visible highlight.
+
 Single-monitor example:
 
 ```bash

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -21,6 +21,10 @@ from uuid import UUID, uuid4
 import yaml
 
 from adapters.action_executor import OverlayActionExecutor
+from adapters.dcs.overlay.config import (
+    build_multi_target_overlay_config_warning,
+    simtutor_config_path_from_saved_games_dir,
+)
 from adapters.dcs_bios.bios_ui_map import BiosUiMapper
 from adapters.dcs_bios.receiver import DcsBiosRawReceiver, DcsBiosReceiver
 from adapters.dcs.tutor_text import DcsTutorTextSender
@@ -2999,6 +3003,36 @@ class UdpVisionCaptureNotifier:
             self._sock.close()
         except OSError:
             pass
+
+
+def _emit_multi_target_overlay_config_warning(
+    *,
+    max_overlay_targets: int,
+    config_path: Path | None = None,
+    event_sink: Callable[[Event], None] | None = None,
+    prefix: str = "[LIVE_DCS]",
+) -> str | None:
+    warning = build_multi_target_overlay_config_warning(
+        max_overlay_targets=max_overlay_targets,
+        config_path=config_path,
+    )
+    if warning is None:
+        return None
+
+    print(f"{prefix} WARNING: {warning}")
+    if event_sink is not None:
+        event_sink(
+            Event(
+                kind="system",
+                payload={
+                    "event": "overlay_config_warning",
+                    "warning": warning,
+                    "max_overlay_targets": max(0, int(max_overlay_targets)),
+                    "config_path": str(config_path) if config_path is not None else None,
+                },
+            )
+        )
+    return warning
 
 
 class LiveDcsTutorLoop:
@@ -7126,6 +7160,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "resolved_output_path": str(output),
                 },
             )
+        )
+        _emit_multi_target_overlay_config_warning(
+            max_overlay_targets=max(0, int(args.max_overlay_targets)),
+            config_path=simtutor_config_path_from_saved_games_dir(args.vision_saved_games_dir),
+            event_sink=store.append,
         )
         executor = OverlayActionExecutor(
             ui_map_path=args.ui_map,

--- a/simtutor/__main__.py
+++ b/simtutor/__main__.py
@@ -143,7 +143,9 @@ def _run_replay_bios(args: argparse.Namespace) -> int:
         StdinHelpTrigger,
         UdpHelpTrigger,
         _build_vision_port_from_args,
+        _emit_multi_target_overlay_config_warning,
     )
+    from adapters.dcs.overlay.config import simtutor_config_path_from_saved_games_dir
 
     output = Path(args.output) if args.output else _new_replay_bios_log_path()
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -163,6 +165,13 @@ def _run_replay_bios(args: argparse.Namespace) -> int:
             mode="replay",
         )
         with JsonlEventStore(output, mode="w") as store:
+            if not bool(args.dry_run_overlay):
+                _emit_multi_target_overlay_config_warning(
+                    max_overlay_targets=max(0, int(args.max_overlay_targets)),
+                    config_path=simtutor_config_path_from_saved_games_dir(args.vision_saved_games_dir),
+                    event_sink=store.append,
+                    prefix="[REPLAY_BIOS]",
+                )
             with OverlayActionExecutor(
                 ui_map_path=args.ui_map,
                 pack_path=args.pack,

--- a/tests/adapters/test_dcs_overlay_config.py
+++ b/tests/adapters/test_dcs_overlay_config.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from adapters.dcs.overlay.config import (
+    build_multi_target_overlay_config_warning,
+    inspect_overlay_config,
+)
+
+
+def test_inspect_overlay_config_detects_legacy_single_hilite_id(tmp_path: Path) -> None:
+    config_path = tmp_path / "SimTutorConfig.lua"
+    config_path.write_text(
+        "return {\n"
+        "    overlay = {\n"
+        "        command_host = \"127.0.0.1\",\n"
+        "        hilite_id = 9101,\n"
+        "    },\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    inspection = inspect_overlay_config(config_path)
+
+    assert inspection.exists is True
+    assert inspection.hilite_id == 9101
+    assert inspection.hilite_ids == ()
+    assert inspection.declared_slot_count == 1
+
+
+def test_multi_target_overlay_warning_flags_stale_single_slot_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "SimTutorConfig.lua"
+    config_path.write_text(
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_id = 9101,\n"
+        "    },\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    warning = build_multi_target_overlay_config_warning(
+        max_overlay_targets=2,
+        config_path=config_path,
+    )
+
+    assert warning is not None
+    assert "--max-overlay-targets=2" in warning
+    assert "only 1 DCS highlight slot" in warning
+    assert "overlay.hilite_ids" in warning
+    assert "tools.install_dcs_hook" in warning
+
+
+def test_multi_target_overlay_warning_flags_explicit_single_slot_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "SimTutorConfig.lua"
+    config_path.write_text(
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_id = 9101,\n"
+        "        hilite_ids = {9101},\n"
+        "    },\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    warning = build_multi_target_overlay_config_warning(
+        max_overlay_targets=2,
+        config_path=config_path,
+    )
+
+    assert warning is not None
+    assert "only 1 DCS highlight slot" in warning
+
+
+def test_inspect_overlay_config_counts_numeric_keyed_hilite_ids_as_values(tmp_path: Path) -> None:
+    config_path = tmp_path / "SimTutorConfig.lua"
+    config_path.write_text(
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_ids = {[1] = 9101, [2] = 9102},\n"
+        "    },\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    inspection = inspect_overlay_config(config_path)
+
+    assert inspection.hilite_ids == (9101, 9102)
+    assert inspection.declared_slot_count == 2
+
+
+def test_multi_target_overlay_warning_accepts_explicit_two_slot_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "SimTutorConfig.lua"
+    config_path.write_text(
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_id = 9101,\n"
+        "        hilite_ids = {9101, 9102},\n"
+        "    },\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    warning = build_multi_target_overlay_config_warning(
+        max_overlay_targets=2,
+        config_path=config_path,
+    )
+
+    assert warning is None

--- a/tests/test_install_dcs_hook.py
+++ b/tests/test_install_dcs_hook.py
@@ -21,6 +21,23 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _write_repo_scripting_files(
+    repo_root: Path,
+    *,
+    include_function: bool = True,
+    include_hook: bool = True,
+) -> None:
+    simtutor_dir = repo_root / "DCS" / "Scripts" / "SimTutor"
+    _write(simtutor_dir / "SimTutor.lua", "-- SimTutor main\n")
+    if include_function:
+        _write(simtutor_dir / "SimTutor Function.lua", "-- SimTutor functions\n")
+    if include_hook:
+        _write(
+            repo_root / "DCS" / "Scripts" / "Hooks" / "SimTutorHighlight.lua",
+            "-- SimTutor highlight hook\n",
+        )
+
+
 def test_patch_export_appends_line(tmp_path: Path) -> None:
     export_path = tmp_path / "Export.lua"
     original = "pcall(function() local TheWayLfs=require('lfs');dofile(TheWayLfs.writedir()..'Scripts/TheWay/TheWay.lua'); end)\n"
@@ -66,9 +83,7 @@ def test_patch_export_creates_when_missing(tmp_path: Path) -> None:
 
 def test_run_install_copies_and_export(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    simtutor_dir = repo_root / "DCS" / "Scripts" / "SimTutor"
-    _write(simtutor_dir / "SimTutor.lua", "-- SimTutor main\n")
-    _write(simtutor_dir / "SimTutor Function.lua", "-- SimTutor functions\n")
+    _write_repo_scripting_files(repo_root)
 
     saved_games_dir = tmp_path / "Saved Games" / "DCS"
     export_path = saved_games_dir / "Scripts" / "Export.lua"
@@ -85,6 +100,7 @@ def test_run_install_copies_and_export(tmp_path: Path) -> None:
     assert result.export_backup is not None
     assert (saved_games_dir / "Scripts" / "SimTutor" / "SimTutor.lua").exists()
     assert (saved_games_dir / "Scripts" / "SimTutor" / "SimTutor Function.lua").exists()
+    assert (saved_games_dir / "Scripts" / "Hooks" / "SimTutorHighlight.lua").exists()
 
     content = export_path.read_text(encoding="utf-8")
     assert SIMTUTOR_EXPORT_SNIPPET in content
@@ -101,9 +117,7 @@ def test_run_install_missing_source_dir_raises(tmp_path: Path) -> None:
 
 def test_run_install_no_export_copies_only(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    simtutor_dir = repo_root / "DCS" / "Scripts" / "SimTutor"
-    _write(simtutor_dir / "SimTutor.lua", "-- SimTutor main\n")
-    _write(simtutor_dir / "SimTutor Function.lua", "-- SimTutor functions\n")
+    _write_repo_scripting_files(repo_root)
 
     saved_games_dir = tmp_path / "Saved Games" / "DCS"
     result = run_install(
@@ -119,8 +133,7 @@ def test_run_install_no_export_copies_only(tmp_path: Path) -> None:
 
 def test_install_scripting_files_missing_one_file_raises(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    simtutor_dir = repo_root / "DCS" / "Scripts" / "SimTutor"
-    _write(simtutor_dir / "SimTutor.lua", "-- SimTutor main\n")
+    _write_repo_scripting_files(repo_root, include_function=False)
     saved_games_dir = tmp_path / "Saved Games" / "DCS"
 
     with pytest.raises(FileNotFoundError, match="SimTutor Function.lua"):
@@ -148,7 +161,7 @@ def test_build_composite_panel_config_enables_vlm_frame_and_frames_root(tmp_path
     assert "ack_port = 7782" in config
     assert "auto_clear = true" in config
     assert "hilite_id = 9101" in config
-    assert "hilite_ids = {9101, 9102}" in config
+    assert "hilite_ids = {9101, 9102, 9103, 9104}" in config
     assert 'host = "127.0.0.1"' in config
     assert "port = 7783" in config
     # Verify these host/port assertions are scoped to the tutor_text block,
@@ -177,7 +190,16 @@ def test_build_composite_panel_config_supports_custom_overlay_transport(tmp_path
     assert "ack_port = 9002" in config
     assert "auto_clear = false" in config
     assert "hilite_id = 9200" in config
-    assert "hilite_ids = {9200, 9201}" in config
+    assert "hilite_ids = {9200, 9201, 9202, 9203}" in config
+
+
+def test_dcs_highlight_hook_backfills_default_slots_for_legacy_config() -> None:
+    hook_path = Path(__file__).resolve().parents[1] / "DCS" / "Scripts" / "Hooks" / "SimTutorHighlight.lua"
+    hook_text = hook_path.read_text(encoding="utf-8")
+
+    assert "ids[1] = math.floor(fallback_id)" in hook_text
+    assert "ids[2] = math.floor(fallback_id) + 1" in hook_text
+    assert "ids[4] = math.floor(fallback_id) + 3" in hook_text
 
 
 def test_build_composite_panel_config_converts_wsl_mount_output_root_to_windows_path() -> None:
@@ -204,11 +226,29 @@ def test_install_composite_panel_config_is_idempotent(tmp_path: Path) -> None:
     assert 'vlm_frame = true' in first.path.read_text(encoding="utf-8")
 
 
+def test_install_composite_panel_config_updates_legacy_overlay_slots(tmp_path: Path) -> None:
+    saved_games_dir = tmp_path / "Saved Games" / "DCS"
+    config_path = saved_games_dir / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
+    _write(
+        config_path,
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_id = 9101,\n"
+        "    },\n"
+        "}\n",
+    )
+
+    result = install_composite_panel_config(saved_games_dir=saved_games_dir)
+
+    assert result.changed is True
+    config = config_path.read_text(encoding="utf-8")
+    assert "hilite_id = 9101" in config
+    assert "hilite_ids = {9101, 9102, 9103, 9104}" in config
+
+
 def test_run_install_can_deploy_composite_panel_baseline_and_monitor_setup(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    simtutor_dir = repo_root / "DCS" / "Scripts" / "SimTutor"
-    _write(simtutor_dir / "SimTutor.lua", "-- SimTutor main\n")
-    _write(simtutor_dir / "SimTutor Function.lua", "-- SimTutor functions\n")
+    _write_repo_scripting_files(repo_root)
 
     saved_games_dir = tmp_path / "Saved Games" / "DCS"
     result = run_install(
@@ -237,9 +277,7 @@ def test_run_install_can_deploy_composite_panel_baseline_and_monitor_setup(tmp_p
 
 def test_run_install_can_auto_detect_resolution_for_composite_panel(monkeypatch, tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    simtutor_dir = repo_root / "DCS" / "Scripts" / "SimTutor"
-    _write(simtutor_dir / "SimTutor.lua", "-- SimTutor main\n")
-    _write(simtutor_dir / "SimTutor Function.lua", "-- SimTutor functions\n")
+    _write_repo_scripting_files(repo_root)
     monkeypatch.setattr("tools.install_dcs_monitor_setup.detect_main_resolution", lambda: (3440, 1440))
 
     result = run_install(
@@ -260,9 +298,7 @@ def test_run_install_can_auto_detect_resolution_for_composite_panel(monkeypatch,
 
 def test_run_install_rejects_partial_monitor_dimensions_for_composite_panel(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
-    simtutor_dir = repo_root / "DCS" / "Scripts" / "SimTutor"
-    _write(simtutor_dir / "SimTutor.lua", "-- SimTutor main\n")
-    _write(simtutor_dir / "SimTutor Function.lua", "-- SimTutor functions\n")
+    _write_repo_scripting_files(repo_root)
 
     with pytest.raises(ValueError, match="main_width and main_height must be provided together"):
         run_install(

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -44,6 +44,7 @@ from live_dcs import (
     _normalize_cached_response_metadata,
     _path_like_to_uri,
     _prefer_navigation_target_from_vision_context,
+    _emit_multi_target_overlay_config_warning,
     _resolve_overlay_step_id,
     _resolve_step_overlay_allowlist,
     _sanitize_request_payload_for_event,
@@ -5652,6 +5653,38 @@ def test_live_dcs_cli_print_model_io_invalid_env_falls_back_false_with_warning(m
         "SIMTUTOR_PRINT_MODEL_IO" in record.message and "Invalid boolean environment value" in record.message
         for record in caplog.records
     )
+
+
+def test_live_dcs_warns_when_multi_target_overlay_uses_single_slot_config(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    config_path = tmp_path / "Saved Games" / "DCS" / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_id = 9101,\n"
+        "    },\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    events: list[Any] = []
+
+    warning = _emit_multi_target_overlay_config_warning(
+        max_overlay_targets=2,
+        config_path=config_path,
+        event_sink=events.append,
+    )
+
+    captured = capsys.readouterr()
+    assert warning is not None
+    assert "[LIVE_DCS] WARNING:" in captured.out
+    assert "only 1 DCS highlight slot" in captured.out
+    assert len(events) == 1
+    assert events[0].kind == "system"
+    assert events[0].payload["event"] == "overlay_config_warning"
+    assert events[0].payload["max_overlay_targets"] == 2
 
 
 def test_live_dcs_cli_cold_start_production_reads_env_default(monkeypatch) -> None:

--- a/tests/test_replay_bios_cli.py
+++ b/tests/test_replay_bios_cli.py
@@ -221,6 +221,60 @@ def test_cli_replay_bios_udp_help_generates_help_cycle_and_dry_run_overlay(monke
     assert "overlay_dry_run" in kinds
 
 
+def test_cli_replay_bios_warns_for_single_slot_config_when_overlay_enabled(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    replay_path = tmp_path / "bios_cli_replay_empty.jsonl"
+    replay_path.write_text("", encoding="utf-8")
+    output_path = tmp_path / "replay_warning.jsonl"
+    saved_games_dir = tmp_path / "Saved Games" / "DCS"
+    config_path = saved_games_dir / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_id = 9101,\n"
+        "    },\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "adapters.action_executor.DcsOverlaySender",
+        lambda **_kwargs: type("DummySender", (), {"close": lambda self: None})(),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "simtutor",
+            "replay-bios",
+            "--input",
+            str(replay_path),
+            "--output",
+            str(output_path),
+            "--vision-saved-games-dir",
+            str(saved_games_dir),
+            "--session-id",
+            "sess-replay-warning",
+            "--max-overlay-targets",
+            "2",
+            "--no-dry-run-overlay",
+        ],
+    )
+
+    code = main()
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "[REPLAY_BIOS] WARNING:" in captured.out
+    events = JsonlEventStore.load(output_path)
+    warning_event = next(event for event in events if event["payload"].get("event") == "overlay_config_warning")
+    assert warning_event["payload"]["max_overlay_targets"] == 2
+    assert warning_event["payload"]["config_path"] == str(config_path)
+
+
 def test_cli_replay_bios_wires_noop_tutor_text_sender_into_loop(monkeypatch, tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_cli_sender.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])

--- a/tools/install_dcs_hook.py
+++ b/tools/install_dcs_hook.py
@@ -30,6 +30,7 @@ DEFAULT_OVERLAY_ACK_HOST = "127.0.0.1"
 DEFAULT_OVERLAY_ACK_PORT = 7782
 DEFAULT_TUTOR_TEXT_HOST = "127.0.0.1"
 DEFAULT_TUTOR_TEXT_PORT = 7783
+DEFAULT_OVERLAY_HILITE_SLOT_COUNT = 4
 
 
 @dataclass(frozen=True)
@@ -141,6 +142,7 @@ def build_composite_panel_config(
     overlay_ack_port: int = DEFAULT_OVERLAY_ACK_PORT,
     overlay_auto_clear: bool = True,
     overlay_hilite_id: int = 9101,
+    overlay_hilite_slot_count: int = DEFAULT_OVERLAY_HILITE_SLOT_COUNT,
 ) -> str:
     effective_frames_root = (frames_root or _vision_frames_root(saved_games_dir)).expanduser().resolve()
     lua_frames_root = _format_lua_path(effective_frames_root)
@@ -159,6 +161,11 @@ def build_composite_panel_config(
         raise ValueError("overlay_ack_port must be positive")
     if overlay_hilite_id < 0:
         raise ValueError("overlay_hilite_id must be non-negative")
+    if overlay_hilite_slot_count <= 0:
+        raise ValueError("overlay_hilite_slot_count must be positive")
+    overlay_hilite_ids = ", ".join(
+        str(int(overlay_hilite_id) + idx) for idx in range(int(overlay_hilite_slot_count))
+    )
 
     lines = [
         "-- SimTutor composite-panel baseline for v0.4 vision bring-up.",
@@ -188,7 +195,7 @@ def build_composite_panel_config(
         f"        ack_port = {int(overlay_ack_port)},",
         f"        auto_clear = {'true' if overlay_auto_clear else 'false'},",
         f"        hilite_id = {int(overlay_hilite_id)},",
-        f"        hilite_ids = {{{int(overlay_hilite_id)}, {int(overlay_hilite_id) + 1}}},",
+        f"        hilite_ids = {{{overlay_hilite_ids}}},",
         "    },",
         "    tutor_text = {",
         f'        host = "{DEFAULT_TUTOR_TEXT_HOST}",',
@@ -239,6 +246,7 @@ def install_composite_panel_config(
     overlay_ack_port: int = DEFAULT_OVERLAY_ACK_PORT,
     overlay_auto_clear: bool = True,
     overlay_hilite_id: int = 9101,
+    overlay_hilite_slot_count: int = DEFAULT_OVERLAY_HILITE_SLOT_COUNT,
 ) -> ConfigInstallResult:
     config_path = saved_games_dir / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
     config_text = build_composite_panel_config(
@@ -256,6 +264,7 @@ def install_composite_panel_config(
         overlay_ack_port=overlay_ack_port,
         overlay_auto_clear=overlay_auto_clear,
         overlay_hilite_id=overlay_hilite_id,
+        overlay_hilite_slot_count=overlay_hilite_slot_count,
     )
     _ensure_parent(config_path)
     changed = True
@@ -272,9 +281,14 @@ def install_scripting_files(source_root: Path, saved_games_dir: Path) -> bool:
     source_dir = source_root / "DCS" / "Scripts" / "SimTutor"
     if not source_dir.exists():
         raise FileNotFoundError(f"Missing source dir: {source_dir}")
+    hook_source_dir = source_root / "DCS" / "Scripts" / "Hooks"
+    if not hook_source_dir.exists():
+        raise FileNotFoundError(f"Missing source dir: {hook_source_dir}")
 
     target_dir = saved_games_dir / "Scripts" / "SimTutor"
     target_dir.mkdir(parents=True, exist_ok=True)
+    hook_target_dir = saved_games_dir / "Scripts" / "Hooks"
+    hook_target_dir.mkdir(parents=True, exist_ok=True)
 
     any_copied = False
     for name in ["SimTutor.lua", "SimTutor Function.lua"]:
@@ -282,6 +296,13 @@ def install_scripting_files(source_root: Path, saved_games_dir: Path) -> bool:
         if not src.exists():
             raise FileNotFoundError(f"Missing source file: {src}")
         dst = target_dir / name
+        shutil.copy2(src, dst)
+        any_copied = True
+    for name in ["SimTutorHighlight.lua"]:
+        src = hook_source_dir / name
+        if not src.exists():
+            raise FileNotFoundError(f"Missing source file: {src}")
+        dst = hook_target_dir / name
         shutil.copy2(src, dst)
         any_copied = True
     return any_copied


### PR DESCRIPTION
## Summary
- generate and install four DCS highlight slots by default, matching live max-overlay-targets default
- restore Lua hook legacy fallback to multiple slots and deploy SimTutorHighlight.lua through the installer
- warn live/replay users when a real DCS overlay run points at a single-slot SimTutorConfig.lua
- document the required hilite_ids config and add regression coverage

## Tests
- python3 tools/ci_guard.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/adapters/test_dcs_overlay_config.py tests/test_install_dcs_hook.py tests/test_live_dcs.py::test_live_dcs_warns_when_multi_target_overlay_uses_single_slot_config tests/test_replay_bios_cli.py::test_cli_replay_bios_warns_for_single_slot_config_when_overlay_enabled
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k 'overlay or S09 or s09 or multi_target'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Fixes #295