### PR TITLE
Gate VLM facts by live progress floor

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -1318,6 +1318,14 @@ def _coerce_int(value: Any) -> int | None:
     return None
 
 
+def _is_pressed_delta_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    return False
+
+
 def _json_safe_scalar(value: Any) -> str | int | float | bool | None:
     if value is None or isinstance(value, (str, bool, int)):
         return value
@@ -4181,22 +4189,91 @@ class LiveDcsTutorLoop:
             vision_facts=None,
         )
 
+    def _next_step_id_after(self, step_id: str | None) -> str | None:
+        idx = self._step_order_index.get(step_id) if isinstance(step_id, str) else None
+        if idx is None:
+            return None
+        next_idx = idx + 1
+        if next_idx < 0 or next_idx >= len(self.candidate_steps):
+            return None
+        next_step_id = self.candidate_steps[next_idx]
+        return next_step_id if isinstance(next_step_id, str) and next_step_id else None
+
+    def _s08_page_navigation_recently_completed(self) -> bool:
+        bit_root_fact = self._vision_fact_snapshot.get("bit_root_page_visible")
+        if not (isinstance(bit_root_fact, Mapping) and bit_root_fact.get("state") == "seen"):
+            return False
+        fcs_fact = self._vision_fact_snapshot.get("fcs_page_visible")
+        if isinstance(fcs_fact, Mapping) and fcs_fact.get("state") == "seen":
+            return True
+        supt_fact = self._vision_fact_snapshot.get("supt_page_visible")
+        return (
+            isinstance(supt_fact, Mapping)
+            and supt_fact.get("state") == "seen"
+            and self._recent_target_after_fact("left_mdi_pb15", supt_fact)
+        )
+
+    def _recent_target_after_fact(self, target: str, fact: Mapping[str, Any]) -> bool:
+        observed_at_wall_ms = _coerce_int(fact.get("observed_at_wall_ms"))
+        if observed_at_wall_ms is None:
+            return False
+        recent_deltas = build_prompt_recent_deltas(self.recent_ring.snapshot(), self.mapper, max_items=20)
+        for item in recent_deltas:
+            if item.get("mapped_ui_target") != target:
+                continue
+            t_wall = _coerce_float(item.get("t_wall"))
+            if t_wall is None:
+                continue
+            if int(round(t_wall * 1000.0)) >= observed_at_wall_ms and _is_pressed_delta_value(item.get("to")):
+                return True
+        return False
+
     def _active_step_ids_for_vision_facts(
         self,
         preliminary_inference: StepInferenceResult,
+        *,
+        now_wall_ms: int | None = None,
     ) -> list[str]:
-        out: list[str] = []
+        if isinstance(now_wall_ms, int) and now_wall_ms >= 0:
+            self._vision_fact_snapshot = prune_expired_facts(
+                self._vision_fact_snapshot,
+                now_wall_ms=now_wall_ms,
+            )
         current_step_id = preliminary_inference.inferred_step_id
-        if isinstance(current_step_id, str) and current_step_id:
-            out.append(current_step_id)
-
+        last_step_id = self._last_inferred_step_id
         sticky_missing_has_visual_hold = any(
             isinstance(item, str) and item.startswith("vision_facts.")
             for item in self._sticky_inference_missing_conditions
         )
         sticky_step_id = self._sticky_inference_step_id
         sticky_idx = self._step_order_index.get(sticky_step_id) if isinstance(sticky_step_id, str) else None
+
+        if (
+            current_step_id == "S08"
+            and last_step_id == "S08"
+            and self._s08_page_navigation_recently_completed()
+        ):
+            current_step_id = self._next_step_id_after("S08")
+
         current_idx = self._step_order_index.get(current_step_id) if isinstance(current_step_id, str) else None
