### PR TITLE
Fix S10 left engine completion guard

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2332,6 +2332,15 @@ def _s09_comm1_frequency_complete(vars_selected: Mapping[str, Any]) -> bool:
     return value == 13400
 
 
+def _left_engine_start_complete(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("engine_crank_left_complete") is True:
+        return True
+    return (
+        vars_selected.get("rpm_l_gte_60") is True
+        and vars_selected.get("left_engine_nominal_start_params") is True
+    )
+
+
 def _missing_conditions_satisfied_by_vars(
     missing_conditions: Sequence[str],
     vars_selected: Mapping[str, Any],
@@ -2347,6 +2356,8 @@ def _missing_conditions_satisfied_by_vars(
         if "==true" in condition:
             checked = True
             if var_name == "comm1_freq_134_000" and _s09_comm1_frequency_complete(vars_selected):
+                continue
+            if var_name == "engine_crank_left_complete" and _left_engine_start_complete(vars_selected):
                 continue
             if vars_selected.get(var_name) is not True:
                 return False
@@ -4225,36 +4236,75 @@ class LiveDcsTutorLoop:
         sticky_idx = self._step_order_index.get(sticky_step_id) if isinstance(sticky_step_id, str) else None
         if current_idx is None:
             return inference
+        if (
+            current_step_id in {"S09", "S10"}
+            and _missing_conditions_satisfied_by_vars(inference.missing_conditions, vars_selected)
+        ):
+            advanced = self._infer_after_completed_step(
+                current_step_id,
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
         if sticky_idx is None or current_idx >= sticky_idx:
             self._sticky_inference_step_id = current_step_id
             self._sticky_inference_missing_conditions = tuple(inference.missing_conditions)
             return inference
         if (
             isinstance(sticky_step_id, str)
-            and sticky_step_id == "S09"
-            and _s09_comm1_frequency_complete(vars_selected)
+            and sticky_step_id in {"S09", "S10"}
             and _missing_conditions_satisfied_by_vars(self._sticky_inference_missing_conditions, vars_selected)
         ):
-            next_idx = sticky_idx + 1
-            if 0 <= next_idx < len(self.pack_steps):
-                advanced = infer_step_id(
-                    self.pack_steps[next_idx:],
-                    vars_selected,
-                    recent_ui_targets or (),
-                    precondition_gates=self.precondition_gates,
-                    completion_gates=self.completion_gates,
-                    scenario_profile=self.scenario_profile,
-                    pack_path=self.pack_path,
-                    vision_facts=None,
-                )
-                if isinstance(advanced.inferred_step_id, str) and advanced.inferred_step_id:
-                    self._sticky_inference_step_id = advanced.inferred_step_id
-                    self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
-                    return advanced
+            advanced = self._infer_after_completed_step(
+                sticky_step_id,
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
         return StepInferenceResult(
             inferred_step_id=sticky_step_id,
             missing_conditions=self._sticky_inference_missing_conditions,
         )
+
+    def _infer_after_completed_step(
+        self,
+        step_id: str,
+        vars_selected: Mapping[str, Any],
+        *,
+        recent_ui_targets: Sequence[str] | None = None,
+        vision_facts: Any = None,
+    ) -> StepInferenceResult | None:
+        idx = self._step_order_index.get(step_id)
+        if idx is None:
+            return None
+        next_idx = idx + 1
+        if next_idx < 0 or next_idx >= len(self.pack_steps):
+            return None
+        vars_for_advance = vars_selected
+        if step_id == "S10" and _left_engine_start_complete(vars_selected):
+            vars_for_advance = dict(vars_selected)
+            vars_for_advance["engine_crank_left_complete"] = True
+        advanced = infer_step_id(
+            self.pack_steps[next_idx:],
+            vars_for_advance,
+            recent_ui_targets or (),
+            precondition_gates=self.precondition_gates,
+            completion_gates=self.completion_gates,
+            scenario_profile=self.scenario_profile,
+            pack_path=self.pack_path,
+            vision_facts=vision_facts,
+        )
+        if isinstance(advanced.inferred_step_id, str) and advanced.inferred_step_id:
+            return advanced
+        return None
 
     def _infer_preliminary_step_for_vision_facts(self, obs: Observation) -> StepInferenceResult:
         payload = obs.payload if isinstance(obs.payload, Mapping) else {}
@@ -5370,6 +5420,8 @@ class LiveDcsTutorLoop:
             return False, "refuel_probe_motion_wait_already_rewritten"
         if response.metadata.get("s09_comm1_completion_guardrail_applied") is True:
             return False, "s09_comm1_completion_already_rewritten"
+        if response.metadata.get("s10_left_engine_completion_guardrail_applied") is True:
+            return False, "s10_left_engine_completion_already_rewritten"
         if response.metadata.get("completion_conflict_rewritten") is True:
             return False, "completion_conflict_already_rewritten"
         response_mapping_meta = response.metadata.get("response_mapping")
@@ -6060,6 +6112,101 @@ class LiveDcsTutorLoop:
                     "You are on S09. Set COMM1 preset 1 to 134.000 MHz: pull the UFC COMM1 "
                     "channel selector, enter 1-3-4-0-0-0, then press ENT."
                 )
+        elif inferred_step_id == "S10" and _left_engine_start_complete(vars_map):
+            reason = "s10_left_engine_start_complete"
+            recent_actions = context.get("recent_actions")
+            recent_buttons = (
+                [
+                    item for item in recent_actions.get("recent_buttons", [])
+                    if isinstance(item, str) and item
+                ]
+                if isinstance(recent_actions, Mapping)
+                else []
+            )
+            advanced = self._infer_after_completed_step(
+                "S10",
+                vars_map,
+                recent_ui_targets=recent_buttons,
+                vision_facts=context.get("vision_facts"),
+            )
+            next_step_id = (
+                advanced.inferred_step_id
+                if advanced is not None and isinstance(advanced.inferred_step_id, str)
+                else self._next_step_id_after("S10")
+            )
+            if not isinstance(next_step_id, str) or not next_step_id:
+                next_step_id = "S11"
+            if self.lang == "zh":
+                rewritten = f"左发动机启动条件已满足。现在进入 {next_step_id}。"
+            else:
+                rewritten = f"The left-engine start condition is already satisfied. Continue to {next_step_id}."
+            original_actions = copy.deepcopy([dict(action) for action in response.actions if isinstance(action, Mapping)])
+            response.actions = []
+            response.metadata["diagnosis"] = {"step_id": next_step_id, "error_category": "OM"}
+            response.metadata["next"] = {"step_id": next_step_id}
+            response.metadata["validator_rejected"] = True
+            response.metadata["repair_applied"] = True
+            response.metadata["rejected_model_step_id"] = "S10"
+            response.metadata["final_action_plan_source"] = "s10_left_engine_completion_guardrail"
+            if original_actions:
+                response.metadata["s10_left_engine_completion_original_actions"] = original_actions
+                rejected_targets = [
+                    action.get("target")
+                    for action in original_actions
+                    if isinstance(action.get("target"), str)
+                ]
+                if rejected_targets:
+                    response.metadata["rejected_model_targets"] = _dedupe_strings(rejected_targets)
+                    response.metadata["rejected_model_target"] = response.metadata["rejected_model_targets"][0]
+            fallback_help_obj, fallback_reason = self._build_safe_fallback_overlay_help_obj(
+                request,
+                override_inferred_step_id=next_step_id,
+                override_overlay_step_id=next_step_id,
+                ignore_request_allowlist=True,
+            )
+            fallback_used = False
+            if isinstance(fallback_help_obj, Mapping):
+                planned_help_obj = copy.deepcopy(dict(fallback_help_obj))
+                planned_help_obj["diagnosis"] = {"step_id": next_step_id, "error_category": "OM"}
+                planned_help_obj["next"] = {"step_id": next_step_id}
+                planned_help_obj["explanations"] = [rewritten]
+                mapped = map_help_response_to_tutor_response(
+                    planned_help_obj,
+                    request=request,
+                    status=response.status,
+                    max_overlay_targets=self.max_overlay_targets,
+                    ui_map_path=self.ui_map_path,
+                    lang=self.lang,
+                )
+                mapped_meta = dict(mapped.metadata)
+                if mapped_meta:
+                    response.metadata["fallback_response_mapping"] = mapped_meta
+                if mapped.actions:
+                    response.actions = list(mapped.actions)
+                    response.metadata["help_response"] = planned_help_obj
+                    fallback_used = True
+                else:
+                    mapping_errors = mapped_meta.get("mapping_errors")
+                    fallback_reason = (
+                        f"fallback_mapping_failed:{'|'.join(str(item) for item in mapping_errors[:3])}"
+                        if isinstance(mapping_errors, list) and mapping_errors
+                        else "fallback_mapping_failed"
+                    )
+                    _set_text_only_help_response(next_step_id, rewritten)
+            else:
+                _set_text_only_help_response(next_step_id, rewritten)
+            final_targets = _overlay_targets_from_actions(response.actions)
+            response.metadata["harness_action_plan"] = {
+                "step_id": next_step_id,
+                "overlay_step_id": next_step_id,
+                "targets": list(final_targets),
+                "text_only": not bool(final_targets),
+                "source": "s10_left_engine_completion_guardrail",
+            }
+            response.metadata["s10_left_engine_completion_guardrail_applied"] = True
+            response.metadata["s10_left_engine_completion_next_step_id"] = next_step_id
+            response.metadata["s10_left_engine_completion_overlay_applied"] = fallback_used
+            response.metadata["s10_left_engine_completion_overlay_reason"] = fallback_reason
         elif inferred_step_id == "S12":
             if "vars.ins_fast_align_complete==true" in missing_set and (
                 vars_map.get("ins_mode_cv_or_gnd") is True or vars_map.get("ins_mode_set") is True
@@ -6820,8 +6967,14 @@ class LiveDcsTutorLoop:
         self._rewrite_terminal_state_conflict_response(response, request)
         self._rewrite_procedural_guidance_response(response, request)
 
-        fallback_overlay_used = False
-        fallback_overlay_reason = "all_steps_complete" if terminal_state_short_circuited else "not_needed"
+        fallback_overlay_used = bool(response.metadata.get("s10_left_engine_completion_overlay_applied"))
+        fallback_overlay_reason = (
+            response.metadata.get("s10_left_engine_completion_overlay_reason")
+            if fallback_overlay_used
+            else ("all_steps_complete" if terminal_state_short_circuited else "not_needed")
+        )
+        if not isinstance(fallback_overlay_reason, str) or not fallback_overlay_reason:
+            fallback_overlay_reason = "not_needed"
         harness_validation_used, harness_validation_reason = self._apply_harness_validation_action_plan(
             response,
             request,
@@ -6855,7 +7008,12 @@ class LiveDcsTutorLoop:
             request,
             mapped_meta,
         )
-        if should_apply_safe_fallback and not action_hint_override_used and not harness_validation_used:
+        if (
+            should_apply_safe_fallback
+            and not action_hint_override_used
+            and not harness_validation_used
+            and response.metadata.get("s10_left_engine_completion_guardrail_applied") is not True
+        ):
             fallback_overlay_used, fallback_overlay_reason = self._apply_safe_fallback_overlay(
                 response,
                 request,

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -7851,6 +7851,98 @@ def test_live_inference_advances_sticky_s09_when_comm1_value_is_complete(tmp_pat
     assert "vars.comm1_freq_134_000==true" not in stabilized.missing_conditions
 
 
+def test_live_inference_advances_sticky_s10_when_left_engine_is_complete(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_sticky_s10_left_engine_complete.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-s10-sticky-left-complete",
+        lang="zh",
+    )
+    try:
+        loop._sticky_inference_step_id = "S10"
+        loop._sticky_inference_missing_conditions = ("vars.engine_crank_left_complete==true",)
+        loop._last_inferred_step_id = "S10"
+
+        stabilized = loop._stabilize_live_inference(
+            StepInferenceResult("S10", ("vars.engine_crank_left_complete==true",)),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "left_ddi_on": True,
+                "right_ddi_on": True,
+                "mpcd_on": True,
+                "hud_on": True,
+                "right_engine_nominal_start_params": True,
+                "comm1_freq_134_000": True,
+                "engine_crank_left": False,
+                "engine_crank_left_complete": True,
+                "rpm_l": 64,
+                "rpm_l_gte_25": True,
+                "rpm_l_gte_60": True,
+                "left_engine_nominal_start_params": True,
+                "left_engine_idle_ready": True,
+                "throttle_l_not_off": True,
+                "ins_mode": 0,
+                "ins_fast_align_complete": False,
+            },
+            recent_ui_targets=[],
+        )
+    finally:
+        loop.close()
+
+    assert stabilized.inferred_step_id == "S12"
+    assert "vars.engine_crank_left_complete==true" not in stabilized.missing_conditions
+
+
+def test_live_inference_treats_stable_left_engine_params_as_s10_complete(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_sticky_s10_left_engine_stable_params.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-s10-sticky-left-stable-params",
+        lang="zh",
+    )
+    try:
+        loop._sticky_inference_step_id = "S10"
+        loop._sticky_inference_missing_conditions = ("vars.engine_crank_left_complete==true",)
+        loop._last_inferred_step_id = "S10"
+
+        stabilized = loop._stabilize_live_inference(
+            StepInferenceResult("S10", ("vars.engine_crank_left_complete==true",)),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "left_ddi_on": True,
+                "right_ddi_on": True,
+                "mpcd_on": True,
+                "hud_on": True,
+                "right_engine_nominal_start_params": True,
+                "comm1_freq_134_000": True,
+                "engine_crank_left": False,
+                "engine_crank_left_complete": False,
+                "rpm_l": 64,
+                "rpm_l_gte_25": True,
+                "rpm_l_gte_60": True,
+                "left_engine_nominal_start_params": True,
+                "left_engine_idle_ready": True,
+                "throttle_l_not_off": True,
+                "ins_mode": 0,
+                "ins_fast_align_complete": False,
+            },
+            recent_ui_targets=[],
+        )
+    finally:
+        loop.close()
+
+    assert stabilized.inferred_step_id == "S12"
+    assert "vars.engine_crank_left_complete==true" not in stabilized.missing_conditions
+
+
 def test_live_loop_ignores_stale_s19_visual_facts_for_s21(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_s21_ignores_stale_s19_vlm.jsonl"
     frame = _bios_frame(1, 10.0, apu_switch=1)
@@ -9866,6 +9958,215 @@ def test_live_help_fixture_294_s09_comm1_complete_advances_to_s10() -> None:
     assert repaired.metadata["final_overlay_targets"] == ["eng_crank_switch"]
     assert "134.000" in repaired.message
     assert "S10" in repaired.message
+
+
+def test_live_help_fixture_310_s10_left_engine_complete_advances_past_crank() -> None:
+    request = TutorRequest(
+        request_id="issue-310-s10-left-complete",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": True,
+                "right_engine_nominal_start_params": True,
+                "engine_crank_left": False,
+                "engine_crank_left_complete": True,
+                "rpm_l": 64,
+                "rpm_l_gte_25": True,
+                "rpm_l_gte_60": True,
+                "left_engine_nominal_start_params": True,
+                "left_engine_idle_ready": True,
+                "throttle_l_not_off": True,
+            },
+            "gates": {
+                "S10.completion": {
+                    "status": "blocked",
+                    "reason": "Left engine start must have begun.",
+                    "reason_code": "s10_requires_engine_crank_left_complete",
+                },
+                "S12.completion": {
+                    "status": "blocked",
+                    "reason": "INS mode must be set to GND/CV.",
+                    "reason_code": "s12_requires_ins_mode_set",
+                },
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S10",
+                "overlay_step_id": "S10",
+                "missing_conditions": ["vars.engine_crank_left_complete==true"],
+                "step_ui_targets": ["eng_crank_switch"],
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["eng_crank_switch"],
+            "rag_topk": [],
+            "vision_fact_summary": {"status": "vision_not_required", "seen_fact_ids": [], "fresh_fact_ids": []},
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置以启动左发动机。",
+        actions=[
+            {
+                "type": "highlight",
+                "target": "eng_crank_switch",
+                "intent": "guide",
+                "evidence_refs": ["GATES.S10.completion"],
+            }
+        ],
+        explanations=["当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置以启动左发动机。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S10", "error_category": "OM"},
+                "next": {"step_id": "S10"},
+                "overlay": {
+                    "targets": ["eng_crank_switch"],
+                    "evidence": [
+                        {
+                            "target": "eng_crank_switch",
+                            "type": "gate",
+                            "ref": "GATES.S10.completion",
+                            "quote": "Left engine start must have begun.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置以启动左发动机。"],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S12"
+    assert repaired.metadata["next"]["step_id"] == "S12"
+    assert repaired.metadata["s10_left_engine_completion_guardrail_applied"] is True
+    assert repaired.metadata["rejected_model_step_id"] == "S10"
+    assert repaired.metadata["fallback_overlay_used"] is True
+    assert repaired.metadata["final_action_plan"]["source"] == "s10_left_engine_completion_guardrail"
+    assert repaired.metadata["final_overlay_targets"] == ["ins_mode_knob"]
+    assert repaired.metadata["help_response"]["overlay"]["targets"] == ["ins_mode_knob"]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "ins_mode_knob"
+    assert [action["target"] for action in repaired.actions] == ["ins_mode_knob"]
+    assert "S10" not in repaired.message
+    assert "S12" in repaired.message
+
+
+def test_live_help_fixture_310_does_not_fall_back_to_s10_when_next_overlay_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fallback_calls: list[tuple[str | None, str | None]] = []
+    original_builder = LiveDcsTutorLoop._build_safe_fallback_overlay_help_obj
+
+    def failing_s10_completion_fallback(
+        self: LiveDcsTutorLoop,
+        request: TutorRequest,
+        *,
+        override_inferred_step_id: str | None = None,
+        override_overlay_step_id: str | None = None,
+        ignore_request_allowlist: bool = False,
+    ) -> tuple[dict[str, Any] | None, str]:
+        fallback_calls.append((override_inferred_step_id, override_overlay_step_id))
+        if override_inferred_step_id == "S12":
+            return None, "no_verifiable_evidence_ref"
+        return original_builder(
+            self,
+            request,
+            override_inferred_step_id=override_inferred_step_id,
+            override_overlay_step_id=override_overlay_step_id,
+            ignore_request_allowlist=ignore_request_allowlist,
+        )
+
+    monkeypatch.setattr(
+        LiveDcsTutorLoop,
+        "_build_safe_fallback_overlay_help_obj",
+        failing_s10_completion_fallback,
+    )
+
+    request = TutorRequest(
+        request_id="issue-310-s10-left-complete-fallback-fails",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": True,
+                "right_engine_nominal_start_params": True,
+                "engine_crank_left": False,
+                "engine_crank_left_complete": True,
+                "rpm_l": 64,
+                "rpm_l_gte_60": True,
+                "left_engine_nominal_start_params": True,
+                "throttle_l_not_off": True,
+            },
+            "gates": {
+                "S10.completion": {
+                    "status": "blocked",
+                    "reason": "Left engine start must have begun.",
+                    "reason_code": "s10_requires_engine_crank_left_complete",
+                },
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S10",
+                "overlay_step_id": "S10",
+                "missing_conditions": ["vars.engine_crank_left_complete==true"],
+                "step_ui_targets": ["eng_crank_switch"],
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["eng_crank_switch"],
+            "rag_topk": [],
+            "vision_fact_summary": {"status": "vision_not_required", "seen_fact_ids": [], "fresh_fact_ids": []},
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置以启动左发动机。",
+        actions=[
+            {
+                "type": "highlight",
+                "target": "eng_crank_switch",
+                "intent": "guide",
+                "evidence_refs": ["GATES.S10.completion"],
+            }
+        ],
+        explanations=["当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置以启动左发动机。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S10", "error_category": "OM"},
+                "next": {"step_id": "S10"},
+                "overlay": {
+                    "targets": ["eng_crank_switch"],
+                    "evidence": [
+                        {
+                            "target": "eng_crank_switch",
+                            "type": "gate",
+                            "ref": "GATES.S10.completion",
+                            "quote": "Left engine start must have begun.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置以启动左发动机。"],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["s10_left_engine_completion_guardrail_applied"] is True
+    assert repaired.metadata["diagnosis"]["step_id"] == "S12"
+    assert repaired.metadata["next"]["step_id"] == "S12"
+    assert repaired.metadata["fallback_overlay_used"] is False
+    assert repaired.metadata["s10_left_engine_completion_overlay_reason"] == "no_verifiable_evidence_ref"
+    assert repaired.metadata["final_overlay_targets"] == []
+    assert fallback_calls == [("S12", "S12")]
+    assert "eng_crank_switch" not in [action["target"] for action in repaired.actions]
+    assert "S10" not in repaired.message
+    assert "S12" in repaired.message
 
 
 def test_live_help_fixture_294_s09_uses_stage_action_hint_for_next_digit() -> None:


### PR DESCRIPTION
## Summary
- advance live sticky S10 inference when left-engine completion telemetry already satisfies the stale missing condition
- repair stale S10 help responses so they advance to the next incomplete step instead of re-highlighting ENG CRANK
- keep final actions, help_response, public response, and action-plan metadata aligned for the S10 guardrail path

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k '310 or sticky_s10'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k '310 or sticky_s10 or fixture_294 or sticky_s09 or fixture_299'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

## Review
- subagent review loop completed; initial metadata/fallback concerns fixed and final re-review reported no blockers.

Fixes #310