### PR TITLE
Fix S09 UFC sequence planning

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2346,6 +2346,8 @@ def _missing_conditions_satisfied_by_vars(
         var_name = matched.group(1)
         if "==true" in condition:
             checked = True
+            if var_name == "comm1_freq_134_000" and _s09_comm1_frequency_complete(vars_selected):
+                continue
             if vars_selected.get(var_name) is not True:
                 return False
         else:

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2325,6 +2325,34 @@ def _normalize_ufc_scratchpad_text(vars_selected: Mapping[str, Any]) -> str:
     return "".join(parts).replace("。", ".").upper()
 
 
+def _s09_comm1_frequency_complete(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("comm1_freq_134_000") is True:
+        return True
+    value = _coerce_int(vars_selected.get("comm1_freq_value"))
+    return value == 13400
+
+
+def _missing_conditions_satisfied_by_vars(
+    missing_conditions: Sequence[str],
+    vars_selected: Mapping[str, Any],
+) -> bool:
+    checked = False
+    for condition in missing_conditions:
+        if not isinstance(condition, str) or not condition:
+            continue
+        matched = _MISSING_CONDITION_VAR_RE.search(condition)
+        if matched is None:
+            return False
+        var_name = matched.group(1)
+        if "==true" in condition:
+            checked = True
+            if vars_selected.get(var_name) is not True:
+                return False
+        else:
+            return False
+    return checked
+
+
 def _vision_summary_seen_or_fresh(
     summary: Mapping[str, Any] | None,
     fact_id: str,
@@ -2754,7 +2782,7 @@ def _build_procedural_action_hint(
 
     if inferred_step_id != "S09":
         return None
-    if vars_selected.get("comm1_freq_134_000") is True:
+    if _s09_comm1_frequency_complete(vars_selected):
         return None
 
     allowed = {item for item in allowed_targets if isinstance(item, str) and item}
@@ -2770,8 +2798,6 @@ def _build_procedural_action_hint(
             return None
         return {"target": target, "reason": reason}
 
-    if vars_selected.get("ufc_comm1_pull_pressed") is True and "305.000" not in payload:
-        return _hint("ufc_key_1", "COMM1 preset entry is already open on the UFC scratchpad; start typing 134.000 with key 1.")
     if payload.endswith("134.000"):
         return _hint("ufc_ent_button", "The UFC scratchpad already shows 134.000 for COMM1 preset 1; press ENT to commit the frequency.")
     if payload.endswith("13.400") or payload.endswith("1.340") or payload.endswith(".134") or payload.endswith("1.34"):
@@ -2782,6 +2808,8 @@ def _build_procedural_action_hint(
         return _hint("ufc_key_3", "COMM1 preset entry shows 1; press 3 next.")
     if payload.endswith("305.000") or payload.endswith("305000"):
         return _hint("ufc_key_1", "COMM1 preset 1 is open on the scratchpad with the old 305.000 value; press 1 to begin entering 134.000.")
+    if vars_selected.get("ufc_comm1_pull_pressed") is True and "305.000" not in payload:
+        return _hint("ufc_key_1", "COMM1 preset entry is already open on the UFC scratchpad; start typing 134.000 with key 1.")
     if vars_selected.get("ufc_comm1_pull_pressed") is True:
         return _hint("ufc_key_1", "COMM1 preset entry has been opened on the UFC scratchpad; press 1 to begin entering 134.000.")
     return _hint("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector to open preset 1 in the scratchpad before entering 134.000.")
@@ -3894,7 +3922,11 @@ class LiveDcsTutorLoop:
             pack_path=self.pack_path,
             vision_facts=vision_fact_context.get("vision_facts"),
         )
-        inference = self._stabilize_live_inference(inference, vars_selected)
+        inference = self._stabilize_live_inference(
+            inference,
+            vars_selected,
+            recent_ui_targets=recent_buttons,
+        )
 
         new_step_id = inference.inferred_step_id
         if new_step_id != self._last_inferred_step_id:
@@ -4177,6 +4209,8 @@ class LiveDcsTutorLoop:
         self,
         inference: StepInferenceResult,
         vars_selected: Mapping[str, Any],
+        *,
+        recent_ui_targets: Sequence[str] | None = None,
     ) -> StepInferenceResult:
         if self._should_reset_sticky_inference(vars_selected):
             self._clear_live_progress_state()
@@ -4193,6 +4227,28 @@ class LiveDcsTutorLoop:
             self._sticky_inference_step_id = current_step_id
             self._sticky_inference_missing_conditions = tuple(inference.missing_conditions)
             return inference
+        if (
+            isinstance(sticky_step_id, str)
+            and sticky_step_id == "S09"
+            and _s09_comm1_frequency_complete(vars_selected)
+            and _missing_conditions_satisfied_by_vars(self._sticky_inference_missing_conditions, vars_selected)
+        ):
+            next_idx = sticky_idx + 1
+            if 0 <= next_idx < len(self.pack_steps):
+                advanced = infer_step_id(
+                    self.pack_steps[next_idx:],
+                    vars_selected,
+                    recent_ui_targets or (),
+                    precondition_gates=self.precondition_gates,
+                    completion_gates=self.completion_gates,
+                    scenario_profile=self.scenario_profile,
+                    pack_path=self.pack_path,
+                    vision_facts=None,
+                )
+                if isinstance(advanced.inferred_step_id, str) and advanced.inferred_step_id:
+                    self._sticky_inference_step_id = advanced.inferred_step_id
+                    self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                    return advanced
         return StepInferenceResult(
             inferred_step_id=sticky_step_id,
             missing_conditions=self._sticky_inference_missing_conditions,
@@ -5310,6 +5366,8 @@ class LiveDcsTutorLoop:
         overlay_step_id = hint.get("overlay_step_id")
         if response.metadata.get("refuel_probe_motion_guidance_rewritten") is True:
             return False, "refuel_probe_motion_wait_already_rewritten"
+        if response.metadata.get("s09_comm1_completion_guardrail_applied") is True:
+            return False, "s09_comm1_completion_already_rewritten"
         if response.metadata.get("completion_conflict_rewritten") is True:
             return False, "completion_conflict_already_rewritten"
         response_mapping_meta = response.metadata.get("response_mapping")
@@ -5482,7 +5540,7 @@ class LiveDcsTutorLoop:
                     evidence_refs = [bit_root_ref]
         if inferred_step_id == "S18" and not s18_bit_root_to_fcsmc_allowed:
             return False, "legacy_s18_action_hint_guardrail"
-        action_hint_step_ids = ["S08", "S17", "S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"]
+        action_hint_step_ids = ["S08", "S09", "S17", "S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"]
         if inferred_step_id == "S12" and _s12_fast_align_action_hint_allowed(
             context=context,
             hint=hint,
@@ -5968,6 +6026,26 @@ class LiveDcsTutorLoop:
                         "You are on S03. Left-click the APU switch to ON, then wait for "
                         "the green APU READY light."
                     )
+        elif inferred_step_id == "S09" and _s09_comm1_frequency_complete(vars_map):
+            reason = "s09_comm1_frequency_complete"
+            if self.lang == "zh":
+                rewritten = "COMM1 预置 1 已经是 134.000 MHz，S09 已完成。下一步进入 S10，启动左发。"
+            else:
+                rewritten = "COMM1 preset 1 is already set to 134.000 MHz, so S09 is complete. Continue to S10 by starting the left engine."
+            response.actions = []
+            response.metadata["diagnosis"] = {"step_id": "S10", "error_category": "OM"}
+            response.metadata["next"] = {"step_id": "S10"}
+            _set_text_only_help_response("S10", rewritten)
+            fallback_used, fallback_reason = self._apply_safe_fallback_overlay(
+                response,
+                request,
+                override_inferred_step_id="S10",
+                override_overlay_step_id="S10",
+                ignore_request_allowlist=True,
+            )
+            response.metadata["s09_comm1_completion_guardrail_applied"] = True
+            response.metadata["s09_comm1_completion_s10_overlay_applied"] = fallback_used
+            response.metadata["s09_comm1_completion_s10_overlay_reason"] = fallback_reason
         elif inferred_step_id == "S09" and "vars.comm1_freq_134_000==true" in missing_set:
             reason = "s09_comm1_frequency_guidance"
             if self.lang == "zh":

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -7814,6 +7814,43 @@ def test_live_inference_advances_sticky_s09_when_comm1_is_complete(tmp_path: Pat
     assert "vars.comm1_freq_134_000==true" not in stabilized.missing_conditions
 
 
+def test_live_inference_advances_sticky_s09_when_comm1_value_is_complete(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_sticky_s09_value_complete.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-s09-sticky-value-complete",
+        lang="zh",
+    )
+    try:
+        loop._sticky_inference_step_id = "S09"
+        loop._sticky_inference_missing_conditions = ("vars.comm1_freq_134_000==true",)
+        loop._last_inferred_step_id = "S09"
+
+        stabilized = loop._stabilize_live_inference(
+            StepInferenceResult("S08", ("vision_facts.fcs_page_visible==seen",)),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "left_ddi_on": True,
+                "right_ddi_on": True,
+                "mpcd_on": True,
+                "hud_on": True,
+                "right_engine_nominal_start_params": True,
+                "comm1_freq_value": 13400,
+                "engine_crank_left_complete": False,
+            },
+            recent_ui_targets=[],
+        )
+    finally:
+        loop.close()
+
+    assert stabilized.inferred_step_id == "S10"
+    assert "vars.comm1_freq_134_000==true" not in stabilized.missing_conditions
+
+
 def test_live_loop_ignores_stale_s19_visual_facts_for_s21(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_s21_ignores_stale_s19_vlm.jsonl"
     frame = _bios_frame(1, 10.0, apu_switch=1)

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -4981,6 +4981,17 @@ def test_build_procedural_action_hint_for_s09_advances_through_ufc_entry_sequenc
         inferred_step_id="S09",
         vars_selected={
             "comm1_freq_134_000": False,
+            "ufc_comm1_pull_pressed": True,
+            "ufc_scratchpad_string_1_display": "1-",
+            "ufc_scratchpad_string_2_display": "-",
+            "ufc_scratchpad_number_display": "    .13",
+        },
+        allowed_targets=allowed,
+    )["target"] == "ufc_key_4"
+    assert _build_procedural_action_hint(
+        inferred_step_id="S09",
+        vars_selected={
+            "comm1_freq_134_000": False,
             "ufc_scratchpad_string_1_display": "1-",
             "ufc_scratchpad_string_2_display": "-",
             "ufc_scratchpad_number_display": "    .13",
@@ -5007,6 +5018,16 @@ def test_build_procedural_action_hint_for_s09_advances_through_ufc_entry_sequenc
         },
         allowed_targets=allowed,
     )["target"] == "ufc_ent_button"
+    assert _build_procedural_action_hint(
+        inferred_step_id="S09",
+        vars_selected={
+            "comm1_freq_134_000": True,
+            "ufc_scratchpad_string_1_display": " 1",
+            "ufc_scratchpad_string_2_display": "--",
+            "ufc_scratchpad_number_display": " 134.000",
+        },
+        allowed_targets=allowed,
+    ) is None
 
 
 def test_build_procedural_action_hint_for_s14_prefers_obogs_control_before_flow() -> None:
@@ -7756,6 +7777,43 @@ def test_live_loop_does_not_complete_s08_navigation_from_expired_visual_fact(tmp
     assert active == ["S08"]
 
 
+def test_live_inference_advances_sticky_s09_when_comm1_is_complete(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_sticky_s09_complete.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-s09-sticky-complete",
+        lang="zh",
+    )
+    try:
+        loop._sticky_inference_step_id = "S09"
+        loop._sticky_inference_missing_conditions = ("vars.comm1_freq_134_000==true",)
+        loop._last_inferred_step_id = "S09"
+
+        stabilized = loop._stabilize_live_inference(
+            StepInferenceResult("S08", ("vision_facts.fcs_page_visible==seen",)),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "left_ddi_on": True,
+                "right_ddi_on": True,
+                "mpcd_on": True,
+                "hud_on": True,
+                "right_engine_nominal_start_params": True,
+                "comm1_freq_134_000": True,
+                "engine_crank_left_complete": False,
+            },
+            recent_ui_targets=[],
+        )
+    finally:
+        loop.close()
+
+    assert stabilized.inferred_step_id == "S10"
+    assert "vars.comm1_freq_134_000==true" not in stabilized.missing_conditions
+
+
 def test_live_loop_ignores_stale_s19_visual_facts_for_s21(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_s21_ignores_stale_s19_vlm.jsonl"
     frame = _bios_frame(1, 10.0, apu_switch=1)
@@ -9691,6 +9749,176 @@ def _validate_compact_live_help_response(
         return result.response
     finally:
         loop.close()
+
+
+def test_live_help_fixture_294_s09_comm1_complete_advances_to_s10() -> None:
+    request = TutorRequest(
+        request_id="issue-294-s09-complete",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": True,
+                "comm1_freq_value": 13400,
+                "ufc_scratchpad_number_display": " 134.000",
+                "ufc_scratchpad_string_1_display": " 1",
+                "ufc_scratchpad_string_2_display": "--",
+            },
+            "gates": {
+                "S09.completion": {"status": "allowed"},
+                "S10.completion": {
+                    "status": "blocked",
+                    "reason": "Left engine start must have begun.",
+                    "reason_code": "s10_requires_engine_crank_left_complete",
+                },
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_ui_targets": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button",
+                ],
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["eng_crank_switch"],
+            "rag_topk": [],
+            "vision_fact_summary": {"status": "vision_not_required", "seen_fact_ids": [], "fresh_fact_ids": []},
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="请继续设置 COMM1。",
+        actions=[],
+        explanations=["请继续设置 COMM1。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S09", "error_category": "CO"},
+                "next": {"step_id": "S09"},
+                "overlay": {
+                    "targets": ["ufc_comm1_channel_selector_pull"],
+                    "evidence": [
+                        {
+                            "target": "ufc_comm1_channel_selector_pull",
+                            "type": "var",
+                            "ref": "VARS.comm1_freq_134_000",
+                            "quote": "COMM1 is already tuned.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["请继续设置 COMM1。"],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert [action["target"] for action in repaired.actions] == ["eng_crank_switch"]
+    assert repaired.metadata["diagnosis"]["step_id"] == "S10"
+    assert repaired.metadata["next"]["step_id"] == "S10"
+    assert repaired.metadata["s09_comm1_completion_guardrail_applied"] is True
+    assert repaired.metadata["final_overlay_targets"] == ["eng_crank_switch"]
+    assert "134.000" in repaired.message
+    assert "S10" in repaired.message
+
+
+def test_live_help_fixture_294_s09_uses_stage_action_hint_for_next_digit() -> None:
+    request = TutorRequest(
+        request_id="issue-294-s09-next-key",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": False,
+                "ufc_comm1_pull_pressed": True,
+                "ufc_scratchpad_number_display": "    .13",
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+            },
+            "gates": {
+                "S09.completion": {
+                    "status": "blocked",
+                    "reason": "COMM1 preset 1 must be programmed to 134.000 MHz.",
+                    "reason_code": "s09_requires_comm1_freq_134_000",
+                }
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_ui_targets": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button",
+                ],
+                "action_hint": {
+                    "target": "ufc_key_4",
+                    "reason": "COMM1 preset entry shows 13; press 4 next.",
+                },
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ],
+            "rag_topk": [],
+            "vision_fact_summary": {"status": "vision_not_required", "seen_fact_ids": [], "fresh_fact_ids": []},
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="请拉出 COMM1。",
+        actions=[],
+        explanations=["请拉出 COMM1。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S09", "error_category": "OM"},
+                "next": {"step_id": "S09"},
+                "overlay": {
+                    "targets": ["ufc_comm1_channel_selector_pull"],
+                    "evidence": [
+                        {
+                            "target": "ufc_comm1_channel_selector_pull",
+                            "type": "var",
+                            "ref": "VARS.comm1_freq_134_000",
+                            "quote": "COMM1 is not tuned.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["请拉出 COMM1。"],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert [action["target"] for action in repaired.actions] == ["ufc_key_4"]
+    assert repaired.metadata["final_action_plan"]["source"] == "validator_action_hint"
+    assert "action_hint_target_mismatch:ufc_comm1_channel_selector_pull" in repaired.metadata[
+        "harness_validation_reasons"
+    ]
+    assert repaired.metadata["help_response"]["overlay"]["targets"] == ["ufc_key_4"]
+    assert repaired.message == "COMM1 preset entry shows 13; press 4 next."
 
 
 def test_live_help_fixture_299_s12_aligns_pb19_message_and_overlay() -> None:


### PR DESCRIPTION
## Summary
- advance stale sticky S09 to S10 once COMM1 134.000 completion telemetry is present
- stage S09 UFC hints by scratchpad state so future digit keys are not highlighted early
- let harness validation repair S09 overlays to the current action hint

## Tests
- python -m pytest -q tests/test_live_dcs.py -k "s09 and (ufc_entry_sequence or sticky or fixture_294)"
- python -m pytest -q tests/test_live_dcs.py -k "vision_fact_extractor_for_non_visual_step or ignores_stale_s19_visual_facts or visual_priority_progress_floor or s09 or fixture_294"
- python -m pytest -q tests/test_evidence_packet.py tests/test_step_inference.py tests/test_harness_validation.py
- python -m pytest -q -s --basetemp=.tmp/pytest-full

Fixes #294