+        last_idx = self._step_order_index.get(last_step_id) if isinstance(last_step_id, str) else None
+        if current_idx is not None and last_idx is not None and current_idx < last_idx:
+            if (
+                last_step_id == "S19"
+                and not (
+                    sticky_missing_has_visual_hold
+                    and sticky_step_id == last_step_id
+                )
+            ):
+                current_step_id = self._next_step_id_after(last_step_id) or last_step_id
+            else:
+                current_step_id = last_step_id
+            current_idx = self._step_order_index.get(current_step_id) if isinstance(current_step_id, str) else None
+
+        out: list[str] = []
+        if isinstance(current_step_id, str) and current_step_id:
+            out.append(current_step_id)
+
         if (
             sticky_missing_has_visual_hold
             and isinstance(sticky_step_id, str)
@@ -6727,7 +6804,10 @@ class LiveDcsTutorLoop:
         )
         help_cycle_id = str(uuid4())
         preliminary_inference = self._infer_preliminary_step_for_vision_facts(obs)
-        vision_fact_active_step_ids = self._active_step_ids_for_vision_facts(preliminary_inference)
+        vision_fact_active_step_ids = self._active_step_ids_for_vision_facts(
+            preliminary_inference,
+            now_wall_ms=vision_selection.trigger_wall_ms,
+        )
         vision_fact_context = self._extract_vision_fact_context(
             vision_selection=vision_selection,
             help_cycle_id=help_cycle_id,

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -7188,6 +7188,283 @@ def test_live_loop_keeps_unresolved_visual_sticky_hold_for_regressed_preliminary
     assert advanced == ["S20"]
 
 
+def test_live_loop_suppresses_stale_visual_preliminary_behind_progress(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_stale_visual_preliminary.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-stale-visual-preliminary",
+    )
+    try:
+        loop._last_inferred_step_id = "S16"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()))
+    finally:
+        loop.close()
+
+    assert active == ["S16"]
+
+
+def test_live_loop_floors_stale_preliminary_to_non_visual_progress(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_non_visual_progress_floor.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-non-visual-progress-floor",
+    )
+    try:
+        loop._last_inferred_step_id = "S14"
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()))
+    finally:
+        loop.close()
+
+    assert active == ["S14"]
+
+
+def test_live_loop_preserves_visual_priority_progress_floor_with_nonvisual_hold(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_visual_progress_floor.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-visual-progress-floor",
+    )
+    try:
+        loop._last_inferred_step_id = "S15"
+        loop._sticky_inference_step_id = "S15"
+        loop._sticky_inference_missing_conditions = ("vars.fcs_reset_complete==true",)
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()))
+    finally:
+        loop.close()
+
+    assert active == ["S15"]
+
+
+def test_live_loop_advances_past_visual_progress_without_visual_hold(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_completed_visual_progress.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-completed-visual-progress",
+    )
+    try:
+        loop._last_inferred_step_id = "S19"
+        loop._sticky_inference_step_id = "S19"
+        loop._sticky_inference_missing_conditions = ("vars.ext_refuel_probe_value>=60000",)
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()))
+    finally:
+        loop.close()
+
+    assert active == ["S20"]
+
+
+def test_live_loop_treats_completed_s08_page_navigation_as_s09_for_vision_gate(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_completed_s08_navigation.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-s08-nav-complete",
+    )
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+        loop.recent_ring.add_delta({"LEFT_DDI_PB_15": 1}, t_wall=10.1, seq=2)
+        loop._vision_fact_snapshot = {
+            "bit_root_page_visible": {
+                "fact_id": "bit_root_page_visible",
+                "state": "seen",
+                "source_frame_id": "old-s08-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 10000,
+            },
+            "supt_page_visible": {
+                "fact_id": "supt_page_visible",
+                "state": "seen",
+                "source_frame_id": "old-s08-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 10000,
+            }
+        }
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()), now_wall_ms=10000)
+    finally:
+        loop.close()
+
+    assert active == ["S09"]
+
+
+def test_live_loop_does_not_complete_s08_navigation_from_pb15_before_supt_fact(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_early_pb15_s08_navigation.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-early-pb15-s08-nav",
+    )
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+        loop.recent_ring.add_delta({"LEFT_DDI_PB_15": 1}, t_wall=9.0, seq=1)
+        loop._vision_fact_snapshot = {
+            "bit_root_page_visible": {
+                "fact_id": "bit_root_page_visible",
+                "state": "seen",
+                "source_frame_id": "old-s08-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 10000,
+            },
+            "supt_page_visible": {
+                "fact_id": "supt_page_visible",
+                "state": "seen",
+                "source_frame_id": "old-s08-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 10000,
+            },
+        }
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()), now_wall_ms=11000)
+    finally:
+        loop.close()
+
+    assert active == ["S08"]
+
+
+def test_live_loop_does_not_complete_s08_navigation_from_pb15_release_after_supt_fact(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_pb15_release_s08_navigation.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-pb15-release-s08-nav",
+    )
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+        loop.recent_ring.add_delta({"LEFT_DDI_PB_15": 1}, t_wall=9.0, seq=1)
+        loop.recent_ring.add_delta({"LEFT_DDI_PB_15": 0}, t_wall=10.1, seq=2)
+        loop._vision_fact_snapshot = {
+            "bit_root_page_visible": {
+                "fact_id": "bit_root_page_visible",
+                "state": "seen",
+                "source_frame_id": "old-s08-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 10000,
+            },
+            "supt_page_visible": {
+                "fact_id": "supt_page_visible",
+                "state": "seen",
+                "source_frame_id": "old-s08-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 10000,
+            },
+        }
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()), now_wall_ms=11000)
+    finally:
+        loop.close()
+
+    assert active == ["S08"]
+
+
+def test_live_loop_does_not_complete_s08_navigation_without_bit_root(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_incomplete_s08_navigation.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-incomplete-s08-nav",
+    )
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+        loop._step_interacted_targets = {"left_mdi_pb15"}
+        loop._vision_fact_snapshot = {
+            "supt_page_visible": {
+                "fact_id": "supt_page_visible",
+                "state": "seen",
+                "source_frame_id": "old-s08-frame",
+                "sticky": False,
+            }
+        }
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()), now_wall_ms=10000)
+    finally:
+        loop.close()
+
+    assert active == ["S08"]
+
+
+def test_live_loop_does_not_complete_s08_navigation_from_expired_visual_fact(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_expired_s08_navigation.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-expired-s08-nav",
+    )
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+        loop._step_interacted_targets = {"left_mdi_pb15"}
+        loop.recent_ring.add_delta({"LEFT_DDI_PB_15": 1}, t_wall=9.5, seq=1)
+        loop._vision_fact_snapshot = {
+            "bit_root_page_visible": {
+                "fact_id": "bit_root_page_visible",
+                "state": "seen",
+                "source_frame_id": "fresh-bit-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 9500,
+                "expires_at_wall_ms": 12000,
+            },
+            "supt_page_visible": {
+                "fact_id": "supt_page_visible",
+                "state": "seen",
+                "source_frame_id": "expired-s08-frame",
+                "sticky": False,
+                "observed_at_wall_ms": 8000,
+                "expires_at_wall_ms": 9000,
+            }
+        }
+
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S08", ()), now_wall_ms=10000)
+    finally:
+        loop.close()
+
+    assert active == ["S08"]
+
+
 def test_live_loop_ignores_stale_s19_visual_facts_for_s21(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_s21_ignores_stale_s19_vlm.jsonl"
     frame = _bios_frame(1, 10.0, apu_switch=1)


### PR DESCRIPTION
## Summary
- keep VLM active-step gating from trusting stale S08 preliminary inference when live progress is already on a later non-visual step
- prune cached vision facts before the S08 navigation shortcut and require BIT-root evidence plus a real PB15 press after SUPT before treating S08 navigation as complete
- keep S15/S18/S19 visual-priority paths available while preventing completed S19 from leaking sticky VLM facts into S20/S21
- add regression coverage for stale S08 preliminary, S15/S19 progress floor, and S08 shortcut freshness/order/release edges

Fixes #298

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py tests/test_evidence_packet.py tests/test_help_cycle_audit.py tests/test_live_replay_fixture.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full