### PR TITLE
Enforce final evidence consistency

### DIFF
--- a/artifacts/live_fixtures/168fc73d-f98c-498e-a35c-fef91b06ee2e.fixture.json
+++ b/artifacts/live_fixtures/168fc73d-f98c-498e-a35c-fef91b06ee2e.fixture.json
@@ -1,0 +1,2666 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 1,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "frame_count": 20,
+        "latest_seq": 8025
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:54439",
+          "raw_delta_count": 1,
+          "seq": 8025
+        },
+        "observation_id": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41446
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 8025,
+          "t_wall": 1779109680.3539028,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": false,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 0,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 0.0,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 0,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 0,
+            "rpm_l_gte_25": false,
+            "rpm_l_gte_60": false,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 10,
+            "temp_r": 309,
+            "throttle_l_not_off": false,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": " 134.000",
+            "ufc_scratchpad_string_1_display": " 1",
+            "ufc_scratchpad_string_2_display": "--",
+            "vars_source_missing": [
+              "ins_fast_align_pressed"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-18T13:08:00.353902+00:00",
+        "version": "v1"
+      }
+    ],
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "frame_count": 20,
+      "latest_seq": 8025
+    },
+    "vision": {
+      "frame_ids": [
+        "1779109680504_000109"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779109680504_000109",
+        "frame_ids": [
+          "1779109680504_000109"
+        ],
+        "frame_stale": false,
+        "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+        "observation_seq": 8025,
+        "observation_t_wall_ms": 1779109680354,
+        "observation_t_wall_s": 1779109680.3539028,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779109680504,
+            "channel": "composite_panel",
+            "frame_id": "1779109680504_000109",
+            "frame_seq": 109,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779109680504_000109_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779109680504_000109.png",
+            "sync_delta_ms": 72,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 72,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779109680504,
+          "channel": "composite_panel",
+          "frame_id": "1779109680504_000109",
+          "frame_seq": 109,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779109680504_000109_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779109680504_000109.png",
+          "sync_delta_ms": 72,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779109680432,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779109680504_000109"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+        "kind": "tutor_request",
+        "lineno": 8436,
+        "metadata": {
+          "frame_id": "1779109680504_000109",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 72,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779109680504_000109"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S09",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S09",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 1,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 8025
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.29554266378183,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 13.182159039373342,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_10",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "3. Step Criticality",
+                "score": 13.120994677243015,
+                "section": "3. Step Criticality",
+                "snippet_id": "fa18c_error_coding_guide_10"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_5",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+                "score": 12.704192866546279,
+                "section": "Phase P3 – Displays & Communications (S08–S09)",
+                "snippet_id": "Appendix - Training Task Syllabus_5"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 93,
+                "score": 10.553560644586302,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.comm1_freq_134_000==true"
+                ],
+                "overlay_step_id": "S09",
+                "role": "candidate_not_authoritative",
+                "step_id": "S09"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 8025,
+                "source_status": "nominal",
+                "vars_source_missing_count": 1
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8025,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 8025,
+                "latest_t_wall": 1779109680.3539028,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed"
+                ],
+                "window_duration_s": 0.373
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779109680504_000109",
+              "frame_ids": [
+                "1779109680504_000109"
+              ],
+              "frame_stale": false,
+              "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+              "observation_seq": 8025,
+              "observation_t_wall_ms": 1779109680354,
+              "observation_t_wall_s": 1779109680.3539028,
+              "status": "partial",
+              "sync_delta_ms": 72,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779109680432,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779109680504_000109"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 1,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 8025
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "frame_id": "1779109680504_000109",
+            "fused_missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "fused_step_id": "S09",
+            "grounding_cache_hit": true,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_coldstart_quiz_1",
+              "fa18c_startup_master_1",
+              "fa18c_error_coding_guide_10",
+              "Appendix - Training Task Syllabus_5",
+              "DCS FA-18C Early Access Guide EN_92"
+            ],
+            "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+            "prompt_tokens_est": 5482,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "source_chunk_refs": [
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 72,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779109680504_000109"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779109680504_000109"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+          "request_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+          "timestamp": "2026-05-18T13:08:01.171233+00:00",
+          "version": "v1"
+        },
+        "related_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+        "vision_refs": [
+          "1779109680504_000109"
+        ]
+      },
+      {
+        "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+        "kind": "overlay_requested",
+        "lineno": 8437,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779109680504_000109",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 72,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779109680504_000109"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "c379b4c9-0cd2-43c2-b983-b98c6416ac21",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779109680504_000109",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 72,
+          "target": "pnt_124",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779109680504_000109"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+        "kind": "tutor_response",
+        "lineno": 8438,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779109680504_000109",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 72,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779109680504_000109"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.comm1_freq_134_000"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "frame_id": "1779109680504_000109",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 72,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779109680504_000109"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+          ],
+          "in_reply_to": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+          "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+          "metadata": {
+            "allowed_evidence_ref_count": 117,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "bad275e3-1b9a-435e-a8bd-4b67141ca3f3",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ]
+            },
+            "diagnosis": {
+              "error_category": "CO",
+              "step_id": "S09"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "overlay_step_id": "S09",
+              "source": "model",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "model",
+            "final_overlay_targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_124",
+                  "evidence_refs": [
+                    "VARS.comm1_freq_134_000"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_comm1_channel_selector_pull"
+                  ],
+                  "frame_id": "1779109680504_000109",
+                  "fused_missing_conditions": [
+                    "vars.comm1_freq_134_000==true"
+                  ],
+                  "fused_step_id": "S09",
+                  "generation_mode": "model",
+                  "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "model",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 72,
+                  "target": "ufc_comm1_channel_selector_pull",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779109680504_000109"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+              ],
+              "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+              "next": {
+                "step_id": "S09"
+              }
+            },
+            "frame_id": "1779109680504_000109",
+            "fused_missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "fused_step_id": "S09",
+            "generation_mode": "model",
+            "generation_prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+            "generation_prompt_tokens_est": 5482,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S09",
+              "source": "model",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": [
+                    "GATES.S10.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S11",
+                  "supporting_evidence_refs": [
+                    "GATES.S11.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "GATES.S13.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "ufc_comm1_channel_selector_pull",
+                  "ufc_key_1",
+                  "ufc_key_3",
+                  "ufc_key_4",
+                  "ufc_key_0",
+                  "ufc_ent_button"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S09",
+                "supporting_evidence_refs": []
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 1,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "frame_count": 20,
+                  "latest_seq": 8025
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "final_action_plan": {
+                "overlay_step_id": "S09",
+                "source": "model",
+                "step_id": "S09",
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "message_category": "model",
+              "model_decision": {
+                "evidence_refs": [
+                  "VARS.comm1_freq_134_000"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ],
+                "status": "ok",
+                "step_id": "S09"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": false,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": null
+              },
+              "schema_version": "v1",
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779109680504_000109"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 72,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [],
+            "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.comm1_freq_134_000",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.comm1_freq_134_000",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 5183,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "model",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S09"
+            },
+            "model_raw_explanations": [
+              "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.comm1_freq_134_000",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S09"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779109680504_000109"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779109680504_000109",
+            "next": {
+              "step_id": "S09"
+            },
+            "observability_status": "observable",
+            "procedural_guidance_original_explanations": [
+              "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+            ],
+            "procedural_guidance_original_message": "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。",
+            "procedural_guidance_rewrite_reason": "s09_comm1_frequency_guidance",
+            "procedural_guidance_rewritten": true,
+            "prompt_budget_used": 5560,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_freq_134_000",
+                "GATES.S09.completion",
+                "GATES.S09.precondition",
+                "GATES.S10.completion",
+                "GATES.S11.completion",
+                "GATES.S11.precondition",
+                "GATES.S12.completion",
+                "GATES.S12.precondition",
+                "GATES.S13.completion",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_10",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_5",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_92"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 23,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "ufc_comm1_channel_selector_pull",
+              "prompt_chars": 21925,
+              "prompt_tokens_est": 5482,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_coldstart_quiz_1",
+                "fa18c_startup_master_1",
+                "fa18c_error_coding_guide_10",
+                "Appendix - Training Task Syllabus_5",
+                "DCS FA-18C Early Access Guide EN_92"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+            "prompt_tokens_est": 5482,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+            "request_prompt_tokens_est": 5482,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 117,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "next": {
+                "step_id": "S09"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "state_key": "7cffd898f7af82989acdb7dbcfb05afb6f93926f2270cc15f6cbf22b0b45f615",
+            "sync_delta_ms": 72,
+            "validator_rejected": false,
+            "vision": {
+              "frame_id": "1779109680504_000109",
+              "frame_ids": [
+                "1779109680504_000109"
+              ],
+              "frame_stale": false,
+              "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+              "observation_seq": 8025,
+              "observation_t_wall_ms": 1779109680354,
+              "observation_t_wall_s": 1779109680.3539028,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779109680504,
+                  "channel": "composite_panel",
+                  "frame_id": "1779109680504_000109",
+                  "frame_seq": 109,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779109680504_000109_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779109680504_000109.png",
+                  "sync_delta_ms": 72,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 72,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779109680504,
+                "channel": "composite_panel",
+                "frame_id": "1779109680504_000109",
+                "frame_seq": 109,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779109680504_000109_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779109680504_000109.png",
+                "sync_delta_ms": 72,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779109680432,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S09"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779109680504_000109"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779109680504_000109"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "ab73222c-f5ea-46c4-8d0e-cb6f3995ac17",
+          "status": "ok",
+          "timestamp": "2026-05-18T13:08:06.356447+00:00",
+          "version": "v1"
+        },
+        "related_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+        "vision_refs": [
+          "1779109680504_000109"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S09",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S09",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 1,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 8025
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.29554266378183,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 13.182159039373342,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_10",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "3. Step Criticality",
+            "score": 13.120994677243015,
+            "section": "3. Step Criticality",
+            "snippet_id": "fa18c_error_coding_guide_10"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_5",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+            "score": 12.704192866546279,
+            "section": "Phase P3 – Displays & Communications (S08–S09)",
+            "snippet_id": "Appendix - Training Task Syllabus_5"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 93,
+            "score": 10.553560644586302,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "overlay_step_id": "S09",
+            "role": "candidate_not_authoritative",
+            "step_id": "S09"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 8025,
+            "source_status": "nominal",
+            "vars_source_missing_count": 1
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8025,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 8025,
+            "latest_t_wall": 1779109680.3539028,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed"
+            ],
+            "window_duration_s": 0.373
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779109680504_000109",
+          "frame_ids": [
+            "1779109680504_000109"
+          ],
+          "frame_stale": false,
+          "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+          "observation_seq": 8025,
+          "observation_t_wall_ms": 1779109680354,
+          "observation_t_wall_s": 1779109680.3539028,
+          "status": "partial",
+          "sync_delta_ms": 72,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779109680432,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779109680504_000109"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 1,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 8025
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "frame_id": "1779109680504_000109",
+        "fused_missing_conditions": [
+          "vars.comm1_freq_134_000==true"
+        ],
+        "fused_step_id": "S09",
+        "grounding_cache_hit": true,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_coldstart_quiz_1",
+          "fa18c_startup_master_1",
+          "fa18c_error_coding_guide_10",
+          "Appendix - Training Task Syllabus_5",
+          "DCS FA-18C Early Access Guide EN_92"
+        ],
+        "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+        "prompt_tokens_est": 5482,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "source_chunk_refs": [
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 72,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779109680504_000109"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779109680504_000109"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+      "request_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+      "timestamp": "2026-05-18T13:08:01.171233+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_124",
+          "evidence_refs": [
+            "VARS.comm1_freq_134_000"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779109680504_000109",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 72,
+          "target": "ufc_comm1_channel_selector_pull",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779109680504_000109"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+      ],
+      "in_reply_to": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+      "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+      "metadata": {
+        "allowed_evidence_ref_count": 117,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "bad275e3-1b9a-435e-a8bd-4b67141ca3f3",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ]
+        },
+        "diagnosis": {
+          "error_category": "CO",
+          "step_id": "S09"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "overlay_step_id": "S09",
+          "source": "model",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "model",
+        "final_overlay_targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.comm1_freq_134_000"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "frame_id": "1779109680504_000109",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 72,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779109680504_000109"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+          ],
+          "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+          "next": {
+            "step_id": "S09"
+          }
+        },
+        "frame_id": "1779109680504_000109",
+        "fused_missing_conditions": [
+          "vars.comm1_freq_134_000==true"
+        ],
+        "fused_step_id": "S09",
+        "generation_mode": "model",
+        "generation_prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+        "generation_prompt_tokens_est": 5482,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S09",
+          "source": "model",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S09",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S10",
+              "supporting_evidence_refs": [
+                "GATES.S10.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S11",
+              "supporting_evidence_refs": [
+                "GATES.S11.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "GATES.S13.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0",
+              "ufc_ent_button"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S09",
+            "supporting_evidence_refs": []
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 1,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "frame_count": 20,
+              "latest_seq": 8025
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "final_action_plan": {
+            "overlay_step_id": "S09",
+            "source": "model",
+            "step_id": "S09",
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "message_category": "model",
+          "model_decision": {
+            "evidence_refs": [
+              "VARS.comm1_freq_134_000"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "status": "ok",
+            "step_id": "S09"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": false,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": null
+          },
+          "schema_version": "v1",
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779109680504_000109"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 72,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [],
+        "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.comm1_freq_134_000",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.comm1_freq_134_000",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 5183,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "model",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S09"
+        },
+        "model_raw_explanations": [
+          "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.comm1_freq_134_000",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S09"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779109680504_000109"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779109680504_000109",
+        "next": {
+          "step_id": "S09"
+        },
+        "observability_status": "observable",
+        "procedural_guidance_original_explanations": [
+          "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+        ],
+        "procedural_guidance_original_message": "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。",
+        "procedural_guidance_rewrite_reason": "s09_comm1_frequency_guidance",
+        "procedural_guidance_rewritten": true,
+        "prompt_budget_used": 5560,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_freq_134_000",
+            "GATES.S09.completion",
+            "GATES.S09.precondition",
+            "GATES.S10.completion",
+            "GATES.S11.completion",
+            "GATES.S11.precondition",
+            "GATES.S12.completion",
+            "GATES.S12.precondition",
+            "GATES.S13.completion",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_10",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_5",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_92"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 23,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "ufc_comm1_channel_selector_pull",
+          "prompt_chars": 21925,
+          "prompt_tokens_est": 5482,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_coldstart_quiz_1",
+            "fa18c_startup_master_1",
+            "fa18c_error_coding_guide_10",
+            "Appendix - Training Task Syllabus_5",
+            "DCS FA-18C Early Access Guide EN_92"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+        "prompt_tokens_est": 5482,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "3f15476b38e6963a86ab225fe2e525c544287cd3f7411894199bad6dffbb0d47",
+        "request_prompt_tokens_est": 5482,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 117,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "next": {
+            "step_id": "S09"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "state_key": "7cffd898f7af82989acdb7dbcfb05afb6f93926f2270cc15f6cbf22b0b45f615",
+        "sync_delta_ms": 72,
+        "validator_rejected": false,
+        "vision": {
+          "frame_id": "1779109680504_000109",
+          "frame_ids": [
+            "1779109680504_000109"
+          ],
+          "frame_stale": false,
+          "observation_ref": "21f8ce2e-580c-450b-8f12-3087e8cb11ee",
+          "observation_seq": 8025,
+          "observation_t_wall_ms": 1779109680354,
+          "observation_t_wall_s": 1779109680.3539028,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779109680504,
+              "channel": "composite_panel",
+              "frame_id": "1779109680504_000109",
+              "frame_seq": 109,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779109680504_000109_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779109680504_000109.png",
+              "sync_delta_ms": 72,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 72,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779109680504,
+            "channel": "composite_panel",
+            "frame_id": "1779109680504_000109",
+            "frame_seq": 109,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779109680504_000109_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779109680504_000109.png",
+            "sync_delta_ms": 72,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779109680432,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S09"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779109680504_000109"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779109680504_000109"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "ab73222c-f5ea-46c4-8d0e-cb6f3995ac17",
+      "status": "ok",
+      "timestamp": "2026-05-18T13:08:06.356447+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S09",
+    "expected_overlay_target_ids": [
+      "ufc_comm1_channel_selector_pull"
+    ],
+    "final_response_source": "model",
+    "llm_decision_status": "accepted",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S09",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S11",
+        "supporting_evidence_refs": [
+          "GATES.S11.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "overlay_step_id": "S09",
+      "source": "model",
+      "step_id": "S09",
+      "targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VARS.comm1_freq_134_000"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "status": "ok",
+      "step_id": "S09"
+    },
+    "repair_result": {
+      "applied": false,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": null
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S09",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S10",
+          "supporting_evidence_refs": [
+            "GATES.S10.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S11",
+          "supporting_evidence_refs": [
+            "GATES.S11.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "GATES.S13.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S09",
+        "supporting_evidence_refs": []
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 1,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "frame_count": 20,
+          "latest_seq": 8025
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "final_action_plan": {
+        "overlay_step_id": "S09",
+        "source": "model",
+        "step_id": "S09",
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "message_category": "model",
+      "model_decision": {
+        "evidence_refs": [
+          "VARS.comm1_freq_134_000"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "status": "ok",
+        "step_id": "S09"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": false,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": null
+      },
+      "schema_version": "v1",
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779109680504_000109"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 72,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.comm1_freq_134_000",
+            "target": "ufc_comm1_channel_selector_pull",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "S08 已完成，当前处于 S09 阶段。COMM1 频率已正确设置为 134.000。请左键点击 UFC COMM1 频道选择旋钮（ufc_comm1_channel_selector_pull）以拉出旋钮，完成通讯配置。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.comm1_freq_134_000",
+            "target": "ufc_comm1_channel_selector_pull",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "168fc73d-f98c-498e-a35c-fef91b06ee2e",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 8632,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260518_125935.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/c3c775ce-7a4d-4e7f-a841-3a022528138e.fixture.json
+++ b/artifacts/live_fixtures/c3c775ce-7a4d-4e7f-a841-3a022528138e.fixture.json
@@ -1,0 +1,2650 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "frame_count": 20,
+        "latest_seq": 5603
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:59770",
+          "raw_delta_count": 1,
+          "seq": 5603
+        },
+        "observation_id": "523fbca0-a175-4aec-8b39-1e024dadca50",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41488
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 5603,
+          "t_wall": 1779113716.7468793,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 296,
+            "temp_r": 296,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-18T14:15:16.746879+00:00",
+        "version": "v1"
+      }
+    ],
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "frame_count": 20,
+      "latest_seq": 5603
+    },
+    "vision": {
+      "frame_ids": [
+        "1779113716800_000129"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779113716800_000129",
+        "frame_ids": [
+          "1779113716800_000129"
+        ],
+        "frame_stale": false,
+        "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+        "observation_seq": 5603,
+        "observation_t_wall_ms": 1779113716747,
+        "observation_t_wall_s": 1779113716.7468793,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779113716800,
+            "channel": "composite_panel",
+            "frame_id": "1779113716800_000129",
+            "frame_seq": 129,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779113716800_000129_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779113716800_000129.png",
+            "sync_delta_ms": 68,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 68,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779113716800,
+          "channel": "composite_panel",
+          "frame_id": "1779113716800_000129",
+          "frame_seq": 129,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779113716800_000129_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779113716800_000129.png",
+          "sync_delta_ms": 68,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779113716732,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779113716800_000129"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+        "kind": "tutor_request",
+        "lineno": 6032,
+        "metadata": {
+          "frame_id": "1779113716800_000129",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 68,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779113716800_000129"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S10",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S10",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "eng_crank_switch"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 5603
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_6",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "score": 22.433209884437428,
+                "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "snippet_id": "Appendix - Training Task Syllabus_6"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_3",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q3. Left Engine Preconditions",
+                "score": 20.454016185702667,
+                "section": "Q3. Left Engine Preconditions",
+                "snippet_id": "fa18c_coldstart_quiz_3"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 20.411451188900127,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_7",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.5 State Violation (SV)",
+                "score": 19.11157429423624,
+                "section": "2.5 State Violation (SV)",
+                "snippet_id": "fa18c_error_coding_guide_7"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_3",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P1 – Power-Up & Safety (S01–S03)",
+                "score": 18.00574425802828,
+                "section": "Phase P1 – Power-Up & Safety (S01–S03)",
+                "snippet_id": "Appendix - Training Task Syllabus_3"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.engine_crank_left_complete==true"
+                ],
+                "overlay_step_id": "S10",
+                "role": "candidate_not_authoritative",
+                "step_id": "S10"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 5603,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5603,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 5603,
+                "latest_t_wall": 1779113716.7468793,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.962
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779113716800_000129",
+              "frame_ids": [
+                "1779113716800_000129"
+              ],
+              "frame_stale": false,
+              "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+              "observation_seq": 5603,
+              "observation_t_wall_ms": 1779113716747,
+              "observation_t_wall_s": 1779113716.7468793,
+              "status": "partial",
+              "sync_delta_ms": 68,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779113716732,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779113716800_000129"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 5603
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "frame_id": "1779113716800_000129",
+            "fused_missing_conditions": [
+              "vars.engine_crank_left_complete==true"
+            ],
+            "fused_step_id": "S10",
+            "grounding_cache_hit": true,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "Appendix - Training Task Syllabus_6",
+              "fa18c_coldstart_quiz_3",
+              "fa18c_startup_master_1",
+              "fa18c_error_coding_guide_7",
+              "Appendix - Training Task Syllabus_3"
+            ],
+            "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+            "prompt_tokens_est": 5571,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "source_chunk_refs": [
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_3",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_7",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_3"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 68,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779113716800_000129"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779113716800_000129"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+          "request_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+          "timestamp": "2026-05-18T14:15:17.246454+00:00",
+          "version": "v1"
+        },
+        "related_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+        "vision_refs": [
+          "1779113716800_000129"
+        ]
+      },
+      {
+        "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+        "kind": "overlay_requested",
+        "lineno": 6033,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779113716800_000129",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 68,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779113716800_000129"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "3e9fd3d6-7e66-4159-8c7b-07d847e16c90",
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779113716800_000129",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 68,
+          "target": "pnt_377",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779113716800_000129"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+        "kind": "tutor_response",
+        "lineno": 6034,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779113716800_000129",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 68,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779113716800_000129"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_377",
+              "evidence_refs": [
+                "VARS.engine_crank_left"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "eng_crank_switch"
+              ],
+              "frame_id": "1779113716800_000129",
+              "fused_missing_conditions": [
+                "vars.engine_crank_left_complete==true"
+              ],
+              "fused_step_id": "S10",
+              "generation_mode": "model",
+              "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 68,
+              "target": "eng_crank_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779113716800_000129"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+          ],
+          "in_reply_to": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+          "message": "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。",
+          "metadata": {
+            "allowed_evidence_ref_count": 117,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "5fcdcf5a-70d6-4386-a141-f239d2cb5abc",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ]
+            },
+            "diagnosis": {
+              "error_category": "CO",
+              "step_id": "S10"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "overlay_step_id": "S10",
+              "source": "model",
+              "step_id": "S10",
+              "targets": [
+                "eng_crank_switch"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "model",
+            "final_overlay_targets": [
+              "eng_crank_switch"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_377",
+                  "evidence_refs": [
+                    "VARS.engine_crank_left"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "eng_crank_switch"
+                  ],
+                  "frame_id": "1779113716800_000129",
+                  "fused_missing_conditions": [
+                    "vars.engine_crank_left_complete==true"
+                  ],
+                  "fused_step_id": "S10",
+                  "generation_mode": "model",
+                  "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "model",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 68,
+                  "target": "eng_crank_switch",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779113716800_000129"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+              ],
+              "message": "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。",
+              "next": {
+                "step_id": "S10"
+              }
+            },
+            "frame_id": "1779113716800_000129",
+            "fused_missing_conditions": [
+              "vars.engine_crank_left_complete==true"
+            ],
+            "fused_step_id": "S10",
+            "generation_mode": "model",
+            "generation_prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+            "generation_prompt_tokens_est": 5571,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S10",
+              "source": "model",
+              "step_id": "S10",
+              "targets": [
+                "eng_crank_switch"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "GATES.S13.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "obogs_control_switch",
+                    "obogs_flow_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S14",
+                  "supporting_evidence_refs": [
+                    "GATES.S14.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "fcs_reset_button",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S15",
+                  "supporting_evidence_refs": [
+                    "GATES.S15.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "eng_crank_switch"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S10",
+                "supporting_evidence_refs": []
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "frame_count": 20,
+                  "latest_seq": 5603
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "final_action_plan": {
+                "overlay_step_id": "S10",
+                "source": "model",
+                "step_id": "S10",
+                "targets": [
+                  "eng_crank_switch"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "eng_crank_switch"
+              ],
+              "message_category": "model",
+              "model_decision": {
+                "evidence_refs": [
+                  "VARS.engine_crank_left"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "eng_crank_switch"
+                ],
+                "status": "ok",
+                "step_id": "S10"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": false,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": null
+              },
+              "schema_version": "v1",
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779113716800_000129"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 68,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [],
+            "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+              ],
+              "next": {
+                "step_id": "S10"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.engine_crank_left",
+                    "target": "eng_crank_switch",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "eng_crank_switch"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+              ],
+              "next": {
+                "step_id": "S10"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.engine_crank_left",
+                    "target": "eng_crank_switch",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "eng_crank_switch"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4043,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "model",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S10"
+            },
+            "model_raw_explanations": [
+              "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+              ],
+              "next": {
+                "step_id": "S10"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.engine_crank_left",
+                    "target": "eng_crank_switch",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "eng_crank_switch"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S10"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779113716800_000129"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779113716800_000129",
+            "next": {
+              "step_id": "S10"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5606,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.engine_crank_left_complete",
+                "GATES.S10.completion",
+                "GATES.S10.precondition",
+                "GATES.S12.completion",
+                "GATES.S13.completion",
+                "GATES.S13.precondition",
+                "GATES.S14.completion",
+                "GATES.S14.precondition",
+                "GATES.S15.completion",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_3",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_7",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_3"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": null,
+              "prompt_chars": 22284,
+              "prompt_tokens_est": 5571,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "Appendix - Training Task Syllabus_6",
+                "fa18c_coldstart_quiz_3",
+                "fa18c_startup_master_1",
+                "fa18c_error_coding_guide_7",
+                "Appendix - Training Task Syllabus_3"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+            "prompt_tokens_est": 5571,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+            "request_prompt_tokens_est": 5571,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 117,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S10"
+              },
+              "next": {
+                "step_id": "S10"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "state_key": "df4326d79b720c0c49d9d4ff60f026826154a2e514ffb57a025f5f913e2903d3",
+            "sync_delta_ms": 68,
+            "validator_rejected": false,
+            "vision": {
+              "frame_id": "1779113716800_000129",
+              "frame_ids": [
+                "1779113716800_000129"
+              ],
+              "frame_stale": false,
+              "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+              "observation_seq": 5603,
+              "observation_t_wall_ms": 1779113716747,
+              "observation_t_wall_s": 1779113716.7468793,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779113716800,
+                  "channel": "composite_panel",
+                  "frame_id": "1779113716800_000129",
+                  "frame_seq": 129,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779113716800_000129_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779113716800_000129.png",
+                  "sync_delta_ms": 68,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 68,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779113716800,
+                "channel": "composite_panel",
+                "frame_id": "1779113716800_000129",
+                "frame_seq": 129,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779113716800_000129_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779113716800_000129.png",
+                "sync_delta_ms": 68,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779113716732,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S10"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779113716800_000129"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779113716800_000129"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "3e9525b6-2d9d-4666-bec1-0b869d811ca8",
+          "status": "ok",
+          "timestamp": "2026-05-18T14:15:21.290270+00:00",
+          "version": "v1"
+        },
+        "related_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+        "vision_refs": [
+          "1779113716800_000129"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S10",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S10",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "eng_crank_switch"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 5603
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_6",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "score": 22.433209884437428,
+            "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "snippet_id": "Appendix - Training Task Syllabus_6"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_3",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q3. Left Engine Preconditions",
+            "score": 20.454016185702667,
+            "section": "Q3. Left Engine Preconditions",
+            "snippet_id": "fa18c_coldstart_quiz_3"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 20.411451188900127,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_7",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.5 State Violation (SV)",
+            "score": 19.11157429423624,
+            "section": "2.5 State Violation (SV)",
+            "snippet_id": "fa18c_error_coding_guide_7"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_3",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P1 – Power-Up & Safety (S01–S03)",
+            "score": 18.00574425802828,
+            "section": "Phase P1 – Power-Up & Safety (S01–S03)",
+            "snippet_id": "Appendix - Training Task Syllabus_3"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.engine_crank_left_complete==true"
+            ],
+            "overlay_step_id": "S10",
+            "role": "candidate_not_authoritative",
+            "step_id": "S10"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 5603,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5603,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 5603,
+            "latest_t_wall": 1779113716.7468793,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.962
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779113716800_000129",
+          "frame_ids": [
+            "1779113716800_000129"
+          ],
+          "frame_stale": false,
+          "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+          "observation_seq": 5603,
+          "observation_t_wall_ms": 1779113716747,
+          "observation_t_wall_s": 1779113716.7468793,
+          "status": "partial",
+          "sync_delta_ms": 68,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779113716732,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779113716800_000129"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 5603
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "frame_id": "1779113716800_000129",
+        "fused_missing_conditions": [
+          "vars.engine_crank_left_complete==true"
+        ],
+        "fused_step_id": "S10",
+        "grounding_cache_hit": true,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "Appendix - Training Task Syllabus_6",
+          "fa18c_coldstart_quiz_3",
+          "fa18c_startup_master_1",
+          "fa18c_error_coding_guide_7",
+          "Appendix - Training Task Syllabus_3"
+        ],
+        "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+        "prompt_tokens_est": 5571,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "source_chunk_refs": [
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_3",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_7",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_3"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 68,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779113716800_000129"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779113716800_000129"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+      "request_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+      "timestamp": "2026-05-18T14:15:17.246454+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_377",
+          "evidence_refs": [
+            "VARS.engine_crank_left"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779113716800_000129",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 68,
+          "target": "eng_crank_switch",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779113716800_000129"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+      ],
+      "in_reply_to": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+      "message": "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。",
+      "metadata": {
+        "allowed_evidence_ref_count": 117,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "5fcdcf5a-70d6-4386-a141-f239d2cb5abc",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ]
+        },
+        "diagnosis": {
+          "error_category": "CO",
+          "step_id": "S10"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "overlay_step_id": "S10",
+          "source": "model",
+          "step_id": "S10",
+          "targets": [
+            "eng_crank_switch"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "model",
+        "final_overlay_targets": [
+          "eng_crank_switch"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_377",
+              "evidence_refs": [
+                "VARS.engine_crank_left"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "eng_crank_switch"
+              ],
+              "frame_id": "1779113716800_000129",
+              "fused_missing_conditions": [
+                "vars.engine_crank_left_complete==true"
+              ],
+              "fused_step_id": "S10",
+              "generation_mode": "model",
+              "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 68,
+              "target": "eng_crank_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779113716800_000129"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+          ],
+          "message": "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。",
+          "next": {
+            "step_id": "S10"
+          }
+        },
+        "frame_id": "1779113716800_000129",
+        "fused_missing_conditions": [
+          "vars.engine_crank_left_complete==true"
+        ],
+        "fused_step_id": "S10",
+        "generation_mode": "model",
+        "generation_prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+        "generation_prompt_tokens_est": 5571,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S10",
+          "source": "model",
+          "step_id": "S10",
+          "targets": [
+            "eng_crank_switch"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S10",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "GATES.S13.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "obogs_control_switch",
+                "obogs_flow_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S14",
+              "supporting_evidence_refs": [
+                "GATES.S14.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "fcs_reset_button",
+                "left_mdi_pb18",
+                "left_mdi_pb15"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S15",
+              "supporting_evidence_refs": [
+                "GATES.S15.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "eng_crank_switch"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S10",
+            "supporting_evidence_refs": []
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "frame_count": 20,
+              "latest_seq": 5603
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "final_action_plan": {
+            "overlay_step_id": "S10",
+            "source": "model",
+            "step_id": "S10",
+            "targets": [
+              "eng_crank_switch"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "message_category": "model",
+          "model_decision": {
+            "evidence_refs": [
+              "VARS.engine_crank_left"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "eng_crank_switch"
+            ],
+            "status": "ok",
+            "step_id": "S10"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": false,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": null
+          },
+          "schema_version": "v1",
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779113716800_000129"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 68,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [],
+        "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+          ],
+          "next": {
+            "step_id": "S10"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.engine_crank_left",
+                "target": "eng_crank_switch",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "eng_crank_switch"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+          ],
+          "next": {
+            "step_id": "S10"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.engine_crank_left",
+                "target": "eng_crank_switch",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "eng_crank_switch"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4043,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "model",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S10"
+        },
+        "model_raw_explanations": [
+          "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+          ],
+          "next": {
+            "step_id": "S10"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.engine_crank_left",
+                "target": "eng_crank_switch",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "eng_crank_switch"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S10"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779113716800_000129"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779113716800_000129",
+        "next": {
+          "step_id": "S10"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5606,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.engine_crank_left_complete",
+            "GATES.S10.completion",
+            "GATES.S10.precondition",
+            "GATES.S12.completion",
+            "GATES.S13.completion",
+            "GATES.S13.precondition",
+            "GATES.S14.completion",
+            "GATES.S14.precondition",
+            "GATES.S15.completion",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_3",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_7",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_3"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": null,
+          "prompt_chars": 22284,
+          "prompt_tokens_est": 5571,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "Appendix - Training Task Syllabus_6",
+            "fa18c_coldstart_quiz_3",
+            "fa18c_startup_master_1",
+            "fa18c_error_coding_guide_7",
+            "Appendix - Training Task Syllabus_3"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+        "prompt_tokens_est": 5571,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "c0bfc4a4faf4212c7c8f51358d034fe1e66d8804bbbda99ee5c4fb0a2544f549",
+        "request_prompt_tokens_est": 5571,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 117,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S10"
+          },
+          "next": {
+            "step_id": "S10"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "state_key": "df4326d79b720c0c49d9d4ff60f026826154a2e514ffb57a025f5f913e2903d3",
+        "sync_delta_ms": 68,
+        "validator_rejected": false,
+        "vision": {
+          "frame_id": "1779113716800_000129",
+          "frame_ids": [
+            "1779113716800_000129"
+          ],
+          "frame_stale": false,
+          "observation_ref": "523fbca0-a175-4aec-8b39-1e024dadca50",
+          "observation_seq": 5603,
+          "observation_t_wall_ms": 1779113716747,
+          "observation_t_wall_s": 1779113716.7468793,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779113716800,
+              "channel": "composite_panel",
+              "frame_id": "1779113716800_000129",
+              "frame_seq": 129,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779113716800_000129_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779113716800_000129.png",
+              "sync_delta_ms": 68,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 68,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779113716800,
+            "channel": "composite_panel",
+            "frame_id": "1779113716800_000129",
+            "frame_seq": 129,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779113716800_000129_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779113716800_000129.png",
+            "sync_delta_ms": 68,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779113716732,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S10"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779113716800_000129"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779113716800_000129"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "3e9525b6-2d9d-4666-bec1-0b869d811ca8",
+      "status": "ok",
+      "timestamp": "2026-05-18T14:15:21.290270+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S10",
+    "expected_overlay_target_ids": [
+      "eng_crank_switch"
+    ],
+    "final_response_source": "model",
+    "llm_decision_status": "accepted",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S10",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "obogs_control_switch",
+          "obogs_flow_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S14",
+        "supporting_evidence_refs": [
+          "GATES.S14.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "fcs_reset_button",
+          "left_mdi_pb18",
+          "left_mdi_pb15"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S15",
+        "supporting_evidence_refs": [
+          "GATES.S15.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "overlay_step_id": "S10",
+      "source": "model",
+      "step_id": "S10",
+      "targets": [
+        "eng_crank_switch"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VARS.engine_crank_left"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "eng_crank_switch"
+      ],
+      "status": "ok",
+      "step_id": "S10"
+    },
+    "repair_result": {
+      "applied": false,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": null
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S10",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "GATES.S13.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "obogs_control_switch",
+            "obogs_flow_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S14",
+          "supporting_evidence_refs": [
+            "GATES.S14.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "fcs_reset_button",
+            "left_mdi_pb18",
+            "left_mdi_pb15"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S15",
+          "supporting_evidence_refs": [
+            "GATES.S15.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S10",
+        "supporting_evidence_refs": []
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "frame_count": 20,
+          "latest_seq": 5603
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "final_action_plan": {
+        "overlay_step_id": "S10",
+        "source": "model",
+        "step_id": "S10",
+        "targets": [
+          "eng_crank_switch"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "eng_crank_switch"
+      ],
+      "message_category": "model",
+      "model_decision": {
+        "evidence_refs": [
+          "VARS.engine_crank_left"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "eng_crank_switch"
+        ],
+        "status": "ok",
+        "step_id": "S10"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": false,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": null
+      },
+      "schema_version": "v1",
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779113716800_000129"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 68,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S10"
+      },
+      "explanations": [
+        "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+      ],
+      "next": {
+        "step_id": "S10"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.engine_crank_left",
+            "target": "eng_crank_switch",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "eng_crank_switch"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S10"
+      },
+      "explanations": [
+        "当前处于 S10 步骤。请将 ENG CRANK 开关拨到 LEFT 位置（左键点击）以启动左发动机。"
+      ],
+      "next": {
+        "step_id": "S10"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.engine_crank_left",
+            "target": "eng_crank_switch",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "eng_crank_switch"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "c3c775ce-7a4d-4e7f-a841-3a022528138e",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 6129,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260518_134513.jsonl"
+  }
+}

--- a/core/evidence_packet.py
+++ b/core/evidence_packet.py
@@ -831,7 +831,7 @@ def _build_gate_evidence(context: Mapping[str, Any]) -> GateEvidence:
         blocked_gate_ids=tuple(item["gate_id"] for item in blocked),
         satisfied_gate_ids=tuple(item["gate_id"] for item in satisfied),
         blocked_gates=tuple(blocked[:16]),
-        satisfied_gates=tuple(satisfied[:16]),
+        satisfied_gates=tuple(satisfied),
     )
 
 

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -89,9 +89,6 @@ def _telemetry_digest_has_true_var(evidence_packet: Any, var_name: str) -> bool:
     stable_true = getattr(digest, "stable_true_vars", ())
     if var_name in set(_strings(stable_true if isinstance(stable_true, (list, tuple, set)) else None)):
         return True
-    last_seen_true = getattr(digest, "last_seen_true", ())
-    if isinstance(last_seen_true, (list, tuple)):
-        return any(isinstance(item, Mapping) and item.get("var") == var_name for item in last_seen_true)
     return False
 
 
@@ -107,6 +104,8 @@ def _predicate_satisfied_by_latest_evidence(
     var_name = matched.group(1)
     if latest_vars.get(var_name) is True:
         return True
+    if latest_vars.get(var_name) is False:
+        return False
     return _telemetry_digest_has_true_var(evidence_packet, var_name)
 
 
@@ -114,8 +113,12 @@ def _completion_gate_satisfied(evidence_packet: Any, step_id: str | None) -> boo
     if not isinstance(step_id, str) or not step_id:
         return False
     gate_evidence = getattr(evidence_packet, "gate_evidence", None)
-    satisfied = getattr(gate_evidence, "satisfied_gate_ids", ())
-    return f"{step_id}.completion" in set(_strings(satisfied if isinstance(satisfied, (list, tuple, set)) else None))
+    for gate in getattr(gate_evidence, "satisfied_gates", ()):
+        if not isinstance(gate, Mapping):
+            continue
+        if gate.get("gate_id") == f"{step_id}.completion" and gate.get("status") == "satisfied":
+            return True
+    return False
 
 
 def validate_final_evidence_consistency(

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -8,11 +8,15 @@ small plan that adapters can map to their transport-specific actions.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
 from core.step_harness import StepHarnessSpec
+
+
+_VARS_TRUE_PREDICATE_RE = re.compile(r"^\s*(?:payload\.)?vars\.([A-Za-z0-9_]+)\s*==\s*true\s*$")
 
 
 @dataclass(frozen=True)
@@ -55,6 +59,16 @@ class HarnessTextGuidanceRule:
     source: str = "validator_text_only_guidance"
 
 
+@dataclass(frozen=True)
+class EvidenceConsistencyResult:
+    accepted: bool
+    validator_rejected: bool
+    repair_applied: bool
+    rejected_missing_conditions: tuple[str, ...]
+    final_action_plan_source: str
+    reasons: tuple[str, ...]
+
+
 def _strings(raw: Sequence[str] | set[str] | tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
     if not isinstance(raw, (list, tuple, set)):
         return ()
@@ -66,6 +80,85 @@ def _strings(raw: Sequence[str] | set[str] | tuple[str, ...] | list[str] | None)
         seen.add(item)
         out.append(item)
     return tuple(out)
+
+
+def _telemetry_digest_has_true_var(evidence_packet: Any, var_name: str) -> bool:
+    digest = getattr(evidence_packet, "telemetry_window_digest", None)
+    if digest is None:
+        return False
+    stable_true = getattr(digest, "stable_true_vars", ())
+    if var_name in set(_strings(stable_true if isinstance(stable_true, (list, tuple, set)) else None)):
+        return True
+    last_seen_true = getattr(digest, "last_seen_true", ())
+    if isinstance(last_seen_true, (list, tuple)):
+        return any(isinstance(item, Mapping) and item.get("var") == var_name for item in last_seen_true)
+    return False
+
+
+def _predicate_satisfied_by_latest_evidence(
+    predicate: str,
+    *,
+    latest_vars: Mapping[str, Any],
+    evidence_packet: Any = None,
+) -> bool:
+    matched = _VARS_TRUE_PREDICATE_RE.match(predicate)
+    if matched is None:
+        return False
+    var_name = matched.group(1)
+    if latest_vars.get(var_name) is True:
+        return True
+    return _telemetry_digest_has_true_var(evidence_packet, var_name)
+
+
+def _completion_gate_satisfied(evidence_packet: Any, step_id: str | None) -> bool:
+    if not isinstance(step_id, str) or not step_id:
+        return False
+    gate_evidence = getattr(evidence_packet, "gate_evidence", None)
+    satisfied = getattr(gate_evidence, "satisfied_gate_ids", ())
+    return f"{step_id}.completion" in set(_strings(satisfied if isinstance(satisfied, (list, tuple, set)) else None))
+
+
+def validate_final_evidence_consistency(
+    *,
+    accepted_step_id: str | None,
+    accepted_overlay_targets: Sequence[str] | None,
+    accepted_missing_conditions: Sequence[str] | None,
+    latest_vars: Mapping[str, Any] | None,
+    evidence_packet: Any = None,
+) -> EvidenceConsistencyResult:
+    del accepted_overlay_targets
+    vars_map = latest_vars if isinstance(latest_vars, Mapping) else {}
+    missing_conditions = _strings(
+        accepted_missing_conditions
+        if isinstance(accepted_missing_conditions, (list, tuple, set))
+        else None
+    )
+    rejected_missing = tuple(
+        condition
+        for condition in missing_conditions
+        if _predicate_satisfied_by_latest_evidence(
+            condition,
+            latest_vars=vars_map,
+            evidence_packet=evidence_packet,
+        )
+    )
+
+    reasons = [
+        f"missing_condition_satisfied_by_latest_telemetry:{condition}"
+        for condition in rejected_missing
+    ]
+    if _completion_gate_satisfied(evidence_packet, accepted_step_id):
+        reasons.append(f"completion_gate_already_satisfied:{accepted_step_id}")
+
+    rejected = bool(reasons)
+    return EvidenceConsistencyResult(
+        accepted=not rejected,
+        validator_rejected=rejected,
+        repair_applied=rejected,
+        rejected_missing_conditions=rejected_missing,
+        final_action_plan_source="final_evidence_consistency_validator" if rejected else "model",
+        reasons=tuple(reasons),
+    )
 
 
 def _hint_targets(action_hint: Mapping[str, Any] | None) -> tuple[str, ...]:
@@ -382,9 +475,11 @@ def plan_harness_action(
 
 
 __all__ = [
+    "EvidenceConsistencyResult",
     "HarnessActionHintFactRule",
     "HarnessActionPlan",
     "HarnessCompletionAdvance",
     "HarnessTextGuidanceRule",
     "plan_harness_action",
+    "validate_final_evidence_consistency",
 ]

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -168,16 +168,22 @@ def _completion_gate_satisfied(evidence_packet: Any, step_id: str | None) -> boo
     if not isinstance(step_id, str) or not step_id:
         return False
     gate_evidence = getattr(evidence_packet, "gate_evidence", None)
+    gate_id = f"{step_id}.completion"
     for gate in getattr(gate_evidence, "satisfied_gates", ()):
         if not isinstance(gate, Mapping):
             continue
-        if gate.get("gate_id") != f"{step_id}.completion":
+        if gate.get("gate_id") != gate_id:
             continue
+        if gate.get("reason_code") == "no_rules":
+            return False
         status = gate.get("status")
         if status == "satisfied":
             return True
-        if (status == "allowed" or gate.get("allowed") is True) and gate.get("reason_code") != "no_rules":
+        if status == "allowed" or gate.get("allowed") is True:
             return True
+    satisfied_ids = getattr(gate_evidence, "satisfied_gate_ids", ())
+    if gate_id in set(_strings(satisfied_ids if isinstance(satisfied_ids, (list, tuple, set)) else None)):
+        return True
     return False
 
 

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -8,6 +8,7 @@ small plan that adapters can map to their transport-specific actions.
 
 from __future__ import annotations
 
+import ast
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -16,7 +17,9 @@ from typing import Any
 from core.step_harness import StepHarnessSpec
 
 
-_VARS_TRUE_PREDICATE_RE = re.compile(r"^\s*(?:payload\.)?vars\.([A-Za-z0-9_]+)\s*==\s*true\s*$")
+_VARS_PREDICATE_RE = re.compile(
+    r"^\s*(?:payload\.)?vars\.([A-Za-z0-9_]+)\s*(==|!=|>=|<=|>|<|\bin\b)\s*(.+?)\s*$"
+)
 
 
 @dataclass(frozen=True)
@@ -92,19 +95,71 @@ def _telemetry_digest_has_true_var(evidence_packet: Any, var_name: str) -> bool:
     return False
 
 
+def _parse_predicate_literal(raw: str) -> Any:
+    text = raw.strip()
+    lowered = text.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"none", "null"}:
+        return None
+    try:
+        return ast.literal_eval(text)
+    except (SyntaxError, ValueError):
+        pass
+    try:
+        if any(ch in text for ch in (".", "e", "E")):
+            return float(text)
+        return int(text)
+    except ValueError:
+        return text
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _compare_predicate_value(value: Any, op: str, expected: Any) -> bool:
+    if op == "==":
+        return value == expected
+    if op == "!=":
+        return value != expected
+    if op in {">=", "<=", ">", "<"}:
+        if not (_is_number(value) and _is_number(expected)):
+            return False
+        if op == ">=":
+            return value >= expected
+        if op == "<=":
+            return value <= expected
+        if op == ">":
+            return value > expected
+        return value < expected
+    if op == "in":
+        if isinstance(expected, (list, tuple)) and len(expected) == 2 and all(_is_number(item) for item in expected):
+            low, high = expected
+            return _is_number(value) and low <= value <= high
+        if isinstance(expected, (list, tuple, set, frozenset)):
+            return value in expected
+    return False
+
+
 def _predicate_satisfied_by_latest_evidence(
     predicate: str,
     *,
     latest_vars: Mapping[str, Any],
     evidence_packet: Any = None,
 ) -> bool:
-    matched = _VARS_TRUE_PREDICATE_RE.match(predicate)
+    matched = _VARS_PREDICATE_RE.match(predicate)
     if matched is None:
         return False
     var_name = matched.group(1)
-    if latest_vars.get(var_name) is True:
-        return True
-    if latest_vars.get(var_name) is False:
+    op = matched.group(2).strip()
+    expected = _parse_predicate_literal(matched.group(3))
+    latest_value = latest_vars.get(var_name)
+    if var_name in latest_vars:
+        return _compare_predicate_value(latest_value, op, expected)
+    if not (op == "==" and expected is True):
         return False
     return _telemetry_digest_has_true_var(evidence_packet, var_name)
 
@@ -116,7 +171,12 @@ def _completion_gate_satisfied(evidence_packet: Any, step_id: str | None) -> boo
     for gate in getattr(gate_evidence, "satisfied_gates", ()):
         if not isinstance(gate, Mapping):
             continue
-        if gate.get("gate_id") == f"{step_id}.completion" and gate.get("status") == "satisfied":
+        if gate.get("gate_id") != f"{step_id}.completion":
+            continue
+        status = gate.get("status")
+        if status == "satisfied":
+            return True
+        if (status == "allowed" or gate.get("allowed") is True) and gate.get("reason_code") != "no_rules":
             return True
     return False
 

--- a/core/security.py
+++ b/core/security.py
@@ -39,6 +39,10 @@ _PROMPT_LEAK_MARKERS = (
     "system prompt",
 )
 _TRAILING_PUNCTUATION = ".,;:!?)"
+_INTERNAL_PREDICATE_RE = re.compile(
+    r"\b(?:payload\.)?vars\.[A-Za-z0-9_]+"
+    r"(?:\s*(?:==|!=|>=|<=|>|<|\bin\b)\s*(?:\[[^\]]*\]|[^\s,;。.!?]+))?"
+)
 
 
 class ModelTransportSecurityError(ValueError):
@@ -169,6 +173,8 @@ def sanitize_public_model_text(value: Any, *, lang: str) -> Any:
     if not isinstance(value, str):
         return value
     redacted = redact_sensitive_text(value)
+    predicate_marker = "the unmet condition" if lang == "en" else "该步骤的未满足条件"
+    redacted = _INTERNAL_PREDICATE_RE.sub(predicate_marker, redacted)
     if looks_like_prompt_leak(redacted):
         if lang == "en":
             return "Potential prompt/source leakage was blocked. Re-trigger Help after confirming the current step."

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -4632,6 +4632,17 @@ class LiveDcsTutorLoop:
 
     def _annotate_response_audit_metadata(self, response: TutorResponse) -> None:
         self._capture_model_raw_help_response(response)
+        sanitized_message = sanitize_public_model_text(response.message, lang=self.lang)
+        response.message = sanitized_message if isinstance(sanitized_message, str) else response.message
+        response.explanations = [
+            item
+            for item in (
+                sanitize_public_model_text(raw, lang=self.lang)
+                for raw in response.explanations
+                if isinstance(raw, str)
+            )
+            if isinstance(item, str)
+        ]
 
         final_public_response: dict[str, Any] = {
             "message": response.message,

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -5423,6 +5423,8 @@ class LiveDcsTutorLoop:
             return False, "s09_comm1_completion_already_rewritten"
         if response.metadata.get("s10_left_engine_completion_guardrail_applied") is True:
             return False, "s10_left_engine_completion_already_rewritten"
+        if response.metadata.get("final_evidence_consistency_repair_applied") is True:
+            return False, "final_evidence_consistency_already_rewritten"
         if response.metadata.get("completion_conflict_rewritten") is True:
             return False, "completion_conflict_already_rewritten"
         response_mapping_meta = response.metadata.get("response_mapping")
@@ -6001,8 +6003,6 @@ class LiveDcsTutorLoop:
         accepted_step_id: str | None,
         accepted_missing_conditions: Sequence[str],
     ) -> bool:
-        if not accepted_missing_conditions:
-            return False
         context = request.context if isinstance(request.context, Mapping) else {}
         vars_selected = context.get("vars")
         vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
@@ -6043,6 +6043,186 @@ class LiveDcsTutorLoop:
         response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
         return True
 
+    def _deterministic_missing_conditions_from_context(self, context: Mapping[str, Any]) -> list[str]:
+        hint = context.get("deterministic_step_hint")
+        if isinstance(hint, Mapping):
+            missing_conditions = hint.get("missing_conditions")
+            if isinstance(missing_conditions, (list, tuple)):
+                out = [item for item in missing_conditions if isinstance(item, str) and item]
+                if out:
+                    return out
+        state_harness = context.get("state_harness")
+        if isinstance(state_harness, Mapping):
+            deterministic = state_harness.get("deterministic_candidate")
+            if isinstance(deterministic, Mapping):
+                missing_conditions = deterministic.get("missing_conditions")
+                if isinstance(missing_conditions, (list, tuple)):
+                    return [item for item in missing_conditions if isinstance(item, str) and item]
+        return []
+
+    def _rewrite_final_evidence_consistency_conflict_response(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+        *,
+        rejected_step_id: str,
+        rejected_missing_conditions: Sequence[str],
+    ) -> tuple[bool, str]:
+        context = request.context if isinstance(request.context, Mapping) else {}
+        vars_selected = context.get("vars")
+        vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        recent_actions = context.get("recent_actions")
+        recent_buttons = (
+            [
+                item for item in recent_actions.get("recent_buttons", [])
+                if isinstance(item, str) and item
+            ]
+            if isinstance(recent_actions, Mapping)
+            else []
+        )
+        advanced = self._infer_after_completed_step(
+            rejected_step_id,
+            vars_map,
+            recent_ui_targets=recent_buttons,
+            vision_facts=context.get("vision_facts"),
+        )
+        next_step_id = (
+            advanced.inferred_step_id
+            if advanced is not None and isinstance(advanced.inferred_step_id, str)
+            else self._next_step_id_after(rejected_step_id)
+        )
+        if not isinstance(next_step_id, str) or not next_step_id:
+            next_step_id = rejected_step_id
+
+        if self.lang == "zh":
+            rewritten = f"{rejected_step_id} 的最新证据已经满足。现在进入 {next_step_id}。"
+        else:
+            rewritten = f"The latest evidence satisfies {rejected_step_id}. Continue to {next_step_id}."
+
+        original_actions = copy.deepcopy([dict(action) for action in response.actions if isinstance(action, Mapping)])
+        if original_actions:
+            response.metadata["final_evidence_consistency_original_actions"] = original_actions
+            rejected_targets = [
+                action.get("target")
+                for action in original_actions
+                if isinstance(action.get("target"), str)
+            ]
+            if rejected_targets:
+                response.metadata["rejected_model_targets"] = _dedupe_strings(rejected_targets)
+                response.metadata["rejected_model_target"] = response.metadata["rejected_model_targets"][0]
+
+        response.actions = []
+        response.message = rewritten
+        response.explanations = [rewritten]
+        response.metadata["diagnosis"] = {"step_id": next_step_id, "error_category": "OM"}
+        response.metadata["next"] = {"step_id": next_step_id}
+        response.metadata["final_action_plan_source"] = "final_evidence_consistency_validator"
+        response.metadata["rejected_model_step_id"] = rejected_step_id
+        response.metadata["rejected_missing_conditions"] = [
+            item for item in rejected_missing_conditions if isinstance(item, str) and item
+        ]
+
+        fallback_help_obj, fallback_reason = self._build_safe_fallback_overlay_help_obj(
+            request,
+            override_inferred_step_id=next_step_id,
+            override_overlay_step_id=next_step_id,
+            ignore_request_allowlist=True,
+        )
+        fallback_used = False
+        if isinstance(fallback_help_obj, Mapping):
+            planned_help_obj = copy.deepcopy(dict(fallback_help_obj))
+            planned_help_obj["diagnosis"] = {"step_id": next_step_id, "error_category": "OM"}
+            planned_help_obj["next"] = {"step_id": next_step_id}
+            planned_help_obj["explanations"] = [rewritten]
+            mapped = map_help_response_to_tutor_response(
+                planned_help_obj,
+                request=request,
+                status=response.status,
+                max_overlay_targets=self.max_overlay_targets,
+                ui_map_path=self.ui_map_path,
+                lang=self.lang,
+            )
+            mapped_meta = dict(mapped.metadata)
+            if mapped_meta:
+                response.metadata["final_evidence_consistency_mapping"] = mapped_meta
+            if mapped.actions:
+                response.actions = list(mapped.actions)
+                response.metadata["help_response"] = planned_help_obj
+                fallback_used = True
+            else:
+                fallback_reason = "fallback_mapping_failed"
+                response.metadata["help_response"] = {
+                    "diagnosis": {"step_id": next_step_id, "error_category": "OM"},
+                    "next": {"step_id": next_step_id},
+                    "overlay": {"targets": [], "evidence": []},
+                    "explanations": [rewritten],
+                }
+        else:
+            response.metadata["help_response"] = {
+                "diagnosis": {"step_id": next_step_id, "error_category": "OM"},
+                "next": {"step_id": next_step_id},
+                "overlay": {"targets": [], "evidence": []},
+                "explanations": [rewritten],
+            }
+
+        final_targets = _overlay_targets_from_actions(response.actions)
+        response.metadata["harness_action_plan"] = {
+            "step_id": next_step_id,
+            "overlay_step_id": next_step_id,
+            "targets": list(final_targets),
+            "text_only": not bool(final_targets),
+            "source": "final_evidence_consistency_validator",
+        }
+        response.metadata["final_evidence_consistency_repair_applied"] = True
+        response.metadata["final_evidence_consistency_overlay_applied"] = fallback_used
+        response.metadata["final_evidence_consistency_overlay_reason"] = fallback_reason
+        return True, "final_evidence_consistency_validator"
+
+    def _final_response_step_id(self, response: TutorResponse) -> str | None:
+        final_plan = response.metadata.get("harness_action_plan") or response.metadata.get("final_action_plan")
+        if isinstance(final_plan, Mapping):
+            step_id = final_plan.get("step_id")
+            if isinstance(step_id, str) and step_id:
+                return step_id
+        for key in ("next", "diagnosis"):
+            raw = response.metadata.get(key)
+            if isinstance(raw, Mapping):
+                step_id = raw.get("step_id")
+                if isinstance(step_id, str) and step_id:
+                    return step_id
+        return None
+
+    def _enforce_final_evidence_consistency_after_repairs(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> tuple[bool, str]:
+        context = request.context if isinstance(request.context, Mapping) else {}
+        hint = context.get("deterministic_step_hint")
+        if not isinstance(hint, Mapping):
+            return False, "missing_deterministic_hint"
+        inferred_step_id = hint.get("inferred_step_id")
+        if not isinstance(inferred_step_id, str) or not inferred_step_id:
+            return False, "missing_inferred_step_id"
+        final_step_id = self._final_response_step_id(response)
+        if final_step_id != inferred_step_id:
+            return False, "final_step_already_advanced"
+        missing_list = self._deterministic_missing_conditions_from_context(context)
+        rejected = self._apply_final_evidence_consistency_metadata(
+            response,
+            request,
+            accepted_step_id=inferred_step_id,
+            accepted_missing_conditions=missing_list,
+        )
+        if not rejected:
+            return False, "final_evidence_consistent"
+        return self._rewrite_final_evidence_consistency_conflict_response(
+            response,
+            request,
+            rejected_step_id=inferred_step_id,
+            rejected_missing_conditions=response.metadata.get("rejected_missing_conditions", []),
+        )
+
     def _rewrite_procedural_guidance_response(
         self,
         response: TutorResponse,
@@ -6053,11 +6233,7 @@ class LiveDcsTutorLoop:
         if not isinstance(hint, Mapping):
             return False, "missing_deterministic_hint"
         inferred_step_id = hint.get("inferred_step_id")
-        missing_conditions = hint.get("missing_conditions")
-        missing_list = [
-            item for item in missing_conditions
-            if isinstance(item, str) and item
-        ] if isinstance(missing_conditions, (list, tuple)) else []
+        missing_list = self._deterministic_missing_conditions_from_context(context)
         missing_set = set(missing_list)
 
         vars_selected = context.get("vars")
@@ -6441,6 +6617,13 @@ class LiveDcsTutorLoop:
                     response.metadata["help_response"] = rewritten_help_response
 
         if not rewritten:
+            if final_consistency_rejected and isinstance(inferred_step_id, str):
+                return self._rewrite_final_evidence_consistency_conflict_response(
+                    response,
+                    request,
+                    rejected_step_id=inferred_step_id,
+                    rejected_missing_conditions=missing_list,
+                )
             return False, reason
 
         original_message = response.message
@@ -7096,6 +7279,13 @@ class LiveDcsTutorLoop:
         if manual_throttle_rewritten:
             fallback_overlay_used = False
             fallback_overlay_reason = manual_throttle_reason
+        final_consistency_used, final_consistency_reason = self._enforce_final_evidence_consistency_after_repairs(
+            response,
+            request,
+        )
+        if final_consistency_used:
+            fallback_overlay_used = bool(response.actions)
+            fallback_overlay_reason = final_consistency_reason
 
         if mapped_meta:
             mapping_failure_codes = classify_mapping_failure(mapped_meta)

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -4572,7 +4572,7 @@ class LiveDcsTutorLoop:
             if inferred_step_id and missing_conditions:
                 return (
                     f"降级提示：你大概率卡在 {inferred_step_id}，"
-                    f"请先满足：{'; '.join(missing_conditions)}。"
+                    "请先完成该步骤的未满足条件。"
                 )
             if inferred_step_id:
                 return f"降级提示：你大概率卡在 {inferred_step_id}，请先检查并执行该步骤。"
@@ -4580,7 +4580,7 @@ class LiveDcsTutorLoop:
         if inferred_step_id and missing_conditions:
             return (
                 f"Fallback: likely stuck at {inferred_step_id}; "
-                f"please satisfy: {'; '.join(missing_conditions)}."
+                "please complete the unmet conditions for that step."
             )
         if inferred_step_id:
             return f"Fallback: likely stuck at {inferred_step_id}; please check that step."
@@ -4834,18 +4834,18 @@ class LiveDcsTutorLoop:
                     "but it has not entered the FCS page yet; press Left DDI PB15 to enter the FCS page first."
                 )
         elif self.lang == "zh":
-            rewritten = f"当前 {inferred_step_id} 尚未完成，请先满足：{'; '.join(normalized_missing)}。"
+            rewritten = f"当前 {inferred_step_id} 尚未完成，请先完成该步骤的未满足条件。"
             if isinstance(action_target, str) and action_target:
-                rewritten = f"当前 {inferred_step_id} 尚未完成。请先操作 {action_target}，再满足：{'; '.join(normalized_missing)}。"
+                rewritten = f"当前 {inferred_step_id} 尚未完成。请先操作 {action_target}，并确认该步骤条件已满足。"
         else:
             rewritten = (
                 f"{inferred_step_id} is not complete yet. "
-                f"Please satisfy: {'; '.join(normalized_missing)}."
+                "Please complete the unmet conditions for that step."
             )
             if isinstance(action_target, str) and action_target:
                 rewritten = (
                     f"{inferred_step_id} is not complete yet. "
-                    f"Please operate {action_target} first, then satisfy: {'; '.join(normalized_missing)}."
+                    f"Please operate {action_target} first and confirm that step is complete."
                 )
 
         response.message = rewritten
@@ -6006,8 +6006,9 @@ class LiveDcsTutorLoop:
         context = request.context if isinstance(request.context, Mapping) else {}
         vars_selected = context.get("vars")
         vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        evidence_context = self._context_with_full_pack_gates(context)
         try:
-            evidence_packet = build_evidence_packet(context)
+            evidence_packet = build_evidence_packet(evidence_context)
         except Exception:
             evidence_packet = None
         targets = _overlay_targets_from_actions(response.actions)
@@ -6042,6 +6043,24 @@ class LiveDcsTutorLoop:
         merged_reasons.extend(result.reasons)
         response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
         return True
+
+    def _context_with_full_pack_gates(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
+        vars_selected = context.get("vars")
+        if not isinstance(vars_selected, Mapping):
+            return context
+        full_gates = evaluate_pack_gates(
+            observations=[{"payload": {"vars": dict(vars_selected)}, "vars": dict(vars_selected)}],
+            precondition_gates=self.precondition_gates,
+            completion_gates=self.completion_gates,
+        )
+        if not full_gates:
+            return context
+        merged = dict(context)
+        existing_gates = context.get("gates")
+        gates = dict(existing_gates) if isinstance(existing_gates, Mapping) else {}
+        gates.update(full_gates)
+        merged["gates"] = gates
+        return merged
 
     def _deterministic_missing_conditions_from_context(self, context: Mapping[str, Any]) -> list[str]:
         hint = context.get("deterministic_step_hint")
@@ -6192,6 +6211,42 @@ class LiveDcsTutorLoop:
                     return step_id
         return None
 
+    def _missing_conditions_for_final_step(
+        self,
+        step_id: str,
+        context: Mapping[str, Any],
+    ) -> list[str]:
+        vars_selected = context.get("vars")
+        vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        idx = self._step_order_index.get(step_id)
+        if idx is None:
+            return []
+        full_context = self._context_with_full_pack_gates(context)
+        gates = full_context.get("gates")
+        recent_actions = context.get("recent_actions")
+        recent_buttons = (
+            [
+                item for item in recent_actions.get("recent_buttons", [])
+                if isinstance(item, str) and item
+            ]
+            if isinstance(recent_actions, Mapping)
+            else []
+        )
+        inference = infer_step_id(
+            self.pack_steps[idx:],
+            vars_map,
+            recent_buttons,
+            gates=gates if isinstance(gates, Mapping) else None,
+            precondition_gates=self.precondition_gates,
+            completion_gates=self.completion_gates,
+            scenario_profile=self.scenario_profile,
+            pack_path=self.pack_path,
+            vision_facts=context.get("vision_facts"),
+        )
+        if inference.inferred_step_id != step_id:
+            return []
+        return [item for item in inference.missing_conditions if isinstance(item, str) and item]
+
     def _enforce_final_evidence_consistency_after_repairs(
         self,
         response: TutorResponse,
@@ -6210,7 +6265,7 @@ class LiveDcsTutorLoop:
         missing_list = (
             self._deterministic_missing_conditions_from_context(context)
             if final_step_id == inferred_step_id
-            else []
+            else self._missing_conditions_for_final_step(final_step_id, context)
         )
         rejected = self._apply_final_evidence_consistency_metadata(
             response,
@@ -6760,14 +6815,23 @@ class LiveDcsTutorLoop:
         if step_fallback_profile.get("overlay_enabled") is False:
             return None, f"overlay_disabled:{overlay_step_id}"
         declared_fallback_target = fallback_targets[0]
+        overridden_inferred_step = (
+            isinstance(override_inferred_step_id, str)
+            and override_inferred_step_id
+            and override_inferred_step_id != hint.get("inferred_step_id")
+        )
         missing_conditions_raw = hint.get("missing_conditions")
         missing_conditions = [
             item for item in missing_conditions_raw if isinstance(item, str) and item
         ] if isinstance(missing_conditions_raw, (list, tuple)) else []
+        if overridden_inferred_step:
+            missing_conditions = self._missing_conditions_for_final_step(inferred_step_id, context)
         gate_blockers_raw = hint.get("gate_blockers")
         gate_blockers = [
             item for item in gate_blockers_raw if isinstance(item, Mapping) and item
         ] if isinstance(gate_blockers_raw, (list, tuple)) else []
+        if overridden_inferred_step:
+            gate_blockers = []
 
         if inferred_step_id == "S33" and not missing_conditions and not gate_blockers:
             return None, "all_steps_complete"

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -92,6 +92,7 @@ from core.harness_validation import (
     HarnessCompletionAdvance,
     HarnessTextGuidanceRule,
     plan_harness_action,
+    validate_final_evidence_consistency,
 )
 from core.help_orchestrator import (
     HelpCycleDecisionResult,
@@ -5992,6 +5993,56 @@ class LiveDcsTutorLoop:
             response.metadata["manual_throttle_guidance_original_explanations"] = original_explanations
         return True, "manual_throttle_keyboard_guidance"
 
+    def _apply_final_evidence_consistency_metadata(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+        *,
+        accepted_step_id: str | None,
+        accepted_missing_conditions: Sequence[str],
+    ) -> bool:
+        if not accepted_missing_conditions:
+            return False
+        context = request.context if isinstance(request.context, Mapping) else {}
+        vars_selected = context.get("vars")
+        vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        try:
+            evidence_packet = build_evidence_packet(context)
+        except Exception:
+            evidence_packet = None
+        targets = _overlay_targets_from_actions(response.actions)
+        if not targets:
+            help_response = response.metadata.get("help_response")
+            targets = _help_response_overlay_targets(help_response)
+        result = validate_final_evidence_consistency(
+            accepted_step_id=accepted_step_id,
+            accepted_overlay_targets=targets,
+            accepted_missing_conditions=accepted_missing_conditions,
+            latest_vars=vars_map,
+            evidence_packet=evidence_packet,
+        )
+        if result.accepted:
+            return False
+
+        response.metadata["validator_rejected"] = True
+        response.metadata["repair_applied"] = True
+        response.metadata["rejected_missing_conditions"] = list(result.rejected_missing_conditions)
+        response.metadata["final_evidence_consistency_validator_applied"] = True
+        response.metadata["final_evidence_consistency_reasons"] = list(result.reasons)
+        response.metadata.setdefault("final_action_plan_source", result.final_action_plan_source)
+        if isinstance(accepted_step_id, str) and accepted_step_id:
+            response.metadata.setdefault("rejected_model_step_id", accepted_step_id)
+
+        existing_reasons = response.metadata.get("harness_validation_reasons")
+        merged_reasons = (
+            [item for item in existing_reasons if isinstance(item, str) and item]
+            if isinstance(existing_reasons, list)
+            else []
+        )
+        merged_reasons.extend(result.reasons)
+        response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
+        return True
+
     def _rewrite_procedural_guidance_response(
         self,
         response: TutorResponse,
@@ -6003,13 +6054,20 @@ class LiveDcsTutorLoop:
             return False, "missing_deterministic_hint"
         inferred_step_id = hint.get("inferred_step_id")
         missing_conditions = hint.get("missing_conditions")
-        missing_set = {
+        missing_list = [
             item for item in missing_conditions
             if isinstance(item, str) and item
-        } if isinstance(missing_conditions, (list, tuple)) else set()
+        ] if isinstance(missing_conditions, (list, tuple)) else []
+        missing_set = set(missing_list)
 
         vars_selected = context.get("vars")
         vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        final_consistency_rejected = self._apply_final_evidence_consistency_metadata(
+            response,
+            request,
+            accepted_step_id=inferred_step_id if isinstance(inferred_step_id, str) else None,
+            accepted_missing_conditions=missing_list,
+        )
         vision_fact_summary = context.get("vision_fact_summary")
         vision_summary = vision_fact_summary if isinstance(vision_fact_summary, Mapping) else {}
         vision_seen_or_fresh: set[str] = set()
@@ -6100,6 +6158,17 @@ class LiveDcsTutorLoop:
             response.metadata["s09_comm1_completion_guardrail_applied"] = True
             response.metadata["s09_comm1_completion_s10_overlay_applied"] = fallback_used
             response.metadata["s09_comm1_completion_s10_overlay_reason"] = fallback_reason
+            final_targets = _overlay_targets_from_actions(response.actions)
+            response.metadata["harness_action_plan"] = {
+                "step_id": "S10",
+                "overlay_step_id": "S10",
+                "targets": list(final_targets),
+                "text_only": not bool(final_targets),
+                "source": response.metadata.get(
+                    "final_action_plan_source",
+                    "final_evidence_consistency_validator",
+                ),
+            }
         elif inferred_step_id == "S09" and "vars.comm1_freq_134_000==true" in missing_set:
             reason = "s09_comm1_frequency_guidance"
             if self.lang == "zh":
@@ -6380,6 +6449,8 @@ class LiveDcsTutorLoop:
         response.explanations = [rewritten]
         response.metadata["procedural_guidance_rewritten"] = True
         response.metadata["procedural_guidance_rewrite_reason"] = reason
+        if final_consistency_rejected:
+            response.metadata["procedural_guidance_rewrite_source"] = "final_evidence_consistency_validator"
         if reason.startswith(("s20_refuel_probe_", "s21_refuel_probe_")):
             response.metadata["refuel_probe_motion_guidance_rewritten"] = True
         if original_message != rewritten:

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -6205,13 +6205,17 @@ class LiveDcsTutorLoop:
         if not isinstance(inferred_step_id, str) or not inferred_step_id:
             return False, "missing_inferred_step_id"
         final_step_id = self._final_response_step_id(response)
-        if final_step_id != inferred_step_id:
-            return False, "final_step_already_advanced"
-        missing_list = self._deterministic_missing_conditions_from_context(context)
+        if not isinstance(final_step_id, str) or not final_step_id:
+            return False, "missing_final_step_id"
+        missing_list = (
+            self._deterministic_missing_conditions_from_context(context)
+            if final_step_id == inferred_step_id
+            else []
+        )
         rejected = self._apply_final_evidence_consistency_metadata(
             response,
             request,
-            accepted_step_id=inferred_step_id,
+            accepted_step_id=final_step_id,
             accepted_missing_conditions=missing_list,
         )
         if not rejected:
@@ -6219,7 +6223,7 @@ class LiveDcsTutorLoop:
         return self._rewrite_final_evidence_consistency_conflict_response(
             response,
             request,
-            rejected_step_id=inferred_step_id,
+            rejected_step_id=final_step_id,
             rejected_missing_conditions=response.metadata.get("rejected_missing_conditions", []),
         )
 

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -64,6 +64,38 @@ def test_final_evidence_consistency_rejects_missing_condition_satisfied_by_telem
     assert "missing_condition_satisfied_by_latest_telemetry:vars.comm1_freq_134_000==true" in result.reasons
 
 
+def test_final_evidence_consistency_rejects_numeric_missing_condition_satisfied_by_telemetry() -> None:
+    context = {
+        "vars": {"rpm_r": 26, "ext_refuel_probe_value": 1200},
+        "deterministic_step_hint": {
+            "inferred_step_id": "S05",
+            "overlay_step_id": "S05",
+            "missing_conditions": [
+                "vars.rpm_r>=25",
+                "vars.ext_refuel_probe_value in [0,5000]",
+            ],
+        },
+    }
+    packet = build_evidence_packet(context)
+
+    result = validate_final_evidence_consistency(
+        accepted_step_id="S05",
+        accepted_overlay_targets=[],
+        accepted_missing_conditions=[
+            "vars.rpm_r>=25",
+            "vars.ext_refuel_probe_value in [0,5000]",
+        ],
+        latest_vars=context["vars"],
+        evidence_packet=packet,
+    )
+
+    assert result.accepted is False
+    assert result.rejected_missing_conditions == (
+        "vars.rpm_r>=25",
+        "vars.ext_refuel_probe_value in [0,5000]",
+    )
+
+
 def test_final_evidence_consistency_does_not_use_stale_last_seen_true_when_latest_false() -> None:
     context = {
         "vars": {"apu_start_support_complete": False},
@@ -114,6 +146,49 @@ def test_final_evidence_consistency_rejects_already_satisfied_completion_gate() 
     assert result.accepted is False
     assert result.rejected_missing_conditions == ()
     assert "completion_gate_already_satisfied:S03" in result.reasons
+
+
+def test_final_evidence_consistency_rejects_allowed_completion_gate_but_ignores_no_rules() -> None:
+    packet = build_evidence_packet(
+        {
+            "vars": {},
+            "gates": {
+                "S03.completion": {
+                    "status": "allowed",
+                    "allowed": True,
+                    "step_id": "S03",
+                    "gate_type": "completion",
+                    "reason_code": "ok",
+                },
+                "S04.completion": {
+                    "status": "allowed",
+                    "allowed": True,
+                    "step_id": "S04",
+                    "gate_type": "completion",
+                    "reason_code": "no_rules",
+                },
+            },
+        }
+    )
+
+    rejected = validate_final_evidence_consistency(
+        accepted_step_id="S03",
+        accepted_overlay_targets=[],
+        accepted_missing_conditions=[],
+        latest_vars={},
+        evidence_packet=packet,
+    )
+    accepted = validate_final_evidence_consistency(
+        accepted_step_id="S04",
+        accepted_overlay_targets=[],
+        accepted_missing_conditions=[],
+        latest_vars={},
+        evidence_packet=packet,
+    )
+
+    assert rejected.accepted is False
+    assert "completion_gate_already_satisfied:S03" in rejected.reasons
+    assert accepted.accepted is True
 
 
 def test_plan_harness_action_repairs_invalid_target_to_step_spec_target() -> None:

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -64,6 +64,58 @@ def test_final_evidence_consistency_rejects_missing_condition_satisfied_by_telem
     assert "missing_condition_satisfied_by_latest_telemetry:vars.comm1_freq_134_000==true" in result.reasons
 
 
+def test_final_evidence_consistency_does_not_use_stale_last_seen_true_when_latest_false() -> None:
+    context = {
+        "vars": {"apu_start_support_complete": False},
+        "telemetry_window_frames": [
+            {"seq": 1, "t_wall": 1.0, "vars": {"apu_start_support_complete": True}},
+            {"seq": 2, "t_wall": 2.0, "vars": {"apu_start_support_complete": False}},
+        ],
+        "deterministic_step_hint": {
+            "inferred_step_id": "S03",
+            "overlay_step_id": "S03",
+            "missing_conditions": ["vars.apu_start_support_complete==true"],
+        },
+    }
+    packet = build_evidence_packet(context)
+
+    result = validate_final_evidence_consistency(
+        accepted_step_id="S03",
+        accepted_overlay_targets=["apu_switch"],
+        accepted_missing_conditions=["vars.apu_start_support_complete==true"],
+        latest_vars=context["vars"],
+        evidence_packet=packet,
+    )
+
+    assert result.accepted is True
+    assert result.rejected_missing_conditions == ()
+
+
+def test_final_evidence_consistency_rejects_already_satisfied_completion_gate() -> None:
+    context = {
+        "vars": {},
+        "gates": {"S03.completion": {"status": "satisfied", "step_id": "S03", "gate_type": "completion"}},
+        "deterministic_step_hint": {
+            "inferred_step_id": "S03",
+            "overlay_step_id": "S03",
+            "missing_conditions": [],
+        },
+    }
+    packet = build_evidence_packet(context)
+
+    result = validate_final_evidence_consistency(
+        accepted_step_id="S03",
+        accepted_overlay_targets=["apu_switch"],
+        accepted_missing_conditions=[],
+        latest_vars=context["vars"],
+        evidence_packet=packet,
+    )
+
+    assert result.accepted is False
+    assert result.rejected_missing_conditions == ()
+    assert "completion_gate_already_satisfied:S03" in result.reasons
+
+
 def test_plan_harness_action_repairs_invalid_target_to_step_spec_target() -> None:
     plan = plan_harness_action(
         step_specs={"S20": _spec("S20", ("refuel_probe_switch",))},

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -191,6 +191,31 @@ def test_final_evidence_consistency_rejects_allowed_completion_gate_but_ignores_
     assert accepted.accepted is True
 
 
+def test_final_evidence_consistency_rejects_late_allowed_completion_gate_after_detail_window() -> None:
+    gates = {
+        f"S{idx:02d}.completion": {
+            "status": "allowed",
+            "allowed": True,
+            "step_id": f"S{idx:02d}",
+            "gate_type": "completion",
+            "reason_code": "ok",
+        }
+        for idx in range(1, 25)
+    }
+    packet = build_evidence_packet({"vars": {}, "gates": gates})
+
+    result = validate_final_evidence_consistency(
+        accepted_step_id="S18",
+        accepted_overlay_targets=[],
+        accepted_missing_conditions=[],
+        latest_vars={},
+        evidence_packet=packet,
+    )
+
+    assert result.accepted is False
+    assert "completion_gate_already_satisfied:S18" in result.reasons
+
+
 def test_plan_harness_action_repairs_invalid_target_to_step_spec_target() -> None:
     plan = plan_harness_action(
         step_specs={"S20": _spec("S20", ("refuel_probe_switch",))},

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from core.harness_validation import (
+    validate_final_evidence_consistency,
     HarnessActionHintFactRule,
     HarnessCompletionAdvance,
     HarnessTextGuidanceRule,
     plan_harness_action,
 )
+from core.evidence_packet import build_evidence_packet
 from core.step_harness import RecoveryActionPolicy, SignalQualityRequirement, StepHarnessSpec
 
 
@@ -34,6 +36,32 @@ def _spec(
         declared_ui_targets=targets,
         overlay_enabled=overlay_enabled,
     )
+
+
+def test_final_evidence_consistency_rejects_missing_condition_satisfied_by_telemetry() -> None:
+    context = {
+        "vars": {"comm1_freq_134_000": True},
+        "deterministic_step_hint": {
+            "inferred_step_id": "S09",
+            "overlay_step_id": "S09",
+            "missing_conditions": ["vars.comm1_freq_134_000==true"],
+        },
+    }
+    packet = build_evidence_packet(context)
+
+    result = validate_final_evidence_consistency(
+        accepted_step_id="S09",
+        accepted_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        accepted_missing_conditions=["vars.comm1_freq_134_000==true"],
+        latest_vars=context["vars"],
+        evidence_packet=packet,
+    )
+
+    assert result.accepted is False
+    assert result.validator_rejected is True
+    assert result.repair_applied is True
+    assert result.rejected_missing_conditions == ("vars.comm1_freq_134_000==true",)
+    assert "missing_condition_satisfied_by_latest_telemetry:vars.comm1_freq_134_000==true" in result.reasons
 
 
 def test_plan_harness_action_repairs_invalid_target_to_step_spec_target() -> None:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -9880,6 +9880,82 @@ def _validate_compact_live_help_response(
         loop.close()
 
 
+def _load_live_help_fixture(path: str) -> dict[str, Any]:
+    return json.loads((Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8"))
+
+
+def _fixture_request_and_model_response(fixture: dict[str, Any]) -> tuple[TutorRequest, TutorResponse]:
+    request_payload = fixture["cycle"]["tutor_request"]
+    context = dict(request_payload.get("context", {}))
+    observations = fixture.get("context", {}).get("observations", [])
+    if observations and isinstance(observations[0], dict):
+        payload = observations[0].get("payload")
+        if isinstance(payload, dict) and isinstance(payload.get("vars"), dict):
+            context.setdefault("vars", payload["vars"])
+    request = TutorRequest(
+        request_id=request_payload["request_id"],
+        message=request_payload.get("message"),
+        observation_ref=request_payload.get("observation_ref"),
+        context=context,
+        metadata=dict(request_payload.get("metadata", {})),
+    )
+    help_response = fixture["model_io"]["help_response"]
+    explanations = [item for item in help_response.get("explanations", []) if isinstance(item, str)]
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message=explanations[0] if explanations else None,
+        actions=[],
+        explanations=explanations,
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": help_response,
+        },
+    )
+    return request, response
+
+
+def test_live_help_fixture_311_replays_real_s09_comm1_complete_fixture() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/168fc73d-f98c-498e-a35c-fef91b06ee2e.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S10"
+    assert repaired.metadata["next"]["step_id"] == "S10"
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["rejected_missing_conditions"] == ["vars.comm1_freq_134_000==true"]
+    assert repaired.metadata["final_action_plan"]["source"] == "final_evidence_consistency_validator"
+    assert repaired.metadata["final_public_response"]["next"]["step_id"] == "S10"
+    assert "ufc_comm1_channel_selector_pull" not in repaired.metadata["final_overlay_targets"]
+    assert "vars.comm1_freq_134_000==true" not in repaired.message
+
+
+def test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/c3c775ce-7a4d-4e7f-a841-3a022528138e.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] != "S10"
+    assert repaired.metadata["next"]["step_id"] != "S10"
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["rejected_missing_conditions"] == ["vars.engine_crank_left_complete==true"]
+    assert repaired.metadata["final_action_plan"]["source"] in {
+        "final_evidence_consistency_validator",
+        "s10_left_engine_completion_guardrail",
+    }
+    assert "eng_crank_switch" not in repaired.metadata["final_overlay_targets"]
+    assert "vars.engine_crank_left_complete==true" not in repaired.message
+
+
 def test_live_help_fixture_294_s09_comm1_complete_advances_to_s10() -> None:
     request = TutorRequest(
         request_id="issue-294-s09-complete",
@@ -9959,6 +10035,7 @@ def test_live_help_fixture_294_s09_comm1_complete_advances_to_s10() -> None:
     assert repaired.metadata["rejected_missing_conditions"] == ["vars.comm1_freq_134_000==true"]
     assert repaired.metadata["s09_comm1_completion_guardrail_applied"] is True
     assert repaired.metadata["final_overlay_targets"] == ["eng_crank_switch"]
+    assert repaired.metadata["final_action_plan"]["source"] == "final_evidence_consistency_validator"
     assert "vars.comm1_freq_134_000==true" not in repaired.message
     assert "134.000" in repaired.message
     assert "S10" in repaired.message
@@ -10169,6 +10246,7 @@ def test_live_help_fixture_310_does_not_fall_back_to_s10_when_next_overlay_fails
     assert repaired.metadata["diagnosis"]["step_id"] == "S12"
     assert repaired.metadata["next"]["step_id"] == "S12"
     assert repaired.metadata["rejected_missing_conditions"] == ["vars.engine_crank_left_complete==true"]
+    assert repaired.metadata["final_action_plan"]["source"] == "s10_left_engine_completion_guardrail"
     assert repaired.metadata["fallback_overlay_used"] is False
     assert repaired.metadata["s10_left_engine_completion_overlay_reason"] == "no_verifiable_evidence_ref"
     assert repaired.metadata["final_overlay_targets"] == []

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -3478,6 +3478,34 @@ def test_normalize_observable_text_only_response_rewrites_visual_analysis_unavai
         loop.close()
 
 
+def test_annotate_response_audit_metadata_sanitizes_public_predicates(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_public_predicate_sanitize.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+    )
+    try:
+        response = TutorResponse(
+            status="ok",
+            message="当前 S04 尚未完成，请先满足：vars.right_engine_nominal_start_params==true。",
+            explanations=["需要 vars.rpm_r>=25 后继续。"],
+            metadata={},
+        )
+
+        loop._annotate_response_audit_metadata(response)
+
+        assert "vars." not in response.message
+        assert all("vars." not in item for item in response.explanations)
+        assert "vars." not in response.metadata["final_public_response"]["message"]
+        assert all("vars." not in item for item in response.metadata["final_public_response"]["explanations"])
+    finally:
+        loop.close()
+
+
 def test_should_use_deterministic_overlay_fallback_for_observable_text_only_step(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_overlay_fallback_observable.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 19.5, apu_switch=0)])

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -9954,8 +9954,12 @@ def test_live_help_fixture_294_s09_comm1_complete_advances_to_s10() -> None:
     assert [action["target"] for action in repaired.actions] == ["eng_crank_switch"]
     assert repaired.metadata["diagnosis"]["step_id"] == "S10"
     assert repaired.metadata["next"]["step_id"] == "S10"
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["rejected_missing_conditions"] == ["vars.comm1_freq_134_000==true"]
     assert repaired.metadata["s09_comm1_completion_guardrail_applied"] is True
     assert repaired.metadata["final_overlay_targets"] == ["eng_crank_switch"]
+    assert "vars.comm1_freq_134_000==true" not in repaired.message
     assert "134.000" in repaired.message
     assert "S10" in repaired.message
 
@@ -10042,6 +10046,9 @@ def test_live_help_fixture_310_s10_left_engine_complete_advances_past_crank() ->
 
     assert repaired.metadata["diagnosis"]["step_id"] == "S12"
     assert repaired.metadata["next"]["step_id"] == "S12"
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["rejected_missing_conditions"] == ["vars.engine_crank_left_complete==true"]
     assert repaired.metadata["s10_left_engine_completion_guardrail_applied"] is True
     assert repaired.metadata["rejected_model_step_id"] == "S10"
     assert repaired.metadata["fallback_overlay_used"] is True
@@ -10050,6 +10057,7 @@ def test_live_help_fixture_310_s10_left_engine_complete_advances_past_crank() ->
     assert repaired.metadata["help_response"]["overlay"]["targets"] == ["ins_mode_knob"]
     assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "ins_mode_knob"
     assert [action["target"] for action in repaired.actions] == ["ins_mode_knob"]
+    assert "vars.engine_crank_left_complete==true" not in repaired.message
     assert "S10" not in repaired.message
     assert "S12" in repaired.message
 
@@ -10160,6 +10168,7 @@ def test_live_help_fixture_310_does_not_fall_back_to_s10_when_next_overlay_fails
     assert repaired.metadata["s10_left_engine_completion_guardrail_applied"] is True
     assert repaired.metadata["diagnosis"]["step_id"] == "S12"
     assert repaired.metadata["next"]["step_id"] == "S12"
+    assert repaired.metadata["rejected_missing_conditions"] == ["vars.engine_crank_left_complete==true"]
     assert repaired.metadata["fallback_overlay_used"] is False
     assert repaired.metadata["s10_left_engine_completion_overlay_reason"] == "no_verifiable_evidence_ref"
     assert repaired.metadata["final_overlay_targets"] == []

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -9916,6 +9916,20 @@ def _fixture_request_and_model_response(fixture: dict[str, Any]) -> tuple[TutorR
     return request, response
 
 
+def _public_response_text(response: TutorResponse) -> str:
+    final_public = response.metadata.get("final_public_response")
+    if not isinstance(final_public, dict):
+        return ""
+    parts: list[str] = []
+    message = final_public.get("message")
+    if isinstance(message, str):
+        parts.append(message)
+    explanations = final_public.get("explanations")
+    if isinstance(explanations, list):
+        parts.extend(item for item in explanations if isinstance(item, str))
+    return "\n".join(parts)
+
+
 def test_live_help_fixture_311_replays_real_s09_comm1_complete_fixture() -> None:
     fixture = _load_live_help_fixture(
         "artifacts/live_fixtures/168fc73d-f98c-498e-a35c-fef91b06ee2e.fixture.json"
@@ -9933,6 +9947,7 @@ def test_live_help_fixture_311_replays_real_s09_comm1_complete_fixture() -> None
     assert repaired.metadata["final_public_response"]["next"]["step_id"] == "S10"
     assert "ufc_comm1_channel_selector_pull" not in repaired.metadata["final_overlay_targets"]
     assert "vars.comm1_freq_134_000==true" not in repaired.message
+    assert "vars.comm1_freq_134_000==true" not in _public_response_text(repaired)
 
 
 def test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture() -> None:
@@ -9954,6 +9969,7 @@ def test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture() -
     }
     assert "eng_crank_switch" not in repaired.metadata["final_overlay_targets"]
     assert "vars.engine_crank_left_complete==true" not in repaired.message
+    assert "vars.engine_crank_left_complete==true" not in _public_response_text(repaired)
 
 
 def test_live_help_fixture_294_s09_comm1_complete_advances_to_s10() -> None:
@@ -10137,6 +10153,126 @@ def test_live_help_fixture_310_s10_left_engine_complete_advances_past_crank() ->
     assert "vars.engine_crank_left_complete==true" not in repaired.message
     assert "S10" not in repaired.message
     assert "S12" in repaired.message
+
+
+def test_final_evidence_validator_rechecks_repaired_fallback_step() -> None:
+    request = TutorRequest(
+        request_id="issue-311-final-fallback-recheck",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": True,
+                "right_engine_nominal_start_params": True,
+                "engine_crank_left": False,
+                "engine_crank_left_complete": True,
+                "rpm_l": 64,
+                "rpm_l_gte_60": True,
+                "left_engine_nominal_start_params": True,
+                "throttle_l_not_off": True,
+                "ins_mode": 2,
+                "ins_mode_set": True,
+                "ins_mode_cv_or_gnd": True,
+                "ins_fast_align_complete": True,
+                "radar_mode_opr": False,
+            },
+            "gates": {
+                "S10.completion": {
+                    "status": "blocked",
+                    "reason": "Left engine start must have begun.",
+                    "reason_code": "s10_requires_engine_crank_left_complete",
+                },
+                "S12.completion": {
+                    "status": "satisfied",
+                    "step_id": "S12",
+                    "gate_type": "completion",
+                },
+                "S13.completion": {
+                    "status": "blocked",
+                    "step_id": "S13",
+                    "gate_type": "completion",
+                    "reason": "Radar knob must be set to OPR.",
+                    "reason_code": "s13_requires_radar_mode_opr",
+                },
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S10",
+                "overlay_step_id": "S10",
+                "missing_conditions": ["vars.engine_crank_left_complete==true"],
+                "step_ui_targets": ["eng_crank_switch"],
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["eng_crank_switch", "ins_mode_knob", "radar_mode_knob"],
+            "rag_topk": [],
+            "vision_fact_summary": {"status": "vision_not_required", "seen_fact_ids": [], "fresh_fact_ids": []},
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="当前处于 S12 步骤。请将 INS 旋钮转到 CV 或 GND。",
+        actions=[
+            {
+                "type": "highlight",
+                "target": "ins_mode_knob",
+                "intent": "guide",
+                "evidence_refs": ["GATES.S12.completion"],
+            }
+        ],
+        explanations=["当前处于 S12 步骤。请将 INS 旋钮转到 CV 或 GND。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "repair",
+            "diagnosis": {"step_id": "S12", "error_category": "OM"},
+            "next": {"step_id": "S12"},
+            "harness_action_plan": {
+                "step_id": "S12",
+                "overlay_step_id": "S12",
+                "targets": ["ins_mode_knob"],
+                "text_only": False,
+                "source": "deterministic_step:S12",
+            },
+            "help_response": {
+                "diagnosis": {"step_id": "S12", "error_category": "OM"},
+                "next": {"step_id": "S12"},
+                "overlay": {
+                    "targets": ["ins_mode_knob"],
+                    "evidence": [
+                        {
+                            "target": "ins_mode_knob",
+                            "type": "gate",
+                            "ref": "GATES.S12.completion",
+                            "quote": "INS alignment must be complete.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["当前处于 S12 步骤。请将 INS 旋钮转到 CV 或 GND。"],
+            },
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-final-fallback-recheck",
+        rag_top_k=0,
+        lang="zh",
+    )
+    try:
+        used, reason = loop._enforce_final_evidence_consistency_after_repairs(response, request)
+    finally:
+        loop.close()
+
+    assert used is True
+    assert reason == "final_evidence_consistency_validator"
+    assert response.metadata["diagnosis"]["step_id"] == "S13"
+    assert response.metadata["next"]["step_id"] == "S13"
+    assert response.metadata["harness_action_plan"]["source"] == "final_evidence_consistency_validator"
+    assert response.metadata["harness_action_plan"]["targets"] == ["radar_mode_knob"]
+    assert [action["target"] for action in response.actions] == ["radar_mode_knob"]
+    assert "ins_mode_knob" not in [action["target"] for action in response.actions]
 
 
 def test_live_help_fixture_310_does_not_fall_back_to_s10_when_next_overlay_fails(

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -3430,8 +3430,9 @@ def test_normalize_observable_text_only_response_rewrites_bad_visual_excuse(tmp_
         loop._normalize_observable_text_only_response(response, request)
 
         assert response.metadata["observable_text_rewritten"] is True
-        assert response.message == "降级提示：你大概率卡在 S05，请先满足：vars.rpm_r>=25。"
-        assert response.explanations == ["降级提示：你大概率卡在 S05，请先满足：vars.rpm_r>=25。"]
+        assert response.message == "降级提示：你大概率卡在 S05，请先完成该步骤的未满足条件。"
+        assert response.explanations == ["降级提示：你大概率卡在 S05，请先完成该步骤的未满足条件。"]
+        assert "vars.rpm_r" not in response.message
     finally:
         loop.close()
 
@@ -3472,7 +3473,7 @@ def test_normalize_observable_text_only_response_rewrites_visual_analysis_unavai
         loop._normalize_observable_text_only_response(response, request)
 
         assert response.metadata["observable_text_rewritten"] is True
-        assert response.message == "降级提示：你大概率卡在 S08，请先满足：vision_facts.fcs_page_visible==seen。"
+        assert response.message == "降级提示：你大概率卡在 S08，请先完成该步骤的未满足条件。"
     finally:
         loop.close()
 
@@ -10181,11 +10182,6 @@ def test_final_evidence_validator_rechecks_repaired_fallback_step() -> None:
                     "reason": "Left engine start must have begun.",
                     "reason_code": "s10_requires_engine_crank_left_complete",
                 },
-                "S12.completion": {
-                    "status": "satisfied",
-                    "step_id": "S12",
-                    "gate_type": "completion",
-                },
                 "S13.completion": {
                     "status": "blocked",
                     "step_id": "S13",
@@ -10271,6 +10267,7 @@ def test_final_evidence_validator_rechecks_repaired_fallback_step() -> None:
     assert response.metadata["next"]["step_id"] == "S13"
     assert response.metadata["harness_action_plan"]["source"] == "final_evidence_consistency_validator"
     assert response.metadata["harness_action_plan"]["targets"] == ["radar_mode_knob"]
+    assert "completion_gate_already_satisfied:S12" in response.metadata["final_evidence_consistency_reasons"]
     assert [action["target"] for action in response.actions] == ["radar_mode_knob"]
     assert "ins_mode_knob" not in [action["target"] for action in response.actions]
 
@@ -11142,7 +11139,8 @@ def test_live_loop_clears_conflicting_overlay_before_fallback_rebuilds_current_s
     assert response.metadata["fallback_overlay_used"] is True
     assert response.actions
     assert response.actions[0]["target"] == "eng_crank_switch"
-    assert response.message == "S10 is not complete yet. Please operate eng_crank_switch first, then satisfy: vars.engine_crank_left_complete==true."
+    assert response.message == "S10 is not complete yet. Please operate eng_crank_switch first and confirm that step is complete."
+    assert "vars.engine_crank_left_complete" not in response.message
     assert response.metadata["final_public_response"]["actions"][0]["target"] == "eng_crank_switch"
 
 def test_build_vision_selection_uses_observation_time_for_audit_anchor(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a core final evidence consistency validator for accepted missing predicates
- record rejected missing conditions and validator metadata in live help repair paths
- cover S09/S10 live regressions plus a synthetic EvidencePacket contradiction test

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_live_dcs.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full