### PR TITLE
Fix final help overlay target consistency

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -1580,6 +1580,7 @@ def _text_claims_step_complete(text: str, step_id: str) -> bool:
     escaped = re.escape(normalized_step)
     negative_patterns = (
         rf"\b{escaped}\b[^.。;；\n]{{0,80}}(?:尚未完成|未完成|not complete|incomplete)",
+        rf"\b{escaped}\b[^.。;；\n]{{0,80}}(?:请|(?<![已经])按下|(?<![已经])操作|(?<![已经])点击|press|operate|set|move)[^.。;；\n]{{0,80}}(?:以|to)?\s*完成",
         rf"(?:当前步骤|current step)[^.。;；\n]{{0,80}}(?:尚未完成|未完成|not complete|incomplete)",
     )
     if any(re.search(pattern, normalized_text) is not None for pattern in negative_patterns):
@@ -2731,6 +2732,60 @@ def _build_procedural_action_hint(
     if vars_selected.get("ufc_comm1_pull_pressed") is True:
         return _hint("ufc_key_1", "COMM1 preset entry has been opened on the UFC scratchpad; press 1 to begin entering 134.000.")
     return _hint("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector to open preset 1 in the scratchpad before entering 134.000.")
+
+
+def _s12_fast_align_action_hint_allowed(
+    *,
+    context: Mapping[str, Any],
+    hint: Mapping[str, Any],
+    missing_conditions: set[str],
+    action_hint: Any,
+) -> bool:
+    if not isinstance(action_hint, Mapping) or action_hint.get("target") != "ampcd_pb19":
+        return False
+    if "vars.ins_fast_align_complete==true" not in missing_conditions:
+        return False
+    if any("vars.ins_mode" in item for item in missing_conditions):
+        return False
+
+    mode_reason_codes = {"s12_requires_ins_mode_gnd", "s12_requires_ins_mode_cv"}
+    gates = context.get("gates")
+    if isinstance(gates, Mapping):
+        gate = gates.get("S12.completion")
+        if isinstance(gate, Mapping):
+            reason_code = gate.get("reason_code")
+            if gate.get("status") == "blocked" and reason_code in mode_reason_codes:
+                return False
+
+    gate_blockers = hint.get("gate_blockers")
+    if isinstance(gate_blockers, (list, tuple)):
+        for blocker in gate_blockers:
+            if not isinstance(blocker, Mapping):
+                continue
+            reason_code = blocker.get("reason_code")
+            raw_var = blocker.get("var")
+            if reason_code in mode_reason_codes or (
+                isinstance(raw_var, str) and "ins_mode" in raw_var
+            ):
+                return False
+
+    vars_map = context.get("vars")
+    vars_selected = vars_map if isinstance(vars_map, Mapping) else {}
+    scenario_profile = context.get("scenario_profile")
+    if not isinstance(scenario_profile, str) or not scenario_profile:
+        scenario_profile = hint.get("scenario_profile")
+
+    ins_mode = vars_selected.get("ins_mode")
+    if isinstance(ins_mode, (int, float)) and not isinstance(ins_mode, bool):
+        normalized_mode = int(ins_mode)
+        if scenario_profile == "carrier":
+            return normalized_mode == 1
+        return normalized_mode == 2
+
+    return (
+        vars_selected.get("ins_mode_cv_or_gnd") is True
+        or vars_selected.get("ins_mode_set") is True
+    )
 
 
 def _resolve_overlay_step_id(
@@ -5299,6 +5354,14 @@ class LiveDcsTutorLoop:
                     evidence_refs = [bit_root_ref]
         if inferred_step_id == "S18" and not s18_bit_root_to_fcsmc_allowed:
             return False, "legacy_s18_action_hint_guardrail"
+        action_hint_step_ids = ["S08", "S17", "S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"]
+        if inferred_step_id == "S12" and _s12_fast_align_action_hint_allowed(
+            context=context,
+            hint=hint,
+            missing_conditions=missing_set,
+            action_hint=action_hint,
+        ):
+            action_hint_step_ids.append("S12")
         manual_text_guidance_rules: list[HarnessTextGuidanceRule] = []
         include_s05_manual_guidance = (
             "vars.throttle_r_not_off==true" in missing_set
@@ -5370,7 +5433,7 @@ class LiveDcsTutorLoop:
                     source="validator_s19_final_go",
                 )
             ],
-            action_hint_step_ids=["S08", "S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
+            action_hint_step_ids=action_hint_step_ids,
             action_hint_fact_rules=[
                 HarnessActionHintFactRule(
                     step_id="S18",
@@ -5782,6 +5845,11 @@ class LiveDcsTutorLoop:
         elif inferred_step_id == "S12":
             if "vars.ins_fast_align_complete==true" in missing_set and (
                 vars_map.get("ins_mode_cv_or_gnd") is True or vars_map.get("ins_mode_set") is True
+            ) and _s12_fast_align_action_hint_allowed(
+                context=context,
+                hint=hint,
+                missing_conditions=missing_set,
+                action_hint={"target": "ampcd_pb19"},
             ):
                 reason = "s12_ampcd_pb19_fast_align_guidance"
                 if self.lang == "zh":

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -51,6 +51,7 @@ from live_dcs import (
     _sanitize_response_payload_for_event,
     _sanitize_policy_error_for_user,
     _telemetry_window_signature,
+    _text_claims_step_complete,
 )
 from simtutor.schemas import validate_instance
 from tools.index_docs import build_index
@@ -9069,6 +9070,291 @@ def test_live_fixture_s18_bit_root_repairs_pb18_to_pb5() -> None:
     assert repaired.metadata["visual_hint_target"] == "right_mdi_pb5"
     assert repaired.metadata["final_action_plan"]["source"] == "visual_action_hint_repair"
     assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "right_mdi_pb5"
+
+
+def _validate_compact_live_help_response(
+    *,
+    request: TutorRequest,
+    response: TutorResponse,
+    vision_status: str = "vision_not_required",
+) -> TutorResponse:
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id=f"sess-{request.request_id}",
+        rag_top_k=0,
+        lang="zh",
+    )
+    try:
+        result = loop._validate_and_repair_live_help_response(
+            response,
+            request,
+            prompt_meta={},
+            state_key=f"state-{request.request_id}",
+            help_cycle_id=request.request_id,
+            vision_selection=HelpCycleVisionSelection(
+                status=vision_status,
+                observation_ref=None,
+                observation_seq=None,
+                observation_t_wall_s=None,
+                observation_t_wall_ms=None,
+                trigger_wall_ms=None,
+                sync_window_ms=None,
+                vision_used=False,
+                frame_id=None,
+                sync_status=None,
+                sync_delta_ms=None,
+                frame_stale=False,
+                frame_ids=[],
+                selected_frames=[],
+                pre_trigger_frame=None,
+                trigger_frame=None,
+                sync_miss_reason=None,
+            ),
+            vision_fact_context={
+                "status": vision_status,
+                "vision_fact_summary": {"status": vision_status},
+                "vision_facts": [],
+            },
+            vision_fact_active_step_ids=[],
+            terminal_state_short_circuited=False,
+        )
+        return result.response
+    finally:
+        loop.close()
+
+
+def test_live_help_fixture_299_s12_aligns_pb19_message_and_overlay() -> None:
+    request = TutorRequest(
+        request_id="2c936164-c567-4865-997c-ce65b827209d",
+        message="help",
+        context={
+            "vars": {
+                "ins_mode_cv_or_gnd": True,
+                "ins_mode_set": True,
+                "ins_fast_align_complete": False,
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S12",
+                "overlay_step_id": "S12",
+                "missing_conditions": ["vars.ins_fast_align_complete==true"],
+                "step_ui_targets": ["ins_mode_knob", "ampcd_pb19"],
+                "action_hint": {"target": "ampcd_pb19"},
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["ins_mode_knob", "ampcd_pb19"],
+            "rag_topk": [{"snippet_id": "DCS FA-18C Early Access Guide EN_115"}],
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="当前步骤 S12 未完成，需要设置 INS 模式。",
+        actions=[],
+        explanations=["当前步骤 S12 未完成，需要设置 INS 模式。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S12", "error_category": "OM"},
+                "next": {"step_id": "S12"},
+                "overlay": {
+                    "targets": ["ins_mode_knob"],
+                    "evidence": [
+                        {
+                            "target": "ins_mode_knob",
+                            "type": "rag",
+                            "ref": "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_115",
+                            "quote": "INS alignment guidance.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["当前步骤 S12 未完成，需要设置 INS 模式。"],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert [action["target"] for action in repaired.actions] == ["ampcd_pb19"]
+    assert "PB19" in repaired.message
+    assert "设置 INS 模式" not in repaired.message
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["final_overlay_targets"] == ["ampcd_pb19"]
+    assert repaired.metadata["final_action_plan"]["targets"] == ["ampcd_pb19"]
+    assert repaired.metadata["final_action_plan"]["source"] == "validator_action_hint"
+    assert "action_hint_target_mismatch:ins_mode_knob" in repaired.metadata["harness_validation_reasons"]
+    assert repaired.metadata["model_raw_help_response"]["overlay"]["targets"] == ["ins_mode_knob"]
+    assert repaired.metadata["help_response"]["overlay"]["targets"] == ["ampcd_pb19"]
+    assert repaired.metadata["final_public_response"]["message"] == repaired.message
+    assert repaired.metadata["final_public_response"]["explanations"] == [repaired.message]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "ampcd_pb19"
+
+
+def test_live_help_fixture_299_s12_carrier_keeps_ins_knob_until_cv_mode() -> None:
+    request = TutorRequest(
+        request_id="issue-299-s12-carrier-gnd",
+        message="help",
+        context={
+            "scenario_profile": "carrier",
+            "vars": {
+                "ins_mode": 2,
+                "ins_mode_cv_or_gnd": True,
+                "ins_mode_set": True,
+                "ins_fast_align_complete": False,
+            },
+            "gates": {
+                "S12.completion": {
+                    "status": "blocked",
+                    "reason_code": "s12_requires_ins_mode_cv",
+                }
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S12",
+                "overlay_step_id": "S12",
+                "scenario_profile": "carrier",
+                "missing_conditions": [
+                    "vars.ins_mode==1",
+                    "vars.ins_fast_align_complete==true",
+                ],
+                "step_ui_targets": ["ins_mode_knob", "ampcd_pb19"],
+                "action_hint": {"target": "ampcd_pb19"},
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["ins_mode_knob", "ampcd_pb19"],
+            "rag_topk": [{"snippet_id": "DCS FA-18C Early Access Guide EN_115"}],
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="INS 仍需设置到 CV。",
+        actions=[],
+        explanations=["INS 仍需设置到 CV。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S12", "error_category": "OM"},
+                "next": {"step_id": "S12"},
+                "overlay": {
+                    "targets": ["ins_mode_knob"],
+                    "evidence": [
+                        {
+                            "target": "ins_mode_knob",
+                            "type": "rag",
+                            "ref": "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_115",
+                            "quote": "Set INS mode to CV for carrier alignment.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["INS 仍需设置到 CV。"],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert [action["target"] for action in repaired.actions] == ["ins_mode_knob"]
+    assert "PB19" not in repaired.message
+    assert repaired.metadata["final_overlay_targets"] == ["ins_mode_knob"]
+    assert repaired.metadata["final_action_plan"]["targets"] == ["ins_mode_knob"]
+    assert repaired.metadata["final_action_plan"]["source"] == "model"
+    assert "action_hint_target_mismatch:ins_mode_knob" not in repaired.metadata["harness_validation_reasons"]
+
+
+def test_live_help_fixture_299_s17_keeps_takeoff_trim_overlay() -> None:
+    request = TutorRequest(
+        request_id="19115196-2759-42d9-82b5-2822cb322285",
+        message="help",
+        context={
+            "vars": {"takeoff_trim_set": False},
+            "gates": {
+                "S17.completion": {
+                    "status": "blocked",
+                    "reason_code": "s17_requires_takeoff_trim_pressed",
+                }
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S17",
+                "overlay_step_id": "S17",
+                "missing_conditions": ["vars.takeoff_trim_set==true"],
+                "step_ui_targets": ["takeoff_trim_button"],
+                "action_hint": {"target": "takeoff_trim_button"},
+                "observability_status": "partial",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["takeoff_trim_button"],
+        },
+    )
+    raw_message = "当前处于 S17 步骤，请按下 TAKEOFF TRIM 按钮以完成该步骤。"
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message=raw_message,
+        actions=[],
+        explanations=[raw_message],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S17", "error_category": "OM"},
+                "next": {"step_id": "S17"},
+                "overlay": {
+                    "targets": ["takeoff_trim_button"],
+                    "evidence": [
+                        {
+                            "target": "takeoff_trim_button",
+                            "type": "gate",
+                            "ref": "GATES.S17.completion",
+                            "quote": "Takeoff trim must be set.",
+                            "grounding_confidence": 0.95,
+                        }
+                    ],
+                },
+                "explanations": [raw_message],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert [action["target"] for action in repaired.actions] == ["takeoff_trim_button"]
+    assert repaired.metadata.get("completion_conflict_rewritten") is not True
+    assert "takeoff_trim_button" in repaired.message
+    assert repaired.explanations == [repaired.message]
+    assert repaired.metadata["next"]["step_id"] == "S17"
+    assert repaired.metadata["diagnosis"]["step_id"] == "S17"
+    assert repaired.metadata["final_overlay_targets"] == ["takeoff_trim_button"]
+    assert repaired.metadata["final_action_plan"]["targets"] == ["takeoff_trim_button"]
+    assert repaired.metadata["final_public_response"]["message"] == repaired.message
+    assert repaired.metadata["final_public_response"]["explanations"] == [repaired.message]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "takeoff_trim_button"
+
+
+def test_completion_claim_parser_distinguishes_guidance_from_completion_claim() -> None:
+    assert not _text_claims_step_complete(
+        "当前处于 S17 步骤，请按下 TAKEOFF TRIM 按钮以完成该步骤。",
+        "S17",
+    )
+    assert not _text_claims_step_complete(
+        "当前处于 S17 步骤，请按下 TAKEOFF TRIM 按钮完成该步骤。",
+        "S17",
+    )
+    assert _text_claims_step_complete(
+        "S20 已经通过展开受油管来完成。当前进入下一步。",
+        "S20",
+    )
+    assert _text_claims_step_complete(
+        "当前处于 S17 步骤，已按下 TAKEOFF TRIM 按钮完成该步骤。",
+        "S17",
+    )
 
 
 def test_map_response_actions_accepts_fake_llm_multi_target_help_response_when_enabled(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- repair S12 fast-align guidance so final message/help_response/action plan converge on ampcd_pb19 only after the profile-specific INS mode gate is satisfied
- keep S17 TAKEOFF TRIM guidance highlightable instead of letting completion-conflict parsing clear the overlay
- tighten completion-claim parsing for Chinese guidance vs real completion statements

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k "fixture_299 or completion_claim_parser or s12"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_pack_gates.py tests/test_live_dcs.py -k "s08 or s12 or s17 or s18 or s19 or s20 or s21 or s22 or s23 or s24 or s25 or s26 or s27 or fixture_299 or completion_claim_parser"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Fixes #299