### PR TITLE
Fix S18 BIT-root PB5 visual repair

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -43,6 +43,8 @@ class HarnessCompletionAdvance:
 class HarnessActionHintFactRule:
     step_id: str
     fact_id: str
+    not_seen_fact_id: str | None = None
+    source: str = "validator_action_hint"
 
 
 @dataclass(frozen=True)
@@ -84,6 +86,14 @@ def _seen_or_fresh(
     vision_fresh_fact_ids: Sequence[str] | None,
 ) -> bool:
     return fact_id in set(_strings(vision_seen_fact_ids)) or fact_id in set(_strings(vision_fresh_fact_ids))
+
+
+def _not_seen(
+    fact_id: str,
+    *,
+    vision_not_seen_fact_ids: Sequence[str] | None,
+) -> bool:
+    return fact_id in set(_strings(vision_not_seen_fact_ids))
 
 
 def _completion_advance_for_seen_fact(
@@ -128,19 +138,29 @@ def _hint_allowed_by_fact_rule(
     action_hint_fact_rules: Sequence[HarnessActionHintFactRule] | None,
     vision_seen_fact_ids: Sequence[str] | None,
     vision_fresh_fact_ids: Sequence[str] | None,
-) -> bool:
+    vision_not_seen_fact_ids: Sequence[str] | None,
+) -> str | None:
     if not isinstance(step_id, str) or not step_id:
-        return False
+        return None
     for rule in action_hint_fact_rules or ():
         if rule.step_id != step_id:
             continue
