### PR TITLE
Repair S08 selector from visual evidence refs

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2321,6 +2321,18 @@ def _visual_fact_ref_from_context(context: Mapping[str, Any], fact_id: str | Non
     return None
 
 
+def _s08_visual_hint_from_evidence_refs(evidence_refs: Sequence[str]) -> tuple[str, str] | None:
+    for fact_id, target in (
+        ("supt_page_visible", "left_mdi_pb15"),
+        ("tac_page_visible", "left_mdi_pb18"),
+    ):
+        prefix = f"VISION_FACTS.{fact_id}"
+        for ref in evidence_refs:
+            if isinstance(ref, str) and (ref == prefix or ref.startswith(f"{prefix}@")):
+                return target, ref
+    return None
+
+
 def _build_procedural_action_hint(
     *,
     inferred_step_id: str | None,
@@ -5043,6 +5055,18 @@ class LiveDcsTutorLoop:
                 )
                 if isinstance(s08_visual_hint_ref, str) and s08_visual_hint_ref:
                     evidence_refs = [s08_visual_hint_ref]
+        if inferred_step_id == "S08" and not s08_visual_hint_used:
+            evidence_hint = _s08_visual_hint_from_evidence_refs(evidence_refs)
+            if evidence_hint is not None:
+                evidence_target, evidence_ref = evidence_hint
+                action_hint = {
+                    "target": evidence_target,
+                    "reason": f"Visual evidence {evidence_ref} indicates S08 page navigation.",
+                }
+                s08_visual_hint_target = evidence_target
+                s08_visual_hint_ref = evidence_ref
+                s08_visual_hint_used = True
+                evidence_refs = [evidence_ref]
         manual_text_guidance_rules: list[HarnessTextGuidanceRule] = []
         missing_conditions = hint.get("missing_conditions")
         missing_set = {

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2310,6 +2310,9 @@ def _visual_fact_ref_from_context(context: Mapping[str, Any], fact_id: str | Non
         for item in vision_facts:
             if not isinstance(item, Mapping) or item.get("fact_id") != fact_id:
                 continue
+            state = item.get("state")
+            if isinstance(state, str) and state not in {"seen", "fresh"}:
+                continue
             frame_id = item.get("source_frame_id")
             return (
                 f"VISION_FACTS.{fact_id}@{frame_id}"
@@ -2321,15 +2324,60 @@ def _visual_fact_ref_from_context(context: Mapping[str, Any], fact_id: str | Non
     return None
 
 
-def _s08_visual_hint_from_evidence_refs(evidence_refs: Sequence[str]) -> tuple[str, str] | None:
+def _s08_visual_hint_from_vision_summary(context: Mapping[str, Any]) -> tuple[str, str, str | None] | None:
+    for fact_id, target, reason in (
+        (
+            "supt_page_visible",
+            "left_mdi_pb15",
+            "VLM confirms SUPT is visible; press PB15 to enter the FCS page.",
+        ),
+        (
+            "tac_page_visible",
+            "left_mdi_pb18",
+            "VLM confirms TAC is visible; press PB18 to reach the SUPT page.",
+        ),
+    ):
+        if _vision_summary_seen_or_fresh(context.get("vision_fact_summary"), fact_id):
+            return target, reason, _visual_fact_ref_from_context(context, fact_id)
+    return None
+
+
+def _s08_visual_evidence_ref_for_target(evidence_refs: Sequence[str], target: str | None) -> str | None:
+    fact_id = _s08_visual_hint_fact_id_for_target(target)
+    if fact_id is None:
+        return None
+    prefix = f"VISION_FACTS.{fact_id}"
+    for ref in evidence_refs:
+        if isinstance(ref, str) and (ref == prefix or ref.startswith(f"{prefix}@")):
+            return ref
+    return None
+
+
+def _s08_visual_fact_ref_for_seen_target(
+    context: Mapping[str, Any],
+    evidence_refs: Sequence[str],
+    target: str | None,
+) -> str | None:
+    fact_id = _s08_visual_hint_fact_id_for_target(target)
+    if fact_id is None or not _vision_summary_seen_or_fresh(context.get("vision_fact_summary"), fact_id):
+        return None
+    return _s08_visual_evidence_ref_for_target(evidence_refs, target) or _visual_fact_ref_from_context(context, fact_id)
+
+
+def _s08_visual_hint_from_seen_evidence_refs(
+    context: Mapping[str, Any],
+    evidence_refs: Sequence[str],
+) -> tuple[str, str, str] | None:
     for fact_id, target in (
         ("supt_page_visible", "left_mdi_pb15"),
         ("tac_page_visible", "left_mdi_pb18"),
     ):
+        if not _vision_summary_seen_or_fresh(context.get("vision_fact_summary"), fact_id):
+            continue
         prefix = f"VISION_FACTS.{fact_id}"
         for ref in evidence_refs:
             if isinstance(ref, str) and (ref == prefix or ref.startswith(f"{prefix}@")):
-                return target, ref
+                return target, f"Visual evidence {ref} confirms S08 page navigation.", ref
     return None
 
 
@@ -5049,24 +5097,29 @@ class LiveDcsTutorLoop:
                 action_hint = visual_action_hint
                 s08_visual_hint_target = visual_target
                 s08_visual_hint_used = True
-                s08_visual_hint_ref = _visual_fact_ref_from_context(
+                s08_visual_hint_ref = _s08_visual_fact_ref_for_seen_target(
                     context,
-                    _s08_visual_hint_fact_id_for_target(visual_target),
+                    evidence_refs,
+                    visual_target,
                 )
                 if isinstance(s08_visual_hint_ref, str) and s08_visual_hint_ref:
                     evidence_refs = [s08_visual_hint_ref]
         if inferred_step_id == "S08" and not s08_visual_hint_used:
-            evidence_hint = _s08_visual_hint_from_evidence_refs(evidence_refs)
+            evidence_hint = _s08_visual_hint_from_seen_evidence_refs(context, evidence_refs)
+            summary_hint = _s08_visual_hint_from_vision_summary(context)
+            if evidence_hint is None and summary_hint is not None:
+                evidence_hint = summary_hint
             if evidence_hint is not None:
-                evidence_target, evidence_ref = evidence_hint
+                evidence_target, evidence_reason, evidence_ref = evidence_hint
                 action_hint = {
                     "target": evidence_target,
-                    "reason": f"Visual evidence {evidence_ref} indicates S08 page navigation.",
+                    "reason": evidence_reason,
                 }
                 s08_visual_hint_target = evidence_target
                 s08_visual_hint_ref = evidence_ref
                 s08_visual_hint_used = True
-                evidence_refs = [evidence_ref]
+                if isinstance(evidence_ref, str) and evidence_ref:
+                    evidence_refs = [evidence_ref]
         manual_text_guidance_rules: list[HarnessTextGuidanceRule] = []
         missing_conditions = hint.get("missing_conditions")
         missing_set = {

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2302,6 +2302,10 @@ def _s08_visual_hint_fact_id_for_target(target: str | None) -> str | None:
     return None
 
 
+def _s08_power_condition_missing(missing_set: set[str]) -> bool:
+    return any(f"vars.{var_name}==true" in missing_set for var_name, _target, _reason in _S08_POWER_SEQUENCE)
+
+
 def _visual_fact_ref_from_context(context: Mapping[str, Any], fact_id: str | None) -> str | None:
     if not isinstance(fact_id, str) or not fact_id:
         return None
@@ -2351,6 +2355,30 @@ def _s08_visual_evidence_ref_for_target(evidence_refs: Sequence[str], target: st
         if isinstance(ref, str) and (ref == prefix or ref.startswith(f"{prefix}@")):
             return ref
     return None
+
+
+def _s08_page_navigation_fact_id_from_ref(ref: str) -> str | None:
+    for fact_id in ("supt_page_visible", "tac_page_visible"):
+        prefix = f"VISION_FACTS.{fact_id}"
+        if ref == prefix or ref.startswith(f"{prefix}@"):
+            return fact_id
+    return None
+
+
+def _s08_filter_unconfirmed_page_navigation_refs(
+    context: Mapping[str, Any],
+    evidence_refs: Sequence[str],
+) -> list[str]:
+    filtered: list[str] = []
+    vision_summary = context.get("vision_fact_summary")
+    for ref in evidence_refs:
+        if not isinstance(ref, str) or not ref:
+            continue
+        fact_id = _s08_page_navigation_fact_id_from_ref(ref)
+        if fact_id is not None and not _vision_summary_seen_or_fresh(vision_summary, fact_id):
+            continue
+        filtered.append(ref)
+    return filtered
 
 
 def _s08_visual_fact_ref_for_seen_target(
@@ -5086,25 +5114,37 @@ class LiveDcsTutorLoop:
             if isinstance(raw_fresh, (list, tuple, set)):
                 vision_fresh_fact_ids = [item for item in raw_fresh if isinstance(item, str) and item]
 
+        missing_conditions = hint.get("missing_conditions")
+        missing_set = {
+            item for item in missing_conditions
+            if isinstance(item, str) and item
+        } if isinstance(missing_conditions, (list, tuple)) else set()
+
         action_hint = hint.get("action_hint")
         visual_action_hint = hint.get("visual_action_hint")
         s08_visual_hint_target: str | None = None
         s08_visual_hint_ref: str | None = None
         s08_visual_hint_used = False
-        if inferred_step_id == "S08" and isinstance(visual_action_hint, Mapping):
+        s08_visual_navigation_allowed = (
+            inferred_step_id == "S08"
+            and not _s08_power_condition_missing(missing_set)
+        )
+        if inferred_step_id == "S08":
+            evidence_refs = _s08_filter_unconfirmed_page_navigation_refs(context, evidence_refs)
+        if s08_visual_navigation_allowed and isinstance(visual_action_hint, Mapping):
             visual_target = visual_action_hint.get("target")
             if isinstance(visual_target, str) and visual_target:
-                action_hint = visual_action_hint
-                s08_visual_hint_target = visual_target
-                s08_visual_hint_used = True
                 s08_visual_hint_ref = _s08_visual_fact_ref_for_seen_target(
                     context,
                     evidence_refs,
                     visual_target,
                 )
                 if isinstance(s08_visual_hint_ref, str) and s08_visual_hint_ref:
+                    action_hint = visual_action_hint
+                    s08_visual_hint_target = visual_target
+                    s08_visual_hint_used = True
                     evidence_refs = [s08_visual_hint_ref]
-        if inferred_step_id == "S08" and not s08_visual_hint_used:
+        if s08_visual_navigation_allowed and not s08_visual_hint_used:
             evidence_hint = _s08_visual_hint_from_seen_evidence_refs(context, evidence_refs)
             summary_hint = _s08_visual_hint_from_vision_summary(context)
             if evidence_hint is None and summary_hint is not None:
@@ -5121,11 +5161,6 @@ class LiveDcsTutorLoop:
                 if isinstance(evidence_ref, str) and evidence_ref:
                     evidence_refs = [evidence_ref]
         manual_text_guidance_rules: list[HarnessTextGuidanceRule] = []
-        missing_conditions = hint.get("missing_conditions")
-        missing_set = {
-            item for item in missing_conditions
-            if isinstance(item, str) and item
-        } if isinstance(missing_conditions, (list, tuple)) else set()
         include_s05_manual_guidance = (
             "vars.throttle_r_not_off==true" in missing_set
             or "vars.throttle_r_idle_complete==true" in missing_set

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2381,6 +2381,40 @@ def _s08_filter_unconfirmed_page_navigation_refs(
     return filtered
 
 
+def _s08_clean_unconfirmed_page_navigation_help_response(
+    context: Mapping[str, Any],
+    help_response: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any] | None, bool]:
+    if not isinstance(help_response, Mapping):
+        return None, False
+    overlay = help_response.get("overlay")
+    if not isinstance(overlay, Mapping):
+        return None, False
+    evidence = overlay.get("evidence")
+    if not isinstance(evidence, list):
+        return None, False
+
+    cleaned_evidence: list[Any] = []
+    changed = False
+    vision_summary = context.get("vision_fact_summary")
+    for item in evidence:
+        ref = item.get("ref") if isinstance(item, Mapping) else None
+        if isinstance(ref, str):
+            fact_id = _s08_page_navigation_fact_id_from_ref(ref)
+            if fact_id is not None and not _vision_summary_seen_or_fresh(vision_summary, fact_id):
+                changed = True
+                continue
+        cleaned_evidence.append(item)
+
+    if not changed:
+        return None, False
+    cleaned_help_response = copy.deepcopy(dict(help_response))
+    cleaned_overlay = copy.deepcopy(dict(overlay))
+    cleaned_overlay["evidence"] = cleaned_evidence
+    cleaned_help_response["overlay"] = cleaned_overlay
+    return cleaned_help_response, True
+
+
 def _s08_visual_fact_ref_for_seen_target(
     context: Mapping[str, Any],
     evidence_refs: Sequence[str],
@@ -5332,6 +5366,14 @@ class LiveDcsTutorLoop:
                 )
             )
         ):
+            cleaned_help_response, evidence_cleaned = _s08_clean_unconfirmed_page_navigation_help_response(
+                context,
+                response.metadata.get("help_response"),
+            )
+            if evidence_cleaned and cleaned_help_response is not None:
+                response.metadata["help_response"] = cleaned_help_response
+                response.metadata["s08_unconfirmed_visual_evidence_filtered"] = True
+                return True, "s08_unconfirmed_visual_evidence_filtered"
             return False, "already_valid"
         if not plan.targets:
             if plan.validator_rejected and response.actions:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -3970,14 +3970,14 @@ def test_harness_validation_repairs_s08_selector_from_tac_evidence_ref(tmp_path:
                     {"gate_id": "S08.precondition", "status": "allowed"},
                 ],
                 "vision_facts": [
-                    {"fact_id": "tac_page_visible", "state": "not_seen", "source_frame_id": "frame-tac"},
+                    {"fact_id": "tac_page_visible", "state": "seen", "source_frame_id": "frame-tac"},
                     {"fact_id": "fcs_page_visible", "state": "not_seen", "source_frame_id": "frame-fcs"},
                 ],
                 "vision_fact_summary": {
                     "status": "available",
-                    "seen_fact_ids": [],
-                    "fresh_fact_ids": [],
-                    "not_seen_fact_ids": ["tac_page_visible", "fcs_page_visible"],
+                    "seen_fact_ids": ["tac_page_visible"],
+                    "fresh_fact_ids": ["tac_page_visible"],
+                    "not_seen_fact_ids": ["fcs_page_visible"],
                     "uncertain_fact_ids": [],
                 },
                 "deterministic_step_hint": {
@@ -4033,6 +4033,95 @@ def test_harness_validation_repairs_s08_selector_from_tac_evidence_ref(tmp_path:
         assert response.metadata["rejected_model_target"] == "left_mdi_brightness_selector"
         assert response.metadata["visual_hint_target"] == "left_mdi_pb18"
         assert response.metadata["visual_hint_evidence_ref"] == "VISION_FACTS.tac_page_visible@frame-tac"
+    finally:
+        loop.close()
+
+
+def test_harness_validation_does_not_trust_s08_tac_evidence_ref_when_fact_not_seen(
+    tmp_path: Path,
+) -> None:
+    replay_path = tmp_path / "bios_s08_visual_evidence_not_seen_keeps_power_hint.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "overlay_target_allowlist": list(loop.overlay_allowlist),
+                "gates": [
+                    {"gate_id": "S08.completion", "status": "blocked", "reason": "Left DDI must be powered."},
+                    {"gate_id": "S08.precondition", "status": "allowed"},
+                ],
+                "vision_facts": [
+                    {"fact_id": "tac_page_visible", "state": "not_seen", "source_frame_id": "frame-tac"},
+                    {"fact_id": "fcs_page_visible", "state": "not_seen", "source_frame_id": "frame-fcs"},
+                ],
+                "vision_fact_summary": {
+                    "status": "available",
+                    "seen_fact_ids": [],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": ["tac_page_visible", "fcs_page_visible"],
+                    "uncertain_fact_ids": [],
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S08",
+                    "overlay_step_id": "S08",
+                    "missing_conditions": ["vars.left_ddi_on==true"],
+                    "gate_blockers": [],
+                    "observability_status": "observable",
+                    "step_evidence_requirements": ["visual", "gate"],
+                    "action_hint": {"target": "left_mdi_brightness_selector"},
+                },
+                "rag_topk": [],
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="The left DDI is showing TAC; navigate toward the FCS page.",
+            actions=[
+                {
+                    "type": "overlay",
+                    "intent": "highlight",
+                    "target": "left_mdi_brightness_selector",
+                    "element_id": "pnt_51",
+                }
+            ],
+            explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
+            metadata={
+                "help_response": {
+                    "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                    "next": {"step_id": "S08"},
+                    "overlay": {
+                        "targets": ["left_mdi_brightness_selector"],
+                        "evidence": [
+                            {
+                                "target": "left_mdi_brightness_selector",
+                                "type": "visual",
+                                "ref": "VISION_FACTS.tac_page_visible@frame-tac",
+                                "quote": "TAC visible.",
+                                "grounding_confidence": 0.9,
+                            }
+                        ],
+                    },
+                    "explanations": ["The left DDI is showing TAC; navigate toward the FCS page."],
+                }
+            },
+        )
+
+        _used, _reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert [action["target"] for action in response.actions] == ["left_mdi_brightness_selector"]
+        assert "s08_visual_hint_repair_applied" not in response.metadata
+        assert "visual_hint_target" not in response.metadata
     finally:
         loop.close()
 

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -3966,6 +3966,98 @@ def test_harness_validation_repairs_s08_selector_from_tac_evidence_ref(tmp_path:
             context={
                 "overlay_target_allowlist": list(loop.overlay_allowlist),
                 "gates": [
+                    {"gate_id": "S08.completion", "status": "blocked", "reason": "FCS page is not visible."},
+                    {"gate_id": "S08.precondition", "status": "allowed"},
+                ],
+                "vision_facts": [
+                    {"fact_id": "tac_page_visible", "state": "seen", "source_frame_id": "frame-tac"},
+                    {"fact_id": "fcs_page_visible", "state": "not_seen", "source_frame_id": "frame-fcs"},
+                ],
+                "vision_fact_summary": {
+                    "status": "available",
+                    "seen_fact_ids": ["tac_page_visible"],
+                    "fresh_fact_ids": ["tac_page_visible"],
+                    "not_seen_fact_ids": ["fcs_page_visible"],
+                    "uncertain_fact_ids": [],
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S08",
+                    "overlay_step_id": "S08",
+                    "missing_conditions": ["vision_facts.fcs_page_visible==seen"],
+                    "gate_blockers": [],
+                    "observability_status": "observable",
+                    "step_evidence_requirements": ["visual", "gate"],
+                    "action_hint": {"target": "left_mdi_brightness_selector"},
+                },
+                "rag_topk": [],
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="The left DDI is showing TAC; navigate toward the FCS page.",
+            actions=[
+                {
+                    "type": "overlay",
+                    "intent": "highlight",
+                    "target": "left_mdi_brightness_selector",
+                    "element_id": "pnt_51",
+                }
+            ],
+            explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
+            metadata={
+                "help_response": {
+                    "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                    "next": {"step_id": "S08"},
+                    "overlay": {
+                        "targets": ["left_mdi_brightness_selector"],
+                        "evidence": [
+                            {
+                                "target": "left_mdi_brightness_selector",
+                                "type": "visual",
+                                "ref": "VISION_FACTS.tac_page_visible@frame-tac",
+                                "quote": "TAC visible.",
+                                "grounding_confidence": 0.9,
+                            }
+                        ],
+                    },
+                    "explanations": ["The left DDI is showing TAC; navigate toward the FCS page."],
+                }
+            },
+        )
+
+        used, _reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert [action["target"] for action in response.actions] == ["left_mdi_pb18"]
+        assert response.metadata["s08_visual_hint_repair_applied"] is True
+        assert response.metadata["rejected_model_target"] == "left_mdi_brightness_selector"
+        assert response.metadata["visual_hint_target"] == "left_mdi_pb18"
+        assert response.metadata["visual_hint_evidence_ref"] == "VISION_FACTS.tac_page_visible@frame-tac"
+    finally:
+        loop.close()
+
+
+def test_harness_validation_keeps_s08_power_hint_when_tac_seen_but_left_ddi_power_missing(
+    tmp_path: Path,
+) -> None:
+    replay_path = tmp_path / "bios_s08_visual_evidence_seen_keeps_power_hint.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "overlay_target_allowlist": list(loop.overlay_allowlist),
+                "gates": [
                     {"gate_id": "S08.completion", "status": "blocked", "reason": "Left DDI must be powered."},
                     {"gate_id": "S08.precondition", "status": "allowed"},
                 ],
@@ -4025,14 +4117,11 @@ def test_harness_validation_repairs_s08_selector_from_tac_evidence_ref(tmp_path:
             },
         )
 
-        used, _reason = loop._apply_harness_validation_action_plan(response, request)
+        _used, _reason = loop._apply_harness_validation_action_plan(response, request)
 
-        assert used is True
-        assert [action["target"] for action in response.actions] == ["left_mdi_pb18"]
-        assert response.metadata["s08_visual_hint_repair_applied"] is True
-        assert response.metadata["rejected_model_target"] == "left_mdi_brightness_selector"
-        assert response.metadata["visual_hint_target"] == "left_mdi_pb18"
-        assert response.metadata["visual_hint_evidence_ref"] == "VISION_FACTS.tac_page_visible@frame-tac"
+        assert [action["target"] for action in response.actions] == ["left_mdi_brightness_selector"]
+        assert "s08_visual_hint_repair_applied" not in response.metadata
+        assert "visual_hint_target" not in response.metadata
     finally:
         loop.close()
 
@@ -4122,6 +4211,105 @@ def test_harness_validation_does_not_trust_s08_tac_evidence_ref_when_fact_not_se
         assert [action["target"] for action in response.actions] == ["left_mdi_brightness_selector"]
         assert "s08_visual_hint_repair_applied" not in response.metadata
         assert "visual_hint_target" not in response.metadata
+        help_response = response.metadata["help_response"]
+        evidence = help_response["overlay"]["evidence"]
+        assert all(item.get("ref") != "VISION_FACTS.tac_page_visible@frame-tac" for item in evidence)
+    finally:
+        loop.close()
+
+
+def test_harness_validation_does_not_trust_s08_visual_action_hint_when_fact_not_seen(
+    tmp_path: Path,
+) -> None:
+    replay_path = tmp_path / "bios_s08_visual_action_hint_not_seen_keeps_selector.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "overlay_target_allowlist": list(loop.overlay_allowlist),
+                "gates": [
+                    {"gate_id": "S08.completion", "status": "blocked", "reason": "FCS page is not visible."},
+                    {"gate_id": "S08.precondition", "status": "allowed"},
+                ],
+                "vision_facts": [
+                    {"fact_id": "tac_page_visible", "state": "not_seen", "source_frame_id": "frame-tac"},
+                    {"fact_id": "fcs_page_visible", "state": "not_seen", "source_frame_id": "frame-fcs"},
+                ],
+                "vision_fact_summary": {
+                    "status": "available",
+                    "seen_fact_ids": [],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": ["tac_page_visible", "fcs_page_visible"],
+                    "uncertain_fact_ids": [],
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S08",
+                    "overlay_step_id": "S08",
+                    "missing_conditions": ["vision_facts.fcs_page_visible==seen"],
+                    "gate_blockers": [],
+                    "observability_status": "observable",
+                    "step_evidence_requirements": ["visual", "gate"],
+                    "action_hint": {"target": "left_mdi_brightness_selector"},
+                    "visual_action_hint": {
+                        "target": "left_mdi_pb18",
+                        "reason": "TAC is visible; press PB18 to reach SUPT.",
+                    },
+                },
+                "rag_topk": [],
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="The left DDI is showing TAC; navigate toward the FCS page.",
+            actions=[
+                {
+                    "type": "overlay",
+                    "intent": "highlight",
+                    "target": "left_mdi_brightness_selector",
+                    "element_id": "pnt_51",
+                }
+            ],
+            explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
+            metadata={
+                "help_response": {
+                    "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                    "next": {"step_id": "S08"},
+                    "overlay": {
+                        "targets": ["left_mdi_brightness_selector"],
+                        "evidence": [
+                            {
+                                "target": "left_mdi_brightness_selector",
+                                "type": "visual",
+                                "ref": "VISION_FACTS.tac_page_visible@frame-tac",
+                                "quote": "TAC visible.",
+                                "grounding_confidence": 0.9,
+                            }
+                        ],
+                    },
+                    "explanations": ["The left DDI is showing TAC; navigate toward the FCS page."],
+                }
+            },
+        )
+
+        _used, _reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert [action["target"] for action in response.actions] == ["left_mdi_brightness_selector"]
+        assert "s08_visual_hint_repair_applied" not in response.metadata
+        assert "visual_hint_target" not in response.metadata
+        help_response = response.metadata["help_response"]
+        evidence = help_response["overlay"]["evidence"]
+        assert all(item.get("ref") != "VISION_FACTS.tac_page_visible@frame-tac" for item in evidence)
     finally:
         loop.close()
 

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -3947,6 +3947,96 @@ def test_harness_validation_repairs_s08_selector_to_tac_visual_hint(tmp_path: Pa
         loop.close()
 
 
+def test_harness_validation_repairs_s08_selector_from_tac_evidence_ref(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s08_visual_evidence_repairs_selector_to_pb18.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="en",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "overlay_target_allowlist": list(loop.overlay_allowlist),
+                "gates": [
+                    {"gate_id": "S08.completion", "status": "blocked", "reason": "Left DDI must be powered."},
+                    {"gate_id": "S08.precondition", "status": "allowed"},
+                ],
+                "vision_facts": [
+                    {"fact_id": "tac_page_visible", "state": "not_seen", "source_frame_id": "frame-tac"},
+                    {"fact_id": "fcs_page_visible", "state": "not_seen", "source_frame_id": "frame-fcs"},
+                ],
+                "vision_fact_summary": {
+                    "status": "available",
+                    "seen_fact_ids": [],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": ["tac_page_visible", "fcs_page_visible"],
+                    "uncertain_fact_ids": [],
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S08",
+                    "overlay_step_id": "S08",
+                    "missing_conditions": ["vars.left_ddi_on==true"],
+                    "gate_blockers": [],
+                    "observability_status": "observable",
+                    "step_evidence_requirements": ["visual", "gate"],
+                    "action_hint": {"target": "left_mdi_brightness_selector"},
+                },
+                "rag_topk": [],
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="The left DDI is showing TAC; navigate toward the FCS page.",
+            actions=[
+                {
+                    "type": "overlay",
+                    "intent": "highlight",
+                    "target": "left_mdi_brightness_selector",
+                    "element_id": "pnt_51",
+                }
+            ],
+            explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
+            metadata={
+                "help_response": {
+                    "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                    "next": {"step_id": "S08"},
+                    "overlay": {
+                        "targets": ["left_mdi_brightness_selector"],
+                        "evidence": [
+                            {
+                                "target": "left_mdi_brightness_selector",
+                                "type": "visual",
+                                "ref": "VISION_FACTS.tac_page_visible@frame-tac",
+                                "quote": "TAC visible.",
+                                "grounding_confidence": 0.9,
+                            }
+                        ],
+                    },
+                    "explanations": ["The left DDI is showing TAC; navigate toward the FCS page."],
+                }
+            },
+        )
+
+        used, _reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert [action["target"] for action in response.actions] == ["left_mdi_pb18"]
+        assert response.metadata["s08_visual_hint_repair_applied"] is True
+        assert response.metadata["rejected_model_target"] == "left_mdi_brightness_selector"
+        assert response.metadata["visual_hint_target"] == "left_mdi_pb18"
+        assert response.metadata["visual_hint_evidence_ref"] == "VISION_FACTS.tac_page_visible@frame-tac"
+    finally:
+        loop.close()
+
+
 def test_s08_dual_visual_missing_overrides_model_left_nav_to_right_display_recovery(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_s08_dual_visual_missing_model_left_nav.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -4005,6 +4005,8 @@ def test_harness_validation_repairs_s08_selector_from_tac_evidence_ref(tmp_path:
             ],
             explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
             metadata={
+                "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                "next": {"step_id": "S08"},
                 "help_response": {
                     "diagnosis": {"step_id": "S08", "error_category": "CO"},
                     "next": {"step_id": "S08"},
@@ -4097,6 +4099,8 @@ def test_harness_validation_keeps_s08_power_hint_when_tac_seen_but_left_ddi_powe
             ],
             explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
             metadata={
+                "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                "next": {"step_id": "S08"},
                 "help_response": {
                     "diagnosis": {"step_id": "S08", "error_category": "CO"},
                     "next": {"step_id": "S08"},
@@ -4186,6 +4190,8 @@ def test_harness_validation_does_not_trust_s08_tac_evidence_ref_when_fact_not_se
             ],
             explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
             metadata={
+                "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                "next": {"step_id": "S08"},
                 "help_response": {
                     "diagnosis": {"step_id": "S08", "error_category": "CO"},
                     "next": {"step_id": "S08"},
@@ -4206,11 +4212,14 @@ def test_harness_validation_does_not_trust_s08_tac_evidence_ref_when_fact_not_se
             },
         )
 
-        _used, _reason = loop._apply_harness_validation_action_plan(response, request)
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
 
+        assert used is True
+        assert reason == "s08_unconfirmed_visual_evidence_filtered"
         assert [action["target"] for action in response.actions] == ["left_mdi_brightness_selector"]
         assert "s08_visual_hint_repair_applied" not in response.metadata
         assert "visual_hint_target" not in response.metadata
+        assert response.metadata["s08_unconfirmed_visual_evidence_filtered"] is True
         help_response = response.metadata["help_response"]
         evidence = help_response["overlay"]["evidence"]
         assert all(item.get("ref") != "VISION_FACTS.tac_page_visible@frame-tac" for item in evidence)
@@ -4282,6 +4291,8 @@ def test_harness_validation_does_not_trust_s08_visual_action_hint_when_fact_not_
             ],
             explanations=["The left DDI is showing TAC; navigate toward the FCS page."],
             metadata={
+                "diagnosis": {"step_id": "S08", "error_category": "CO"},
+                "next": {"step_id": "S08"},
                 "help_response": {
                     "diagnosis": {"step_id": "S08", "error_category": "CO"},
                     "next": {"step_id": "S08"},
@@ -4302,11 +4313,14 @@ def test_harness_validation_does_not_trust_s08_visual_action_hint_when_fact_not_
             },
         )
 
-        _used, _reason = loop._apply_harness_validation_action_plan(response, request)
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
 
+        assert used is True
+        assert reason == "s08_unconfirmed_visual_evidence_filtered"
         assert [action["target"] for action in response.actions] == ["left_mdi_brightness_selector"]
         assert "s08_visual_hint_repair_applied" not in response.metadata
         assert "visual_hint_target" not in response.metadata
+        assert response.metadata["s08_unconfirmed_visual_evidence_filtered"] is True
         help_response = response.metadata["help_response"]
         evidence = help_response["overlay"]["evidence"]
         assert all(item.get("ref") != "VISION_FACTS.tac_page_visible@frame-tac" for item in evidence)


### PR DESCRIPTION
## Summary
- handle the reopened #293 path where S08 lacks deterministic visual_action_hint but model evidence cites TAC/SUPT visual facts
- derive the validator action hint from S08 visual evidence refs so selector targets repair to PB18/PB15
- add regression coverage for the new TAC evidence fixture pattern

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py::test_harness_validation_repairs_s08_selector_from_tac_evidence_ref
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_live_dcs.py -k "s08 or visual_action_hint or harness_validation"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Refs #293