### PR TITLE
Handle S20/S21 refuel probe motion settling

### DIFF
--- a/core/evidence_packet.py
+++ b/core/evidence_packet.py
@@ -1062,7 +1062,11 @@ def _supports_later_avionics(digest: TelemetryWindowDigest) -> bool:
     return False
 
 
-def _telemetry_progression_candidates(digest: TelemetryWindowDigest) -> tuple[tuple[str, str, str, str, bool], ...]:
+def _telemetry_progression_candidates(
+    digest: TelemetryWindowDigest,
+    *,
+    deterministic_step_id: str | None = None,
+) -> tuple[tuple[str, str, str, str, bool], ...]:
     changed = _changed_var_map(digest)
     out: list[tuple[str, str, str, str, bool]] = []
 
@@ -1070,11 +1074,18 @@ def _telemetry_progression_candidates(digest: TelemetryWindowDigest) -> tuple[tu
     if probe is not None:
         first = _coerce_number(probe.get("first_value"))
         last = _coerce_number(probe.get("last_value"))
+        transition_count = _coerce_number(probe.get("transition_count")) or 0
         if last is not None and last >= 60000:
             out.append(("S21", "changed_vars", "ext_refuel_probe_value", "", False))
         elif last is not None and last <= 5000:
             out.append(("S22", "changed_vars", "ext_refuel_probe_value", "", False))
-        elif first is not None and last is not None and last > first:
+        elif (
+            deterministic_step_id == "S20"
+            and transition_count > 0
+            and first is not None
+            and last is not None
+            and last > first
+        ):
             out.append((
                 "S20",
                 "changed_vars",
@@ -1082,7 +1093,13 @@ def _telemetry_progression_candidates(digest: TelemetryWindowDigest) -> tuple[tu
                 "refueling probe extending in progress",
                 True,
             ))
-        elif first is not None and last is not None and last < first:
+        elif (
+            deterministic_step_id == "S21"
+            and transition_count > 0
+            and first is not None
+            and last is not None
+            and last < first
+        ):
             out.append((
                 "S21",
                 "changed_vars",
@@ -1168,6 +1185,7 @@ def build_step_candidates(
             )
         )
 
+    deterministic_step_id = packet.deterministic_candidate.step_id
     telemetry_digest = packet.telemetry_window_digest
     if telemetry_digest.frame_count:
         if _has_first_frame_false(telemetry_digest, "battery_on") and _supports_later_avionics(telemetry_digest):
@@ -1240,7 +1258,10 @@ def build_step_candidates(
                 )
             )
 
-        for step_id, ref_kind, var_name, reason, suppress_targets in _telemetry_progression_candidates(telemetry_digest):
+        for step_id, ref_kind, var_name, reason, suppress_targets in _telemetry_progression_candidates(
+            telemetry_digest,
+            deterministic_step_id=deterministic_step_id,
+        ):
             _append(
                 StepCandidate(
                     step_id=step_id,
@@ -1257,7 +1278,6 @@ def build_step_candidates(
                 )
             )
 
-    deterministic_step_id = packet.deterministic_candidate.step_id
     if isinstance(deterministic_step_id, str) and deterministic_step_id:
         _append(
             StepCandidate(

--- a/core/evidence_packet.py
+++ b/core/evidence_packet.py
@@ -1062,40 +1062,57 @@ def _supports_later_avionics(digest: TelemetryWindowDigest) -> bool:
     return False
 
 
-def _telemetry_progression_candidates(digest: TelemetryWindowDigest) -> tuple[tuple[str, str, str], ...]:
+def _telemetry_progression_candidates(digest: TelemetryWindowDigest) -> tuple[tuple[str, str, str, str, bool], ...]:
     changed = _changed_var_map(digest)
-    out: list[tuple[str, str, str]] = []
+    out: list[tuple[str, str, str, str, bool]] = []
 
     probe = changed.get("ext_refuel_probe_value")
     if probe is not None:
+        first = _coerce_number(probe.get("first_value"))
         last = _coerce_number(probe.get("last_value"))
         if last is not None and last >= 60000:
-            out.append(("S21", "changed_vars", "ext_refuel_probe_value"))
+            out.append(("S21", "changed_vars", "ext_refuel_probe_value", "", False))
         elif last is not None and last <= 5000:
-            out.append(("S22", "changed_vars", "ext_refuel_probe_value"))
+            out.append(("S22", "changed_vars", "ext_refuel_probe_value", "", False))
+        elif first is not None and last is not None and last > first:
+            out.append((
+                "S20",
+                "changed_vars",
+                "ext_refuel_probe_value",
+                "refueling probe extending in progress",
+                True,
+            ))
+        elif first is not None and last is not None and last < first:
+            out.append((
+                "S21",
+                "changed_vars",
+                "ext_refuel_probe_value",
+                "refueling probe retracting in progress",
+                True,
+            ))
 
     launch_bar = changed.get("launch_bar_switch_value")
     if launch_bar is not None:
         last = _coerce_number(launch_bar.get("last_value"))
         if last == 1:
-            out.append(("S23", "changed_vars", "launch_bar_switch_value"))
+            out.append(("S23", "changed_vars", "launch_bar_switch_value", "", False))
         elif last == 0:
-            out.append(("S24", "changed_vars", "launch_bar_switch_value"))
+            out.append(("S24", "changed_vars", "launch_bar_switch_value", "", False))
 
     hook = changed.get("hook_handle_value")
     if hook is not None:
         last = _coerce_number(hook.get("last_value"))
         if last == 1:
-            out.append(("S25", "changed_vars", "hook_handle_value"))
+            out.append(("S25", "changed_vars", "hook_handle_value", "", False))
         elif last == 0:
-            out.append(("S26", "changed_vars", "hook_handle_value"))
+            out.append(("S26", "changed_vars", "hook_handle_value", "", False))
 
     pitot = changed.get("pitot_heat_on")
     if pitot is not None and pitot.get("last_value") is True:
-        out.append(("S27", "changed_vars", "pitot_heat_on"))
+        out.append(("S27", "changed_vars", "pitot_heat_on", "", False))
     changed = _changed_var_map(digest)
 
-    def _age(item: tuple[str, str, str]) -> float:
+    def _age(item: tuple[str, str, str, str, bool]) -> float:
         changed_item = changed.get(item[2])
         if changed_item is None:
             return 999999.0
@@ -1223,7 +1240,7 @@ def build_step_candidates(
                 )
             )
 
-        for step_id, ref_kind, var_name in _telemetry_progression_candidates(telemetry_digest):
+        for step_id, ref_kind, var_name, reason, suppress_targets in _telemetry_progression_candidates(telemetry_digest):
             _append(
                 StepCandidate(
                     step_id=step_id,
@@ -1233,8 +1250,10 @@ def build_step_candidates(
                     refuting_evidence_refs=(),
                     confidence=0.7,
                     missing_conditions=(),
-                    proposed_next_action_target_ids=_targets_for_step(step_id, step_harness_specs),
-                    reason=_candidate_reason("telemetry_window", step_id),
+                    proposed_next_action_target_ids=(
+                        () if suppress_targets else _targets_for_step(step_id, step_harness_specs)
+                    ),
+                    reason=reason or _candidate_reason("telemetry_window", step_id),
                 )
             )
 

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2491,6 +2491,51 @@ def _s08_visual_hint_from_seen_evidence_refs(
     return None
 
 
+def _state_harness_changed_var(context: Mapping[str, Any], var_name: str) -> Mapping[str, Any] | None:
+    state_harness = context.get("state_harness")
+    if not isinstance(state_harness, Mapping):
+        return None
+    digest = state_harness.get("telemetry_window_digest")
+    if not isinstance(digest, Mapping):
+        return None
+    changed_vars = digest.get("changed_vars")
+    if not isinstance(changed_vars, (list, tuple)):
+        return None
+    for item in changed_vars:
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("var") == var_name:
+            return item
+    return None
+
+
+def _refuel_probe_motion_state(context: Mapping[str, Any], step_id: str | None) -> str | None:
+    vars_selected = context.get("vars")
+    vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+    probe_value = _coerce_float(vars_map.get("ext_refuel_probe_value"))
+    switch_value = _coerce_int(vars_map.get("probe_switch_value"))
+    changed = _state_harness_changed_var(context, "ext_refuel_probe_value")
+    first_value = _coerce_float(changed.get("first_value")) if isinstance(changed, Mapping) else None
+    last_value = _coerce_float(changed.get("last_value")) if isinstance(changed, Mapping) else None
+    is_extending = first_value is not None and last_value is not None and last_value > first_value
+    is_retracting = first_value is not None and last_value is not None and last_value < first_value
+
+    if step_id == "S20":
+        if vars_map.get("probe_extended") is True or (probe_value is not None and probe_value >= 60000):
+            return "s20_extended"
+        if switch_value == 0 and probe_value is not None and 0 < probe_value < 60000 and is_extending:
+            return "s20_extending"
+    elif step_id == "S21":
+        if vars_map.get("probe_retracted") is True or (probe_value is not None and probe_value <= 5000):
+            return "s21_retracted"
+        near_retract_threshold = probe_value is not None and 5000 < probe_value <= 7000
+        if switch_value == 1 and probe_value is not None and probe_value > 5000 and (
+            is_retracting or near_retract_threshold
+        ):
+            return "s21_retracting"
+    return None
+
+
 def _build_procedural_action_hint(
     *,
     inferred_step_id: str | None,
@@ -4789,6 +4834,8 @@ class LiveDcsTutorLoop:
     ) -> bool:
         if bool(response.metadata.get("bootstrap_low_confidence_guardrail_applied")):
             return False
+        if bool(response.metadata.get("refuel_probe_motion_guidance_rewritten")):
+            return False
         if response.actions:
             return False
         if response.status == "error":
@@ -5857,6 +5904,16 @@ class LiveDcsTutorLoop:
             vision_seen_or_fresh.update(item for item in raw_fact_ids if isinstance(item, str) and item)
         rewritten: str | None = None
         reason = "not_applicable"
+
+        def _set_text_only_help_response(step_id: str, text: str) -> None:
+            help_response = response.metadata.get("help_response")
+            rewritten_help_response = dict(help_response) if isinstance(help_response, Mapping) else {}
+            rewritten_help_response["diagnosis"] = {"step_id": step_id, "error_category": "OM"}
+            rewritten_help_response["next"] = {"step_id": step_id}
+            rewritten_help_response["overlay"] = {"targets": [], "evidence": []}
+            rewritten_help_response["explanations"] = [text]
+            response.metadata["help_response"] = rewritten_help_response
+
         if inferred_step_id == "S02":
             if "vars.fire_test_a_complete==true" in missing_set:
                 reason = "s02_fire_test_a_guidance"
@@ -5933,6 +5990,47 @@ class LiveDcsTutorLoop:
                     rewritten = "INS 已设置到对准模式。现在请到 AMPCD 按 PB19，启动快速 INS 校准。"
                 else:
                     rewritten = "INS is already set for alignment. Press AMPCD PB19 now to start fast INS alignment."
+        elif inferred_step_id in {"S20", "S21"}:
+            probe_motion_state = _refuel_probe_motion_state(context, inferred_step_id)
+            if probe_motion_state == "s20_extending":
+                reason = "s20_refuel_probe_extending_wait"
+                if self.lang == "zh":
+                    rewritten = "受油管正在伸出。请等待它完全伸出后，再继续四落检查。"
+                else:
+                    rewritten = "The refueling probe is extending. Wait until it is fully extended before continuing the four-down check."
+                response.actions = []
+                response.metadata["diagnosis"] = {"step_id": "S20", "error_category": "OM"}
+                response.metadata["next"] = {"step_id": "S20"}
+                _set_text_only_help_response("S20", rewritten)
+            elif probe_motion_state == "s21_retracting":
+                reason = "s21_refuel_probe_retracting_wait"
+                if self.lang == "zh":
+                    rewritten = "受油管正在收起，已经接近收起阈值。请等待它完全收好后，再继续下一步。"
+                else:
+                    rewritten = "The refueling probe is retracting and is near the stowed threshold. Wait until it is fully stowed before continuing."
+                response.actions = []
+                response.metadata["diagnosis"] = {"step_id": "S21", "error_category": "OM"}
+                response.metadata["next"] = {"step_id": "S21"}
+                _set_text_only_help_response("S21", rewritten)
+            elif probe_motion_state == "s21_retracted":
+                reason = "s21_refuel_probe_retracted_complete"
+                if self.lang == "zh":
+                    rewritten = "受油管已经完全收起，S21 已完成。下一步进入 S22，准备放下 launch bar。"
+                else:
+                    rewritten = "The refueling probe is fully stowed, so S21 is complete. Continue to S22 by extending the launch bar."
+                response.actions = []
+                response.metadata["diagnosis"] = {"step_id": "S22", "error_category": "OM"}
+                response.metadata["next"] = {"step_id": "S22"}
+                _set_text_only_help_response("S22", rewritten)
+                fallback_used, fallback_reason = self._apply_safe_fallback_overlay(
+                    response,
+                    request,
+                    override_inferred_step_id="S22",
+                    override_overlay_step_id="S22",
+                    ignore_request_allowlist=True,
+                )
+                response.metadata["refuel_probe_completion_s22_overlay_applied"] = fallback_used
+                response.metadata["refuel_probe_completion_s22_overlay_reason"] = fallback_reason
         elif inferred_step_id == "S19":
             if "fcsmc_final_go_result_visible" in vision_seen_or_fresh:
                 reason = "s19_final_go_complete"
@@ -6032,6 +6130,8 @@ class LiveDcsTutorLoop:
         response.explanations = [rewritten]
         response.metadata["procedural_guidance_rewritten"] = True
         response.metadata["procedural_guidance_rewrite_reason"] = reason
+        if reason.startswith(("s20_refuel_probe_", "s21_refuel_probe_")):
+            response.metadata["refuel_probe_motion_guidance_rewritten"] = True
         if original_message != rewritten:
             response.metadata["procedural_guidance_original_message"] = original_message
         if original_explanations and original_explanations != [rewritten]:

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -4933,6 +4933,8 @@ class LiveDcsTutorLoop:
                 if isinstance(item, str) and item
             }
         inferred_step_id = hint.get("inferred_step_id")
+        if response.metadata.get("refuel_probe_motion_guidance_rewritten") is True:
+            return False, "refuel_probe_motion_wait_already_rewritten"
         action_hint = hint.get("action_hint")
         if bool(hint.get("requires_visual_confirmation")) is True:
             if isinstance(action_hint, Mapping):

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -5306,6 +5306,8 @@ class LiveDcsTutorLoop:
 
         inferred_step_id = hint.get("inferred_step_id")
         overlay_step_id = hint.get("overlay_step_id")
+        if response.metadata.get("refuel_probe_motion_guidance_rewritten") is True:
+            return False, "refuel_probe_motion_wait_already_rewritten"
         if response.metadata.get("completion_conflict_rewritten") is True:
             return False, "completion_conflict_already_rewritten"
         response_mapping_meta = response.metadata.get("response_mapping")
@@ -6002,6 +6004,25 @@ class LiveDcsTutorLoop:
                 response.metadata["diagnosis"] = {"step_id": "S20", "error_category": "OM"}
                 response.metadata["next"] = {"step_id": "S20"}
                 _set_text_only_help_response("S20", rewritten)
+            elif probe_motion_state == "s20_extended":
+                reason = "s20_refuel_probe_extended_complete"
+                if self.lang == "zh":
+                    rewritten = "受油管已经完全伸出，S20 已完成。下一步进入 S21，收起受油管。"
+                else:
+                    rewritten = "The refueling probe is fully extended, so S20 is complete. Continue to S21 by retracting the probe."
+                response.actions = []
+                response.metadata["diagnosis"] = {"step_id": "S21", "error_category": "OM"}
+                response.metadata["next"] = {"step_id": "S21"}
+                _set_text_only_help_response("S21", rewritten)
+                fallback_used, fallback_reason = self._apply_safe_fallback_overlay(
+                    response,
+                    request,
+                    override_inferred_step_id="S21",
+                    override_overlay_step_id="S21",
+                    ignore_request_allowlist=True,
+                )
+                response.metadata["refuel_probe_completion_s21_overlay_applied"] = fallback_used
+                response.metadata["refuel_probe_completion_s21_overlay_reason"] = fallback_reason
             elif probe_motion_state == "s21_retracting":
                 reason = "s21_refuel_probe_retracting_wait"
                 if self.lang == "zh":

--- a/tests/test_evidence_packet.py
+++ b/tests/test_evidence_packet.py
@@ -530,6 +530,36 @@ def test_telemetry_window_candidates_mark_refuel_probe_motion_in_progress() -> N
     assert telemetry_candidate["proposed_next_action_target_ids"] == []
 
 
+def test_telemetry_window_candidates_mark_refuel_probe_extension_in_progress() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {
+                "probe_switch_value": 0,
+                "ext_refuel_probe_value": 12000,
+                "probe_extended": False,
+            },
+            "telemetry_window_frames": [
+                {"seq": 901, "t_wall": 40.0, "vars": {"ext_refuel_probe_value": 8000}},
+                {"seq": 902, "t_wall": 40.1, "vars": {"ext_refuel_probe_value": 12000}},
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S20",
+                "missing_conditions": ["vars.ext_refuel_probe_value in [60000,65535]"],
+            },
+        }
+    )
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+    telemetry_candidate = next(
+        item
+        for item in candidates
+        if item["source"] == "telemetry_window" and item["step_id"] == "S20"
+    )
+
+    assert telemetry_candidate["reason"] == "refueling probe extending in progress"
+    assert telemetry_candidate["proposed_next_action_target_ids"] == []
+
+
 def test_telemetry_window_candidates_advance_after_refuel_probe_retracted() -> None:
     packet = build_evidence_packet(
         {

--- a/tests/test_evidence_packet.py
+++ b/tests/test_evidence_packet.py
@@ -500,6 +500,57 @@ def test_telemetry_window_candidates_cover_four_down_progression_from_telemetry_
     assert all(item["supporting_evidence_refs"][0].startswith("TELEMETRY_WINDOW.") for item in candidates if item["source"] == "telemetry_window")
 
 
+def test_telemetry_window_candidates_mark_refuel_probe_motion_in_progress() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {
+                "probe_switch_value": 1,
+                "ext_refuel_probe_value": 5606,
+                "probe_retracted": False,
+            },
+            "telemetry_window_frames": [
+                {"seq": 9675, "t_wall": 100.0, "vars": {"ext_refuel_probe_value": 6200}},
+                {"seq": 9676, "t_wall": 100.1, "vars": {"ext_refuel_probe_value": 5606}},
+            ],
+            "deterministic_step_hint": {
+                "inferred_step_id": "S21",
+                "missing_conditions": ["vars.ext_refuel_probe_value in [0,5000]"],
+            },
+        }
+    )
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+    telemetry_candidate = next(
+        item
+        for item in candidates
+        if item["source"] == "telemetry_window" and item["step_id"] == "S21"
+    )
+
+    assert telemetry_candidate["reason"] == "refueling probe retracting in progress"
+    assert telemetry_candidate["proposed_next_action_target_ids"] == []
+
+
+def test_telemetry_window_candidates_advance_after_refuel_probe_retracted() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {
+                "probe_switch_value": 1,
+                "ext_refuel_probe_value": 4652,
+                "probe_retracted": True,
+            },
+            "telemetry_window_frames": [
+                {"seq": 9676, "t_wall": 100.0, "vars": {"ext_refuel_probe_value": 5606}},
+                {"seq": 9678, "t_wall": 100.2, "vars": {"ext_refuel_probe_value": 4652}},
+            ],
+        }
+    )
+
+    candidates = [item.to_dict() for item in build_step_candidates(packet)]
+    telemetry_steps = [item["step_id"] for item in candidates if item["source"] == "telemetry_window"]
+
+    assert telemetry_steps[0] == "S22"
+
+
 def test_telemetry_window_sparse_delta_does_not_mark_first_frame_only_value() -> None:
     packet = build_evidence_packet(
         {

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -5439,6 +5439,138 @@ def test_s19_final_go_trace_preserves_raw_model_step_before_guardrail(tmp_path: 
         loop.close()
 
 
+def test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s21_probe_retracting.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=0,
+        lang="zh",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "vars": {
+                    "probe_switch_value": 1,
+                    "ext_refuel_probe_value": 5606,
+                    "probe_retracted": False,
+                },
+                "state_harness": {
+                    "telemetry_window_digest": {
+                        "frame_count": 2,
+                        "changed_vars": [
+                            {
+                                "var": "ext_refuel_probe_value",
+                                "first_value": 6200,
+                                "last_value": 5606,
+                                "transition_count": 1,
+                            }
+                        ],
+                    }
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S21",
+                    "missing_conditions": ["vars.ext_refuel_probe_value in [0,5000]"],
+                },
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+            actions=[{"kind": "highlight", "target": "refuel_probe_switch"}],
+            explanations=["当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"],
+            metadata={
+                "next": {"step_id": "S21"},
+                "diagnosis": {"step_id": "S21", "error_category": "CO"},
+                "help_response": {
+                    "diagnosis": {"step_id": "S21", "error_category": "CO"},
+                    "next": {"step_id": "S21"},
+                    "overlay": {"targets": ["refuel_probe_switch"], "evidence": []},
+                    "explanations": ["当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"],
+                },
+            },
+        )
+
+        rewritten, reason = loop._rewrite_procedural_guidance_response(response, request)
+
+        assert rewritten is True
+        assert reason == "s21_refuel_probe_retracting_wait"
+        assert response.actions == []
+        assert "正在收起" in response.message
+        assert "等待" in response.message
+        assert "vars.ext_refuel_probe_value" not in response.message
+        assert response.metadata["help_response"]["overlay"]["targets"] == []
+        assert loop._should_use_deterministic_overlay_fallback(response, request, None) is False
+    finally:
+        loop.close()
+
+
+def test_procedural_guidance_waits_without_highlight_for_s20_probe_extending(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s20_probe_extending.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=0,
+        lang="zh",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "vars": {
+                    "probe_switch_value": 0,
+                    "ext_refuel_probe_value": 12000,
+                    "probe_extended": False,
+                },
+                "state_harness": {
+                    "telemetry_window_digest": {
+                        "frame_count": 2,
+                        "changed_vars": [
+                            {
+                                "var": "ext_refuel_probe_value",
+                                "first_value": 8000,
+                                "last_value": 12000,
+                                "transition_count": 1,
+                            }
+                        ],
+                    }
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S20",
+                    "missing_conditions": ["vars.ext_refuel_probe_value in [60000,65535]"],
+                },
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="当前 S20 尚未完成，请先操作 refuel_probe_switch。",
+            actions=[{"kind": "highlight", "target": "refuel_probe_switch"}],
+            explanations=["当前 S20 尚未完成，请先操作 refuel_probe_switch。"],
+            metadata={"next": {"step_id": "S20"}},
+        )
+
+        rewritten, reason = loop._rewrite_procedural_guidance_response(response, request)
+
+        assert rewritten is True
+        assert reason == "s20_refuel_probe_extending_wait"
+        assert response.actions == []
+        assert "正在伸出" in response.message
+        assert "等待" in response.message
+        assert "refuel_probe_switch" not in response.message
+        assert loop._should_use_deterministic_overlay_fallback(response, request, None) is False
+    finally:
+        loop.close()
+
+
 def test_procedural_guidance_rewrite_mentions_s09_frequency_134(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_s09_frequency_rewrite.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -5476,6 +5476,7 @@ def test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting(tm
                 "deterministic_step_hint": {
                     "inferred_step_id": "S21",
                     "missing_conditions": ["vars.ext_refuel_probe_value in [0,5000]"],
+                    "action_hint": {"target": "refuel_probe_switch"},
                 },
             },
         )
@@ -5504,7 +5505,15 @@ def test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting(tm
         assert "正在收起" in response.message
         assert "等待" in response.message
         assert "vars.ext_refuel_probe_value" not in response.message
+        assert all("vars.ext_refuel_probe_value" not in item for item in response.explanations)
         assert response.metadata["help_response"]["overlay"]["targets"] == []
+        assert all(
+            "vars.ext_refuel_probe_value" not in item
+            for item in response.metadata["help_response"]["explanations"]
+        )
+        planned, plan_reason = loop._apply_harness_validation_action_plan(response, request)
+        assert planned is False
+        assert plan_reason == "refuel_probe_motion_wait_already_rewritten"
         assert loop._should_use_deterministic_overlay_fallback(response, request, None) is False
     finally:
         loop.close()
@@ -5547,6 +5556,7 @@ def test_procedural_guidance_waits_without_highlight_for_s20_probe_extending(tmp
                 "deterministic_step_hint": {
                     "inferred_step_id": "S20",
                     "missing_conditions": ["vars.ext_refuel_probe_value in [60000,65535]"],
+                    "action_hint": {"target": "refuel_probe_switch"},
                 },
             },
         )
@@ -5566,7 +5576,134 @@ def test_procedural_guidance_waits_without_highlight_for_s20_probe_extending(tmp
         assert "正在伸出" in response.message
         assert "等待" in response.message
         assert "refuel_probe_switch" not in response.message
+        assert all("refuel_probe_switch" not in item for item in response.explanations)
+        planned, plan_reason = loop._apply_harness_validation_action_plan(response, request)
+        assert planned is False
+        assert plan_reason == "refuel_probe_motion_wait_already_rewritten"
         assert loop._should_use_deterministic_overlay_fallback(response, request, None) is False
+    finally:
+        loop.close()
+
+
+def test_procedural_guidance_advances_to_s22_when_s21_probe_retracted(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s21_probe_retracted.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=0,
+        lang="zh",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "vars": {
+                    "probe_switch_value": 1,
+                    "ext_refuel_probe_value": 4652,
+                    "probe_retracted": True,
+                },
+                "gates": {
+                    "S22.completion": {
+                        "status": "blocked",
+                        "step_id": "S22",
+                        "reason_code": "s22_requires_launch_bar_extended",
+                        "reason": "Launch bar must be extended.",
+                    }
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S21",
+                    "missing_conditions": ["vars.ext_refuel_probe_value in [0,5000]"],
+                    "gate_blockers": [
+                        {
+                            "ref": "S22.completion",
+                            "reason_code": "s22_requires_launch_bar_extended",
+                            "reason": "Launch bar must be extended.",
+                        }
+                    ],
+                },
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+            actions=[{"kind": "highlight", "target": "refuel_probe_switch"}],
+            explanations=["当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"],
+            metadata={"next": {"step_id": "S21"}},
+        )
+
+        rewritten, reason = loop._rewrite_procedural_guidance_response(response, request)
+
+        assert rewritten is True
+        assert reason == "s21_refuel_probe_retracted_complete"
+        assert response.metadata["next"]["step_id"] == "S22"
+        assert response.metadata["diagnosis"]["step_id"] == "S22"
+        assert response.metadata["help_response"]["next"]["step_id"] == "S22"
+        assert response.metadata["help_response"]["overlay"]["targets"] == []
+        assert response.metadata["refuel_probe_completion_s22_overlay_applied"] is True
+        assert response.actions
+        assert response.actions[0]["target"] == "launch_bar_switch"
+        assert "vars.ext_refuel_probe_value" not in response.message
+    finally:
+        loop.close()
+
+
+def test_procedural_guidance_advances_to_s21_when_s20_probe_extended(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s20_probe_extended.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=0,
+        lang="zh",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "vars": {
+                    "probe_switch_value": 0,
+                    "ext_refuel_probe_value": 65000,
+                    "probe_extended": True,
+                },
+                "gates": {
+                    "S21.completion": {
+                        "status": "blocked",
+                        "step_id": "S21",
+                        "reason_code": "s21_requires_probe_retracted",
+                        "reason": "Refueling probe must be fully retracted.",
+                    }
+                },
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S20",
+                    "missing_conditions": ["vars.ext_refuel_probe_value in [60000,65535]"],
+                },
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="当前 S20 尚未完成，请先操作 refuel_probe_switch。",
+            actions=[{"kind": "highlight", "target": "refuel_probe_switch"}],
+            explanations=["当前 S20 尚未完成，请先操作 refuel_probe_switch。"],
+            metadata={"next": {"step_id": "S20"}},
+        )
+
+        rewritten, reason = loop._rewrite_procedural_guidance_response(response, request)
+
+        assert rewritten is True
+        assert reason == "s20_refuel_probe_extended_complete"
+        assert response.metadata["next"]["step_id"] == "S21"
+        assert response.metadata["diagnosis"]["step_id"] == "S21"
+        assert response.metadata["refuel_probe_completion_s21_overlay_applied"] is True
+        assert response.actions
+        assert response.actions[0]["target"] == "refuel_probe_switch"
+        assert "尚未完成" not in response.message
     finally:
         loop.close()
 

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -5575,8 +5575,14 @@ def test_procedural_guidance_waits_without_highlight_for_s20_probe_extending(tmp
         assert response.actions == []
         assert "正在伸出" in response.message
         assert "等待" in response.message
+        assert "vars.ext_refuel_probe_value" not in response.message
         assert "refuel_probe_switch" not in response.message
+        assert all("vars.ext_refuel_probe_value" not in item for item in response.explanations)
         assert all("refuel_probe_switch" not in item for item in response.explanations)
+        assert all(
+            "vars.ext_refuel_probe_value" not in item
+            for item in response.metadata["help_response"]["explanations"]
+        )
         planned, plan_reason = loop._apply_harness_validation_action_plan(response, request)
         assert planned is False
         assert plan_reason == "refuel_probe_motion_wait_already_rewritten"
@@ -5617,6 +5623,7 @@ def test_procedural_guidance_advances_to_s22_when_s21_probe_retracted(tmp_path: 
                 "deterministic_step_hint": {
                     "inferred_step_id": "S21",
                     "missing_conditions": ["vars.ext_refuel_probe_value in [0,5000]"],
+                    "action_hint": {"target": "refuel_probe_switch"},
                     "gate_blockers": [
                         {
                             "ref": "S22.completion",
@@ -5647,6 +5654,15 @@ def test_procedural_guidance_advances_to_s22_when_s21_probe_retracted(tmp_path: 
         assert response.actions
         assert response.actions[0]["target"] == "launch_bar_switch"
         assert "vars.ext_refuel_probe_value" not in response.message
+        assert all("vars.ext_refuel_probe_value" not in item for item in response.explanations)
+        assert all(
+            "vars.ext_refuel_probe_value" not in item
+            for item in response.metadata["help_response"]["explanations"]
+        )
+        overridden, override_reason = loop._apply_action_hint_overlay_override(response, request)
+        assert overridden is False
+        assert override_reason == "refuel_probe_motion_wait_already_rewritten"
+        assert response.actions[0]["target"] == "launch_bar_switch"
     finally:
         loop.close()
 
@@ -5703,6 +5719,12 @@ def test_procedural_guidance_advances_to_s21_when_s20_probe_extended(tmp_path: P
         assert response.metadata["refuel_probe_completion_s21_overlay_applied"] is True
         assert response.actions
         assert response.actions[0]["target"] == "refuel_probe_switch"
+        assert "vars.ext_refuel_probe_value" not in response.message
+        assert all("vars.ext_refuel_probe_value" not in item for item in response.explanations)
+        assert all(
+            "vars.ext_refuel_probe_value" not in item
+            for item in response.metadata["help_response"]["explanations"]
+        )
         assert "尚未完成" not in response.message
     finally:
         loop.close()


### PR DESCRIPTION
## Summary
- detect refuel probe extension/retraction motion in telemetry-window candidates
- rewrite S20/S21 in-progress probe guidance to wait/no-highlight text instead of raw missing predicates
- prevent deterministic overlay fallback from re-highlighting the probe switch during motion wait

## Tests
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_evidence_packet.py::test_telemetry_window_candidates_mark_refuel_probe_motion_in_progress tests/test_evidence_packet.py::test_telemetry_window_candidates_advance_after_refuel_probe_retracted tests/test_live_dcs.py::test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting tests/test_live_dcs.py::test_procedural_guidance_waits_without_highlight_for_s20_probe_extending
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_evidence_packet.py tests/test_live_dcs.py
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_pack_gates.py tests/test_telemetry_pipeline.py tests/test_var_resolver.py
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=/tmp/iefmmq-pytest-full-306-escalated-nocap

Fixes #306