-        if _seen_or_fresh(
+        seen_requirement_met = _seen_or_fresh(
             rule.fact_id,
             vision_seen_fact_ids=vision_seen_fact_ids,
             vision_fresh_fact_ids=vision_fresh_fact_ids,
-        ):
-            return True
-    return False
+        )
+        not_seen_requirement_met = (
+            True
+            if rule.not_seen_fact_id is None
+            else _not_seen(
+                rule.not_seen_fact_id,
+                vision_not_seen_fact_ids=vision_not_seen_fact_ids,
+            )
+        )
+        if seen_requirement_met and not_seen_requirement_met:
+            return rule.source
+    return None
 
 
 def _filter_targets(
@@ -204,6 +224,7 @@ def plan_harness_action(
     max_overlay_targets: int = 1,
     vision_seen_fact_ids: Sequence[str] | None = None,
     vision_fresh_fact_ids: Sequence[str] | None = None,
+    vision_not_seen_fact_ids: Sequence[str] | None = None,
     action_hint: Mapping[str, Any] | None = None,
     completion_advancements: Sequence[HarnessCompletionAdvance] | None = None,
     action_hint_step_ids: Sequence[str] | None = None,
@@ -273,19 +294,23 @@ def plan_harness_action(
     if hinted_targets:
         if selected_step_id in action_hint_step_set:
             use_hint = True
-        if _hint_allowed_by_fact_rule(
+        hint_rule_source = _hint_allowed_by_fact_rule(
             selected_step_id,
             action_hint_fact_rules=action_hint_fact_rules,
             vision_seen_fact_ids=vision_seen_fact_ids,
             vision_fresh_fact_ids=vision_fresh_fact_ids,
-        ):
+            vision_not_seen_fact_ids=vision_not_seen_fact_ids,
+        )
+        if hint_rule_source is not None:
             use_hint = True
+            source = hint_rule_source
 
     if completion_advance is not None:
         base_targets = spec.allowed_overlay_targets if spec is not None else ()
     elif use_hint:
         base_targets = hinted_targets
-        source = "validator_action_hint"
+        if source == "model":
+            source = "validator_action_hint"
     else:
         base_targets = proposed_targets
 

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -5136,8 +5136,6 @@ class LiveDcsTutorLoop:
             and response_mapping_meta.get("rejected_targets_by_request_allowlist")
         ):
             return False, "response_mapping_already_repaired_allowlist"
-        if inferred_step_id == "S18":
-            return False, "legacy_s18_action_hint_guardrail"
         if _state_harness_has_late_vlm_conflict(context.get("state_harness")):
             return False, "late_vlm_conflict_guardrail"
         model_step_id = _extract_model_next_step_id(response.metadata)
@@ -5192,6 +5190,7 @@ class LiveDcsTutorLoop:
         vision_summary = context.get("vision_fact_summary")
         vision_seen_fact_ids: list[str] = []
         vision_fresh_fact_ids: list[str] = []
+        vision_not_seen_fact_ids: list[str] = []
         if isinstance(vision_summary, Mapping):
             raw_seen = vision_summary.get("seen_fact_ids")
             if isinstance(raw_seen, (list, tuple, set)):
@@ -5199,6 +5198,9 @@ class LiveDcsTutorLoop:
             raw_fresh = vision_summary.get("fresh_fact_ids")
             if isinstance(raw_fresh, (list, tuple, set)):
                 vision_fresh_fact_ids = [item for item in raw_fresh if isinstance(item, str) and item]
+            raw_not_seen = vision_summary.get("not_seen_fact_ids")
+            if isinstance(raw_not_seen, (list, tuple, set)):
+                vision_not_seen_fact_ids = [item for item in raw_not_seen if isinstance(item, str) and item]
 
         missing_conditions = hint.get("missing_conditions")
         missing_set = {
@@ -5211,6 +5213,9 @@ class LiveDcsTutorLoop:
         s08_visual_hint_target: str | None = None
         s08_visual_hint_ref: str | None = None
         s08_visual_hint_used = False
+        s18_visual_hint_target: str | None = None
+        s18_visual_hint_reason: str | None = None
+        s18_visual_hint_used = False
         s08_visual_navigation_allowed = (
             inferred_step_id == "S08"
             and not _s08_power_condition_missing(missing_set)
@@ -5246,6 +5251,54 @@ class LiveDcsTutorLoop:
                 s08_visual_hint_used = True
                 if isinstance(evidence_ref, str) and evidence_ref:
                     evidence_refs = [evidence_ref]
+        s18_bit_root_to_fcsmc_allowed = (
+            inferred_step_id == "S18"
+            and (
+                "bit_root_page_visible" in set(vision_seen_fact_ids)
+                or "bit_root_page_visible" in set(vision_fresh_fact_ids)
+            )
+            and "fcsmc_page_visible" in set(vision_not_seen_fact_ids)
+        )
+        if s18_bit_root_to_fcsmc_allowed and isinstance(action_hint, Mapping):
+            action_target = action_hint.get("target")
+            if action_target == "right_mdi_pb5":
+                repaired_hint = dict(action_hint)
+                hint_reason = repaired_hint.get("reason")
+                if not isinstance(hint_reason, str) or not hint_reason:
+                    hint_reason = (
+                        "右 DDI 已在 BIT root 页面；请按右 DDI PB5/FCS-MC 进入 FCS-MC BIT 页面。"
+                        if self.lang == "zh"
+                        else "The right DDI is on the BIT root page; press right DDI PB5/FCS-MC to enter the FCS-MC BIT page."
+                    )
+                    repaired_hint["reason"] = hint_reason
+                action_hint = repaired_hint
+                s18_visual_hint_target = "right_mdi_pb5"
+                s18_visual_hint_reason = hint_reason
+                s18_visual_hint_used = True
+                allowed_refs = _collect_request_evidence_refs(context)
+                bit_root_ref_prefix = "VISION_FACTS.bit_root_page_visible"
+                bit_root_ref = next(
+                    (
+                        ref for ref in evidence_refs
+                        if ref in allowed_refs and ref.startswith(bit_root_ref_prefix)
+                    ),
+                    None,
+                )
+                if bit_root_ref is None:
+                    frame_ids = vision_summary.get("frame_ids") if isinstance(vision_summary, Mapping) else None
+                    candidate_refs: list[str] = []
+                    if isinstance(frame_ids, (list, tuple)):
+                        candidate_refs.extend(
+                            f"{bit_root_ref_prefix}@{frame_id}"
+                            for frame_id in frame_ids
+                            if isinstance(frame_id, str) and frame_id
+                        )
+                    candidate_refs.append(bit_root_ref_prefix)
+                    bit_root_ref = next((ref for ref in candidate_refs if ref in allowed_refs), None)
+                if bit_root_ref is not None:
+                    evidence_refs = [bit_root_ref]
+        if inferred_step_id == "S18" and not s18_bit_root_to_fcsmc_allowed:
+            return False, "legacy_s18_action_hint_guardrail"
         manual_text_guidance_rules: list[HarnessTextGuidanceRule] = []
         include_s05_manual_guidance = (
             "vars.throttle_r_not_off==true" in missing_set
@@ -5307,6 +5360,7 @@ class LiveDcsTutorLoop:
             max_overlay_targets=self.max_overlay_targets,
             vision_seen_fact_ids=vision_seen_fact_ids,
             vision_fresh_fact_ids=vision_fresh_fact_ids,
+            vision_not_seen_fact_ids=vision_not_seen_fact_ids,
             action_hint=action_hint if isinstance(action_hint, Mapping) else None,
             completion_advancements=[
                 HarnessCompletionAdvance(
@@ -5318,10 +5372,19 @@ class LiveDcsTutorLoop:
             ],
             action_hint_step_ids=["S08", "S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
             action_hint_fact_rules=[
+                HarnessActionHintFactRule(
+                    step_id="S18",
+                    fact_id="bit_root_page_visible",
+                    not_seen_fact_id="fcsmc_page_visible",
+                    source="visual_action_hint_repair",
+                ),
                 HarnessActionHintFactRule(step_id="S19", fact_id="fcsmc_intermediate_result_visible")
             ],
             text_guidance_rules=manual_text_guidance_rules,
         )
+        plan_guidance = plan.guidance
+        if s18_visual_hint_used and (not isinstance(plan_guidance, str) or not plan_guidance):
+            plan_guidance = s18_visual_hint_reason
 
         response.metadata["validator_rejected"] = bool(plan.validator_rejected)
         response.metadata["repair_applied"] = bool(response.metadata.get("repair_applied")) or bool(plan.repair_applied)
@@ -5343,6 +5406,13 @@ class LiveDcsTutorLoop:
             if plan.rejected_model_targets:
                 response.metadata["rejected_model_targets"] = list(plan.rejected_model_targets)
                 response.metadata["rejected_model_target"] = plan.rejected_model_targets[0]
+        if s18_visual_hint_used:
+            response.metadata["visual_hint_target"] = s18_visual_hint_target
+            if plan.repair_applied:
+                response.metadata["s18_visual_hint_repair_applied"] = True
+        if plan.rejected_model_targets:
+            response.metadata["rejected_model_targets"] = list(plan.rejected_model_targets)
+            response.metadata["rejected_model_target"] = plan.rejected_model_targets[0]
         if isinstance(plan.rejected_model_step_id, str) and plan.rejected_model_step_id:
             response.metadata["rejected_model_step_id"] = plan.rejected_model_step_id
         elif "rejected_model_step_id" in response.metadata:
@@ -5355,11 +5425,11 @@ class LiveDcsTutorLoop:
             if original_actions:
                 response.metadata["harness_validator_original_actions"] = original_actions
             response.actions = []
-            if isinstance(plan.guidance, str) and plan.guidance:
+            if isinstance(plan_guidance, str) and plan_guidance:
                 original_message = response.message
                 original_explanations = list(response.explanations)
-                response.message = plan.guidance
-                response.explanations = [plan.guidance]
+                response.message = plan_guidance
+                response.explanations = [plan_guidance]
                 if original_message != response.message:
                     response.metadata["harness_validator_original_message"] = original_message
                     response.metadata["manual_throttle_guidance_original_message"] = original_message
@@ -5507,8 +5577,8 @@ class LiveDcsTutorLoop:
                 for target in plan.targets
             ],
         }
-        if isinstance(plan.guidance, str) and plan.guidance:
-            planned_help_obj["explanations"] = [plan.guidance]
+        if isinstance(plan_guidance, str) and plan_guidance:
+            planned_help_obj["explanations"] = [plan_guidance]
 
         mapped = map_help_response_to_tutor_response(
             planned_help_obj,
@@ -5530,9 +5600,9 @@ class LiveDcsTutorLoop:
         response.metadata["next"] = {"step_id": plan.step_id}
         response.metadata["help_response"] = planned_help_obj
         response.metadata["harness_validator_fallback_reason"] = fallback_reason
-        if isinstance(plan.guidance, str) and plan.guidance:
-            response.message = plan.guidance
-            response.explanations = [plan.guidance]
+        if isinstance(plan_guidance, str) and plan_guidance:
+            response.message = plan_guidance
+            response.explanations = [plan_guidance]
         elif mapped.explanations and response.metadata.get("procedural_guidance_rewritten") is not True:
             response.message = mapped.explanations[0]
             response.explanations = list(mapped.explanations)

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -263,3 +263,82 @@ def test_plan_harness_action_records_rejected_target_when_action_hint_repairs_s0
     assert plan.final_action_plan_source == "validator_action_hint"
     assert plan.rejected_model_targets == ("left_mdi_brightness_selector",)
     assert "action_hint_target_mismatch:left_mdi_brightness_selector" in plan.reasons
+
+
+def test_plan_harness_action_repairs_s18_bit_root_to_pb5_when_fcsmc_not_seen() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=["right_mdi_pb18"],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        request_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        allowed_evidence_refs=["VISION_FACTS.bit_root_page_visible@frame-1"],
+        evidence_refs=["VISION_FACTS.bit_root_page_visible@frame-1"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["bit_root_page_visible"],
+        vision_not_seen_fact_ids=["fcsmc_page_visible"],
+        action_hint={
+            "target": "right_mdi_pb5",
+            "reason": "BIT root is visible; press PB5 FCS-MC.",
+        },
+        action_hint_fact_rules=[
+            HarnessActionHintFactRule(
+                step_id="S18",
+                fact_id="bit_root_page_visible",
+                not_seen_fact_id="fcsmc_page_visible",
+                source="visual_action_hint_repair",
+            )
+        ],
+    )
+
+    assert plan.targets == ("right_mdi_pb5",)
+    assert plan.guidance == "BIT root is visible; press PB5 FCS-MC."
+    assert plan.validator_rejected is True
+    assert plan.repair_applied is True
+    assert plan.final_action_plan_source == "visual_action_hint_repair"
+    assert plan.rejected_model_targets == ("right_mdi_pb18",)
+    assert "action_hint_target_mismatch:right_mdi_pb18" in plan.reasons
+
+
+def test_plan_harness_action_keeps_s18_recovery_pb18_when_bit_root_not_visible() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=["right_mdi_pb18"],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        request_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        allowed_evidence_refs=["VISION_FACTS.fcsmc_page_visible@frame-1"],
+        evidence_refs=["VISION_FACTS.fcsmc_page_visible@frame-1"],
+        max_overlay_targets=1,
+        vision_not_seen_fact_ids=["bit_root_page_visible"],
+        action_hint={"target": "right_mdi_pb5"},
+        action_hint_fact_rules=[
+            HarnessActionHintFactRule(
+                step_id="S18",
+                fact_id="bit_root_page_visible",
+                not_seen_fact_id="fcsmc_page_visible",
+                source="visual_action_hint_repair",
+            )
+        ],
+    )
+
+    assert plan.targets == ("right_mdi_pb18",)
+    assert plan.repair_applied is False
+    assert plan.validator_rejected is False
+    assert plan.final_action_plan_source == "model"

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -8931,6 +8931,92 @@ def test_live_loop_overrides_s18_root_menu_overlay_with_action_hint_when_vision_
     assert response.metadata["final_public_response"]["actions"][0]["target"] == "right_mdi_pb5"
 
 
+def test_live_fixture_s18_bit_root_repairs_pb18_to_pb5() -> None:
+    fixture_path = Path("artifacts/live_fixtures/644fac65-eb37-4de1-a591-fd1de392c647.fixture.json")
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+    request_payload = fixture["cycle"]["tutor_request"]
+    context = request_payload["context"]
+    raw_help = fixture["model_io"]["model_raw_help_response"]
+    frame_ids = context["vision_fact_summary"]["frame_ids"]
+    frame_id = frame_ids[0]
+
+    request = TutorRequest(
+        request_id=request_payload["request_id"],
+        message=request_payload.get("message"),
+        observation_ref=request_payload.get("observation_ref"),
+        context=context,
+        metadata=dict(request_payload.get("metadata") or {}),
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+        actions=[],
+        explanations=list(raw_help["explanations"]),
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": raw_help,
+        },
+    )
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-s18-fixture-repair",
+        rag_top_k=0,
+        lang="zh",
+    )
+    try:
+        result = loop._validate_and_repair_live_help_response(
+            response,
+            request,
+            prompt_meta={},
+            state_key="fixture-s18",
+            help_cycle_id=request.request_id,
+            vision_selection=HelpCycleVisionSelection(
+                status="available",
+                observation_ref=context["vision"].get("observation_ref"),
+                observation_seq=context["vision"].get("observation_seq"),
+                observation_t_wall_s=context["vision"].get("observation_t_wall_s"),
+                observation_t_wall_ms=context["vision"].get("observation_t_wall_ms"),
+                trigger_wall_ms=context["vision"].get("trigger_wall_ms"),
+                sync_window_ms=context["vision"].get("sync_window_ms"),
+                vision_used=True,
+                frame_id=frame_id,
+                sync_status=context["vision"].get("sync_status"),
+                sync_delta_ms=context["vision"].get("sync_delta_ms"),
+                frame_stale=False,
+                frame_ids=list(frame_ids),
+                selected_frames=[],
+                pre_trigger_frame=None,
+                trigger_frame=None,
+                sync_miss_reason=context["vision"].get("sync_miss_reason"),
+            ),
+            vision_fact_context={
+                "status": "available",
+                "vision_fact_summary": context["vision_fact_summary"],
+                "vision_facts": context["vision_facts"],
+            },
+            vision_fact_active_step_ids=["S18"],
+            terminal_state_short_circuited=False,
+        )
+    finally:
+        loop.close()
+
+    repaired = result.response
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb5"]
+    assert repaired.message is not None
+    assert "PB5" in repaired.message
+    assert "PB18" not in repaired.message
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["rejected_model_target"] == "right_mdi_pb18"
+    assert repaired.metadata["visual_hint_target"] == "right_mdi_pb5"
+    assert repaired.metadata["final_action_plan"]["source"] == "visual_action_hint_repair"
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "right_mdi_pb5"
+
+
 def test_map_response_actions_accepts_fake_llm_multi_target_help_response_when_enabled(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_multi_target_mapping.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])


### PR DESCRIPTION
## Summary
- enforce S18 BIT-root + FCS-MC-not-seen visual state as a PB5/FCS-MC repair in the harness action planner
- keep PB18 available for S18 recovery when BIT root is not visible
- add core planner and live fixture regression coverage for issue #300

Fixes #300.

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py::test_plan_harness_action_repairs_s18_bit_root_to_pb5_when_fcsmc_not_seen tests/test_harness_validation.py::test_plan_harness_action_keeps_s18_recovery_pb18_when_bit_root_not_visible tests/test_live_dcs.py::test_live_fixture_s18_bit_root_repairs_pb18_to_pb5
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_live_dcs.py::test_live_loop_overrides_s18_root_menu_overlay_with_action_hint_when_vision_is_unavailable tests/test_live_dcs.py::test_build_procedural_action_hint_for_s18_prefers_right_ddi_pb5 tests/test_live_dcs.py::test_build_procedural_action_hint_for_s19_prefers_fcs_bit_switch_on_fcsmc_page tests/test_live_dcs.py::test_live_fixture_s18_bit_root_repairs_pb18_to_pb5
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full