### PR TITLE
Add harness coverage matrix to replay eval

### DIFF
--- a/replay_eval/fa18c_startup_v04/suite.yaml
+++ b/replay_eval/fa18c_startup_v04/suite.yaml
@@ -35,7 +35,7 @@ coverage:
     test_id: tests/test_live_dcs.py::test_live_fixture_s18_bit_root_repairs_pb18_to_pb5
     reason: BIT-root visual sub-state repairs PB18 to PB5.
   - step_id: S21
-    state_category: recent_action_gate_conflict
+    state_category: stale_telemetry
     source: live_fixture_regression
     issue: 306
     fixture: artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json

--- a/replay_eval/fa18c_startup_v04/suite.yaml
+++ b/replay_eval/fa18c_startup_v04/suite.yaml
@@ -12,6 +12,42 @@ defaults:
   max_frames: 2
   vision_sync_window_ms: 100
   vision_trigger_wait_ms: 0
+coverage:
+  - step_id: S09
+    state_category: vlm_not_required
+    source: live_fixture_regression
+    issue: 294
+    fixture: artifacts/live_fixtures/8931fe82-2c72-4fbe-ab49-c78690820773.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_294_s09_uses_stage_action_hint_for_next_digit
+    reason: S09/S10 non-visual help must not be driven by stale S08 VLM evidence.
+  - step_id: S21
+    state_category: vlm_not_required
+    source: live_fixture_regression
+    issue: 298
+    fixture: artifacts/live_fixtures/c2849a41-0f9b-4440-b926-52a9695cd871.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_loop_ignores_stale_s19_visual_facts_for_s21
+    reason: S20/S21 four-down checks must ignore stale visual facts and skip VLM.
+  - step_id: S18
+    state_category: wrong_target_prevention
+    source: live_fixture_regression
+    issue: 300
+    fixture: artifacts/live_fixtures/644fac65-eb37-4de1-a591-fd1de392c647.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_fixture_s18_bit_root_repairs_pb18_to_pb5
+    reason: BIT-root visual sub-state repairs PB18 to PB5.
+  - step_id: S21
+    state_category: recent_action_gate_conflict
+    source: live_fixture_regression
+    issue: 306
+    fixture: artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json
+    test_id: tests/test_live_dcs.py::test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting
+    reason: Probe retracting motion must produce wait/no-highlight guidance instead of a raw missing predicate.
+  - step_id: S10
+    state_category: completion_already_true
+    source: live_fixture_regression
+    issue: 310
+    fixture: artifacts/live_fixtures/c3c775ce-7a4d-4e7f-a841-3a022528138e.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture
+    reason: Latest telemetry with engine_crank_left_complete=true must advance past S10.
 cases:
   - case_id: noop_2min
     input: cases/noop_2min/dcs_bios_raw.jsonl

--- a/replay_eval/fa18c_startup_v04/suite.yaml
+++ b/replay_eval/fa18c_startup_v04/suite.yaml
@@ -35,7 +35,7 @@ coverage:
     test_id: tests/test_live_dcs.py::test_live_fixture_s18_bit_root_repairs_pb18_to_pb5
     reason: BIT-root visual sub-state repairs PB18 to PB5.
   - step_id: S21
-    state_category: stale_telemetry
+    state_category: moving_settling_control
     source: live_fixture_regression
     issue: 306
     fixture: artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json

--- a/simtutor/replay_eval.py
+++ b/simtutor/replay_eval.py
@@ -781,6 +781,26 @@ def _new_coverage_cell(*, status: str = "missing", reason: str | None = None) ->
     return {"status": status, "sources": [], "reason": reason}
 
 
+def _mark_coverage_contract(
+    steps: dict[str, dict[str, dict[str, Any]]],
+    *,
+    step_id: str,
+    state_category: str,
+    source: Mapping[str, Any],
+) -> None:
+    row = steps.get(step_id)
+    if row is None or state_category not in row:
+        return
+    cell = row[state_category]
+    if cell["status"] in {"covered", "not_applicable"}:
+        return
+    cell["status"] = "contract_only"
+    cell["reason"] = None
+    source_dict = _coverage_source_dict(source)
+    if source_dict not in cell["sources"]:
+        cell["sources"].append(source_dict)
+
+
 def _add_coverage_source(
     steps: dict[str, dict[str, dict[str, Any]]],
     *,
@@ -792,6 +812,8 @@ def _add_coverage_source(
     if row is None or state_category not in row:
         return
     cell = row[state_category]
+    if cell["status"] == "not_applicable":
+        return
     cell["status"] = "covered"
     cell["reason"] = None
     source_dict = _coverage_source_dict(source)
@@ -816,37 +838,50 @@ def _mark_coverage_not_applicable(
     cell["reason"] = reason
 
 
-def _all_suite_coverage_tags(suite: ReplayEvalSuite) -> tuple[ReplayEvalCoverageTag, ...]:
+def _case_result_statuses(case_results: Sequence[Mapping[str, Any]] | None) -> dict[str, str]:
+    if case_results is None:
+        return {}
+    statuses: dict[str, str] = {}
+    for result in case_results:
+        case_id = result.get("case_id")
+        status = result.get("status")
+        if isinstance(case_id, str) and isinstance(status, str):
+            statuses[case_id] = status
+    return statuses
+
+
+def _all_suite_coverage_tags(
+    suite: ReplayEvalSuite,
+    *,
+    case_results: Sequence[Mapping[str, Any]] | None = None,
+) -> tuple[ReplayEvalCoverageTag, ...]:
+    case_statuses = _case_result_statuses(case_results)
     tags: list[ReplayEvalCoverageTag] = list(suite.coverage_tags)
     for case in suite.cases:
-        tags.extend(case.coverage_tags)
-        tags.append(
-            ReplayEvalCoverageTag(
-                step_id=case.expectation.step_id,
-                state_category="normal_progression",
-                source="replay_eval_case",
-                case_id=case.case_id,
-                reason="case asserts final harness outcome",
-            )
-        )
-        if case.expectation.vision_status == "vision_unavailable":
+        if case_statuses.get(case.case_id) == "passed":
+            tags.extend(case.coverage_tags)
             tags.append(
                 ReplayEvalCoverageTag(
                     step_id=case.expectation.step_id,
-                    state_category="vlm_unavailable",
+                    state_category="normal_progression",
                     source="replay_eval_case",
                     case_id=case.case_id,
-                    reason="case asserts vision unavailable outcome",
+                    reason="case passed final harness outcome assertions",
                 )
             )
     return tuple(tags)
 
 
-def _build_case_only_coverage_matrix(suite: ReplayEvalSuite, *, reason: str) -> dict[str, Any]:
+def _build_case_only_coverage_matrix(
+    suite: ReplayEvalSuite,
+    *,
+    reason: str,
+    case_results: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
     step_ids = sorted(
         {
             tag.step_id
-            for tag in _all_suite_coverage_tags(suite)
+            for tag in _all_suite_coverage_tags(suite, case_results=case_results)
             if isinstance(tag.step_id, str) and tag.step_id
         },
         key=lambda step_id: (int(step_id[1:]) if step_id.startswith("S") and step_id[1:].isdigit() else 10_000, step_id),
@@ -858,30 +893,57 @@ def _build_case_only_coverage_matrix(suite: ReplayEvalSuite, *, reason: str) -> 
         }
         for step_id in step_ids
     }
-    for tag in _all_suite_coverage_tags(suite):
+    for tag in _all_suite_coverage_tags(suite, case_results=case_results):
         _add_coverage_source(
             steps,
             step_id=tag.step_id,
             state_category=tag.state_category,
             source=_coverage_source_dict(tag),
         )
+    covered_count = sum(
+        1
+        for row in steps.values()
+        for cell in row.values()
+        if cell["status"] == "covered"
+    )
+    contract_only_count = sum(
+        1
+        for row in steps.values()
+        for cell in row.values()
+        if cell["status"] == "contract_only"
+    )
     return {
         "schema_version": "harness_coverage_matrix.v1",
         "step_count": len(step_ids),
         "state_categories": list(HARNESS_COVERAGE_STATE_CATEGORIES),
         "missing_cell_count": 0,
         "missing_cells": [],
+        "covered_cell_count": covered_count,
+        "contract_only_cell_count": contract_only_count,
+        "scenario_profiles": [suite.scenario_profile],
         "steps": steps,
     }
 
 
-def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
+def build_harness_coverage_matrix(
+    suite: ReplayEvalSuite,
+    *,
+    case_results: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
     if not suite.pack_path.exists():
         return _build_case_only_coverage_matrix(
             suite,
             reason=f"pack_path unavailable for spec-derived coverage: {suite.pack_path}",
+            case_results=case_results,
         )
-    step_specs = load_step_harness_specs(suite.pack_path, scenario_profile=suite.scenario_profile)
+    scenario_profiles = tuple(
+        sorted({suite.scenario_profile, *(case.scenario_profile for case in suite.cases)})
+    )
+    specs_by_profile = {
+        profile: load_step_harness_specs(suite.pack_path, scenario_profile=profile)
+        for profile in scenario_profiles
+    }
+    step_specs = specs_by_profile[suite.scenario_profile]
     ordered_step_ids = sorted(
         step_specs.keys(),
         key=lambda step_id: (int(step_id[1:]) if step_id.startswith("S") and step_id[1:].isdigit() else 10_000, step_id),
@@ -895,29 +957,38 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
     }
 
     for step_id in ordered_step_ids:
-        spec = step_specs[step_id]
-        _add_coverage_source(
+        specs_for_step = tuple(
+            profile_specs[step_id]
+            for profile_specs in specs_by_profile.values()
+            if step_id in profile_specs
+        )
+        has_completion_predicates = any(spec.completion_predicates for spec in specs_for_step)
+        has_telemetry_facts = any(spec.telemetry_facts for spec in specs_for_step)
+        has_recent_action_facts = any(spec.recent_action_facts for spec in specs_for_step)
+        has_allowed_overlay_targets = any(spec.allowed_overlay_targets for spec in specs_for_step)
+        visual_step = any(spec.requires_visual_confirmation or spec.vision_facts for spec in specs_for_step)
+        _mark_coverage_contract(
             steps,
             step_id=step_id,
             state_category="normal_progression",
             source={
                 "source": "coldstart_state_matrix",
                 "state_kind": "just_completed",
-                "reason": "synthetic replay input advances through this step",
+                "reason": "synthetic replay input exists; run the coldstart matrix test for executable coverage",
             },
         )
-        _add_coverage_source(
+        _mark_coverage_contract(
             steps,
             step_id=step_id,
             state_category="omission_missing_action",
             source={
                 "source": "coldstart_state_matrix",
                 "state_kind": "blocked",
-                "reason": "synthetic replay input leaves this step incomplete",
+                "reason": "synthetic replay input exists; run the coldstart matrix test for executable coverage",
             },
         )
-        if spec.completion_predicates:
-            _add_coverage_source(
+        if has_completion_predicates:
+            _mark_coverage_contract(
                 steps,
                 step_id=step_id,
                 state_category="completion_already_true",
@@ -934,8 +1005,8 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
                 reason="step has no declared completion predicate",
             )
 
-        if spec.telemetry_facts:
-            _add_coverage_source(
+        if has_telemetry_facts:
+            _mark_coverage_contract(
                 steps,
                 step_id=step_id,
                 state_category="stale_telemetry",
@@ -952,8 +1023,8 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
                 reason="step has no telemetry facts",
             )
 
-        if spec.recent_action_facts:
-            _add_coverage_source(
+        if has_recent_action_facts:
+            _mark_coverage_contract(
                 steps,
                 step_id=step_id,
                 state_category="recent_action_gate_conflict",
@@ -970,8 +1041,8 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
                 reason="step has no recent-action fact contract",
             )
 
-        if spec.allowed_overlay_targets:
-            _add_coverage_source(
+        if has_allowed_overlay_targets:
+            _mark_coverage_contract(
                 steps,
                 step_id=step_id,
                 state_category="wrong_target_prevention",
@@ -988,7 +1059,6 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
                 reason="step does not allow overlay targets",
             )
 
-        visual_step = bool(spec.requires_visual_confirmation or spec.vision_facts)
         if visual_step:
             _mark_coverage_not_applicable(
                 steps,
@@ -1001,7 +1071,7 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
                 ("vlm_unavailable", "vision_unavailable_fallback_contract"),
                 ("vlm_failed", "vision_failure_trace_contract"),
             ):
-                _add_coverage_source(
+                _mark_coverage_contract(
                     steps,
                     step_id=step_id,
                     state_category=category,
@@ -1011,7 +1081,7 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
                     },
                 )
         else:
-            _add_coverage_source(
+            _mark_coverage_contract(
                 steps,
                 step_id=step_id,
                 state_category="vlm_not_required",
@@ -1028,7 +1098,7 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
                     reason="step has no visual confirmation requirement",
                 )
 
-    for tag in _all_suite_coverage_tags(suite):
+    for tag in _all_suite_coverage_tags(suite, case_results=case_results):
         _add_coverage_source(
             steps,
             step_id=tag.step_id,
@@ -1042,12 +1112,27 @@ def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
         for category, cell in row.items()
         if cell["status"] == "missing"
     ]
+    covered_count = sum(
+        1
+        for row in steps.values()
+        for cell in row.values()
+        if cell["status"] == "covered"
+    )
+    contract_only_count = sum(
+        1
+        for row in steps.values()
+        for cell in row.values()
+        if cell["status"] == "contract_only"
+    )
     return {
         "schema_version": "harness_coverage_matrix.v1",
         "step_count": len(ordered_step_ids),
         "state_categories": list(HARNESS_COVERAGE_STATE_CATEGORIES),
         "missing_cell_count": len(missing_cells),
         "missing_cells": missing_cells,
+        "covered_cell_count": covered_count,
+        "contract_only_cell_count": contract_only_count,
+        "scenario_profiles": list(scenario_profiles),
         "steps": steps,
     }
 
@@ -1263,7 +1348,7 @@ def run_replay_eval_suite(
         "lang": suite.lang,
         "model_provider": provider_name,
         "summary": _build_summary(case_results),
-        "coverage_matrix": build_harness_coverage_matrix(suite),
+        "coverage_matrix": build_harness_coverage_matrix(suite, case_results=case_results),
         "cases": case_results,
     }
     if report_path is None:

--- a/simtutor/replay_eval.py
+++ b/simtutor/replay_eval.py
@@ -23,6 +23,7 @@ HARNESS_COVERAGE_STATE_CATEGORIES: tuple[str, ...] = (
     "omission_missing_action",
     "completion_already_true",
     "stale_telemetry",
+    "moving_settling_control",
     "recent_action_gate_conflict",
     "wrong_target_prevention",
     "vlm_not_required",
@@ -801,6 +802,27 @@ def _mark_coverage_contract(
         cell["sources"].append(source_dict)
 
 
+def _add_regression_reference(
+    steps: dict[str, dict[str, dict[str, Any]]],
+    *,
+    step_id: str,
+    state_category: str,
+    source: Mapping[str, Any],
+) -> None:
+    row = steps.get(step_id)
+    if row is None or state_category not in row:
+        return
+    cell = row[state_category]
+    if cell["status"] == "not_applicable":
+        return
+    if cell["status"] not in {"covered", "contract_only"}:
+        cell["status"] = "regression_reference"
+        cell["reason"] = None
+    source_dict = _coverage_source_dict(source)
+    if source_dict not in cell["sources"]:
+        cell["sources"].append(source_dict)
+
+
 def _add_coverage_source(
     steps: dict[str, dict[str, dict[str, Any]]],
     *,
@@ -856,7 +878,7 @@ def _all_suite_coverage_tags(
     case_results: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[ReplayEvalCoverageTag, ...]:
     case_statuses = _case_result_statuses(case_results)
-    tags: list[ReplayEvalCoverageTag] = list(suite.coverage_tags)
+    tags: list[ReplayEvalCoverageTag] = []
     for case in suite.cases:
         if case_statuses.get(case.case_id) == "passed":
             tags.extend(case.coverage_tags)
@@ -900,6 +922,13 @@ def _build_case_only_coverage_matrix(
             state_category=tag.state_category,
             source=_coverage_source_dict(tag),
         )
+    for tag in suite.coverage_tags:
+        _add_regression_reference(
+            steps,
+            step_id=tag.step_id,
+            state_category=tag.state_category,
+            source=_coverage_source_dict(tag),
+        )
     covered_count = sum(
         1
         for row in steps.values()
@@ -912,6 +941,12 @@ def _build_case_only_coverage_matrix(
         for cell in row.values()
         if cell["status"] == "contract_only"
     )
+    regression_reference_count = sum(
+        1
+        for row in steps.values()
+        for cell in row.values()
+        if cell["status"] == "regression_reference"
+    )
     return {
         "schema_version": "harness_coverage_matrix.v1",
         "step_count": len(step_ids),
@@ -920,6 +955,7 @@ def _build_case_only_coverage_matrix(
         "missing_cells": [],
         "covered_cell_count": covered_count,
         "contract_only_cell_count": contract_only_count,
+        "regression_reference_cell_count": regression_reference_count,
         "scenario_profiles": [suite.scenario_profile],
         "steps": steps,
     }
@@ -967,6 +1003,7 @@ def build_harness_coverage_matrix(
         has_recent_action_facts = any(spec.recent_action_facts for spec in specs_for_step)
         has_allowed_overlay_targets = any(spec.allowed_overlay_targets for spec in specs_for_step)
         visual_step = any(spec.requires_visual_confirmation or spec.vision_facts for spec in specs_for_step)
+        has_moving_settling_control = step_id in {"S20", "S21"}
         _mark_coverage_contract(
             steps,
             step_id=step_id,
@@ -1021,6 +1058,24 @@ def build_harness_coverage_matrix(
                 step_id=step_id,
                 state_category="stale_telemetry",
                 reason="step has no telemetry facts",
+            )
+
+        if has_moving_settling_control:
+            _mark_coverage_contract(
+                steps,
+                step_id=step_id,
+                state_category="moving_settling_control",
+                source={
+                    "source": "refuel_probe_motion_contract",
+                    "reason": "step can be in motion/settling while the refuel probe moves toward its threshold",
+                },
+            )
+        else:
+            _mark_coverage_not_applicable(
+                steps,
+                step_id=step_id,
+                state_category="moving_settling_control",
+                reason="step has no moving/settling control contract",
             )
 
         if has_recent_action_facts:
@@ -1105,6 +1160,13 @@ def build_harness_coverage_matrix(
             state_category=tag.state_category,
             source=_coverage_source_dict(tag),
         )
+    for tag in suite.coverage_tags:
+        _add_regression_reference(
+            steps,
+            step_id=tag.step_id,
+            state_category=tag.state_category,
+            source=_coverage_source_dict(tag),
+        )
 
     missing_cells = [
         {"step_id": step_id, "state_category": category}
@@ -1124,6 +1186,12 @@ def build_harness_coverage_matrix(
         for cell in row.values()
         if cell["status"] == "contract_only"
     )
+    regression_reference_count = sum(
+        1
+        for row in steps.values()
+        for cell in row.values()
+        if cell["status"] == "regression_reference"
+    )
     return {
         "schema_version": "harness_coverage_matrix.v1",
         "step_count": len(ordered_step_ids),
@@ -1132,6 +1200,7 @@ def build_harness_coverage_matrix(
         "missing_cells": missing_cells,
         "covered_cell_count": covered_count,
         "contract_only_cell_count": contract_only_count,
+        "regression_reference_cell_count": regression_reference_count,
         "scenario_profiles": list(scenario_profiles),
         "steps": steps,
     }

--- a/simtutor/replay_eval.py
+++ b/simtutor/replay_eval.py
@@ -11,10 +11,25 @@ from adapters.action_executor import OverlayActionExecutor
 from adapters.dcs.tutor_text import NoopTutorTextSender
 from adapters.evidence_refs import collect_evidence_refs_from_context, infer_evidence_type_from_ref
 from adapters.pack_gates import normalize_scenario_profile
+from adapters.step_harness_specs import load_step_harness_specs
 from adapters.vision_frames import DEFAULT_FRAME_CHANNEL, FrameDirectoryVisionPort
 from adapters.vision_prompting import DEFAULT_LAYOUT_ID
 from core.event_store import JsonlEventStore
 from core.types import TutorRequest, TutorResponse
+
+
+HARNESS_COVERAGE_STATE_CATEGORIES: tuple[str, ...] = (
+    "normal_progression",
+    "omission_missing_action",
+    "completion_already_true",
+    "stale_telemetry",
+    "recent_action_gate_conflict",
+    "wrong_target_prevention",
+    "vlm_not_required",
+    "vlm_required",
+    "vlm_unavailable",
+    "vlm_failed",
+)
 
 
 def _repo_root() -> Path:
@@ -75,6 +90,14 @@ def _normalize_string_list(raw: Any, *, field_name: str) -> tuple[str, ...]:
     return tuple(out)
 
 
+def _ensure_optional_positive_issue(raw: Any, *, field_name: str) -> int | None:
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        raise ValueError(f"{field_name} must be a positive integer when provided")
+    return raw
+
+
 def _extract_optional_bool(raw: Any) -> bool | None:
     if isinstance(raw, bool):
         return raw
@@ -96,6 +119,41 @@ def _ensure_scenario_profile(raw: Any, *, field_name: str) -> str:
         return normalize_scenario_profile(value)
     except ValueError as exc:
         raise ValueError(f"{field_name}: {exc}") from exc
+
+
+def _normalize_coverage_tags(
+    raw: Any,
+    *,
+    field_name: str,
+    default_case_id: str | None = None,
+) -> tuple[ReplayEvalCoverageTag, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"{field_name} must be a list")
+    tags: list[ReplayEvalCoverageTag] = []
+    for idx, item in enumerate(raw):
+        item_field = f"{field_name}[{idx}]"
+        if not isinstance(item, Mapping):
+            raise ValueError(f"{item_field} must be a mapping")
+        state_category = _ensure_text(item.get("state_category"), field_name=f"{item_field}.state_category")
+        if state_category not in HARNESS_COVERAGE_STATE_CATEGORIES:
+            allowed = ", ".join(HARNESS_COVERAGE_STATE_CATEGORIES)
+            raise ValueError(f"{item_field}.state_category must be one of {{{allowed}}}")
+        case_id = _extract_optional_text(item.get("case_id")) or default_case_id
+        tags.append(
+            ReplayEvalCoverageTag(
+                step_id=_ensure_text(item.get("step_id"), field_name=f"{item_field}.step_id"),
+                state_category=state_category,
+                source=_ensure_text(item.get("source"), field_name=f"{item_field}.source"),
+                case_id=case_id,
+                issue=_ensure_optional_positive_issue(item.get("issue"), field_name=f"{item_field}.issue"),
+                fixture=_extract_optional_text(item.get("fixture")),
+                test_id=_extract_optional_text(item.get("test_id")),
+                reason=_extract_optional_text(item.get("reason")),
+            )
+        )
+    return tuple(tags)
 
 
 @dataclass(frozen=True)
@@ -122,6 +180,18 @@ class ReplayEvalExpectation:
 
 
 @dataclass(frozen=True)
+class ReplayEvalCoverageTag:
+    step_id: str
+    state_category: str
+    source: str
+    case_id: str | None = None
+    issue: int | None = None
+    fixture: str | None = None
+    test_id: str | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
 class ReplayEvalCase:
     case_id: str
     input_path: Path
@@ -130,6 +200,7 @@ class ReplayEvalCase:
     max_frames: int
     expectation: ReplayEvalExpectation
     vision: ReplayEvalVisionConfig | None = None
+    coverage_tags: tuple[ReplayEvalCoverageTag, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -146,6 +217,7 @@ class ReplayEvalSuite:
     lang: str
     scenario_profile: str
     cases: tuple[ReplayEvalCase, ...]
+    coverage_tags: tuple[ReplayEvalCoverageTag, ...] = ()
 
 
 class ReplayEvalOracleModel:
@@ -284,6 +356,7 @@ def load_replay_eval_suite(path: str | Path) -> ReplayEvalSuite:
         raw.get("scenario_profile", defaults.get("scenario_profile", "airfield")),
         field_name="scenario_profile",
     )
+    suite_coverage_tags = _normalize_coverage_tags(raw.get("coverage"), field_name="suite.coverage")
 
     pack_path = _resolve_required_path(
         suite_dir=suite_dir,
@@ -438,6 +511,11 @@ def load_replay_eval_suite(path: str | Path) -> ReplayEvalSuite:
                 max_frames=max_frames,
                 expectation=expectation,
                 vision=vision_config,
+                coverage_tags=_normalize_coverage_tags(
+                    item.get("coverage"),
+                    field_name=f"{case_id}.coverage",
+                    default_case_id=case_id,
+                ),
             )
         )
 
@@ -454,6 +532,7 @@ def load_replay_eval_suite(path: str | Path) -> ReplayEvalSuite:
         lang=lang,
         scenario_profile=scenario_profile,
         cases=tuple(cases),
+        coverage_tags=suite_coverage_tags,
     )
 
 
@@ -683,6 +762,296 @@ def _build_summary(case_results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _coverage_source_dict(tag: ReplayEvalCoverageTag | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(tag, ReplayEvalCoverageTag):
+        raw: dict[str, Any] = {
+            "source": tag.source,
+            "case_id": tag.case_id,
+            "issue": tag.issue,
+            "fixture": tag.fixture,
+            "test_id": tag.test_id,
+            "reason": tag.reason,
+        }
+    else:
+        raw = dict(tag)
+    return {key: value for key, value in raw.items() if value is not None}
+
+
+def _new_coverage_cell(*, status: str = "missing", reason: str | None = None) -> dict[str, Any]:
+    return {"status": status, "sources": [], "reason": reason}
+
+
+def _add_coverage_source(
+    steps: dict[str, dict[str, dict[str, Any]]],
+    *,
+    step_id: str,
+    state_category: str,
+    source: Mapping[str, Any],
+) -> None:
+    row = steps.get(step_id)
+    if row is None or state_category not in row:
+        return
+    cell = row[state_category]
+    cell["status"] = "covered"
+    cell["reason"] = None
+    source_dict = _coverage_source_dict(source)
+    if source_dict not in cell["sources"]:
+        cell["sources"].append(source_dict)
+
+
+def _mark_coverage_not_applicable(
+    steps: dict[str, dict[str, dict[str, Any]]],
+    *,
+    step_id: str,
+    state_category: str,
+    reason: str,
+) -> None:
+    row = steps.get(step_id)
+    if row is None or state_category not in row:
+        return
+    cell = row[state_category]
+    if cell["status"] == "covered":
+        return
+    cell["status"] = "not_applicable"
+    cell["reason"] = reason
+
+
+def _all_suite_coverage_tags(suite: ReplayEvalSuite) -> tuple[ReplayEvalCoverageTag, ...]:
+    tags: list[ReplayEvalCoverageTag] = list(suite.coverage_tags)
+    for case in suite.cases:
+        tags.extend(case.coverage_tags)
+        tags.append(
+            ReplayEvalCoverageTag(
+                step_id=case.expectation.step_id,
+                state_category="normal_progression",
+                source="replay_eval_case",
+                case_id=case.case_id,
+                reason="case asserts final harness outcome",
+            )
+        )
+        if case.expectation.vision_status == "vision_unavailable":
+            tags.append(
+                ReplayEvalCoverageTag(
+                    step_id=case.expectation.step_id,
+                    state_category="vlm_unavailable",
+                    source="replay_eval_case",
+                    case_id=case.case_id,
+                    reason="case asserts vision unavailable outcome",
+                )
+            )
+    return tuple(tags)
+
+
+def _build_case_only_coverage_matrix(suite: ReplayEvalSuite, *, reason: str) -> dict[str, Any]:
+    step_ids = sorted(
+        {
+            tag.step_id
+            for tag in _all_suite_coverage_tags(suite)
+            if isinstance(tag.step_id, str) and tag.step_id
+        },
+        key=lambda step_id: (int(step_id[1:]) if step_id.startswith("S") and step_id[1:].isdigit() else 10_000, step_id),
+    )
+    steps = {
+        step_id: {
+            category: _new_coverage_cell(status="not_applicable", reason=reason)
+            for category in HARNESS_COVERAGE_STATE_CATEGORIES
+        }
+        for step_id in step_ids
+    }
+    for tag in _all_suite_coverage_tags(suite):
+        _add_coverage_source(
+            steps,
+            step_id=tag.step_id,
+            state_category=tag.state_category,
+            source=_coverage_source_dict(tag),
+        )
+    return {
+        "schema_version": "harness_coverage_matrix.v1",
+        "step_count": len(step_ids),
+        "state_categories": list(HARNESS_COVERAGE_STATE_CATEGORIES),
+        "missing_cell_count": 0,
+        "missing_cells": [],
+        "steps": steps,
+    }
+
+
+def build_harness_coverage_matrix(suite: ReplayEvalSuite) -> dict[str, Any]:
+    if not suite.pack_path.exists():
+        return _build_case_only_coverage_matrix(
+            suite,
+            reason=f"pack_path unavailable for spec-derived coverage: {suite.pack_path}",
+        )
+    step_specs = load_step_harness_specs(suite.pack_path, scenario_profile=suite.scenario_profile)
+    ordered_step_ids = sorted(
+        step_specs.keys(),
+        key=lambda step_id: (int(step_id[1:]) if step_id.startswith("S") and step_id[1:].isdigit() else 10_000, step_id),
+    )
+    steps: dict[str, dict[str, dict[str, Any]]] = {
+        step_id: {
+            category: _new_coverage_cell()
+            for category in HARNESS_COVERAGE_STATE_CATEGORIES
+        }
+        for step_id in ordered_step_ids
+    }
+
+    for step_id in ordered_step_ids:
+        spec = step_specs[step_id]
+        _add_coverage_source(
+            steps,
+            step_id=step_id,
+            state_category="normal_progression",
+            source={
+                "source": "coldstart_state_matrix",
+                "state_kind": "just_completed",
+                "reason": "synthetic replay input advances through this step",
+            },
+        )
+        _add_coverage_source(
+            steps,
+            step_id=step_id,
+            state_category="omission_missing_action",
+            source={
+                "source": "coldstart_state_matrix",
+                "state_kind": "blocked",
+                "reason": "synthetic replay input leaves this step incomplete",
+            },
+        )
+        if spec.completion_predicates:
+            _add_coverage_source(
+                steps,
+                step_id=step_id,
+                state_category="completion_already_true",
+                source={
+                    "source": "final_evidence_consistency_contract",
+                    "reason": "step declares completion predicates checked by final validator",
+                },
+            )
+        else:
+            _mark_coverage_not_applicable(
+                steps,
+                step_id=step_id,
+                state_category="completion_already_true",
+                reason="step has no declared completion predicate",
+            )
+
+        if spec.telemetry_facts:
+            _add_coverage_source(
+                steps,
+                step_id=step_id,
+                state_category="stale_telemetry",
+                source={
+                    "source": "state_harness_telemetry_contract",
+                    "reason": "step declares telemetry facts tracked in evidence packet",
+                },
+            )
+        else:
+            _mark_coverage_not_applicable(
+                steps,
+                step_id=step_id,
+                state_category="stale_telemetry",
+                reason="step has no telemetry facts",
+            )
+
+        if spec.recent_action_facts:
+            _add_coverage_source(
+                steps,
+                step_id=step_id,
+                state_category="recent_action_gate_conflict",
+                source={
+                    "source": "recent_action_fact_contract",
+                    "reason": "step declares recent action facts for gate conflict handling",
+                },
+            )
+        else:
+            _mark_coverage_not_applicable(
+                steps,
+                step_id=step_id,
+                state_category="recent_action_gate_conflict",
+                reason="step has no recent-action fact contract",
+            )
+
+        if spec.allowed_overlay_targets:
+            _add_coverage_source(
+                steps,
+                step_id=step_id,
+                state_category="wrong_target_prevention",
+                source={
+                    "source": "harness_action_planner_allowlist",
+                    "reason": "step declares allowed overlay targets enforced by action planner",
+                },
+            )
+        else:
+            _mark_coverage_not_applicable(
+                steps,
+                step_id=step_id,
+                state_category="wrong_target_prevention",
+                reason="step does not allow overlay targets",
+            )
+
+        visual_step = bool(spec.requires_visual_confirmation or spec.vision_facts)
+        if visual_step:
+            _mark_coverage_not_applicable(
+                steps,
+                step_id=step_id,
+                state_category="vlm_not_required",
+                reason="step requires visual confirmation or declares vision facts",
+            )
+            for category, source_name in (
+                ("vlm_required", "step_harness_visual_contract"),
+                ("vlm_unavailable", "vision_unavailable_fallback_contract"),
+                ("vlm_failed", "vision_failure_trace_contract"),
+            ):
+                _add_coverage_source(
+                    steps,
+                    step_id=step_id,
+                    state_category=category,
+                    source={
+                        "source": source_name,
+                        "reason": "visual step is covered by replay-eval VLM status contract",
+                    },
+                )
+        else:
+            _add_coverage_source(
+                steps,
+                step_id=step_id,
+                state_category="vlm_not_required",
+                source={
+                    "source": "step_harness_non_visual_contract",
+                    "reason": "step has no visual confirmation requirement",
+                },
+            )
+            for category in ("vlm_required", "vlm_unavailable", "vlm_failed"):
+                _mark_coverage_not_applicable(
+                    steps,
+                    step_id=step_id,
+                    state_category=category,
+                    reason="step has no visual confirmation requirement",
+                )
+
+    for tag in _all_suite_coverage_tags(suite):
+        _add_coverage_source(
+            steps,
+            step_id=tag.step_id,
+            state_category=tag.state_category,
+            source=_coverage_source_dict(tag),
+        )
+
+    missing_cells = [
+        {"step_id": step_id, "state_category": category}
+        for step_id, row in steps.items()
+        for category, cell in row.items()
+        if cell["status"] == "missing"
+    ]
+    return {
+        "schema_version": "harness_coverage_matrix.v1",
+        "step_count": len(ordered_step_ids),
+        "state_categories": list(HARNESS_COVERAGE_STATE_CATEGORIES),
+        "missing_cell_count": len(missing_cells),
+        "missing_cells": missing_cells,
+        "steps": steps,
+    }
+
+
 def _default_model_factory(case: ReplayEvalCase, *, lang: str) -> ReplayEvalOracleModel:
     return ReplayEvalOracleModel(case, lang=lang)
 
@@ -894,6 +1263,7 @@ def run_replay_eval_suite(
         "lang": suite.lang,
         "model_provider": provider_name,
         "summary": _build_summary(case_results),
+        "coverage_matrix": build_harness_coverage_matrix(suite),
         "cases": case_results,
     }
     if report_path is None:
@@ -909,11 +1279,14 @@ def run_replay_eval_suite(
 
 
 __all__ = [
+    "HARNESS_COVERAGE_STATE_CATEGORIES",
     "ReplayEvalCase",
+    "ReplayEvalCoverageTag",
     "ReplayEvalExpectation",
     "ReplayEvalOracleModel",
     "ReplayEvalSuite",
     "ReplayEvalVisionConfig",
+    "build_harness_coverage_matrix",
     "load_replay_eval_suite",
     "run_replay_eval_suite",
 ]

--- a/tests/test_replay_eval.py
+++ b/tests/test_replay_eval.py
@@ -73,6 +73,7 @@ def test_harness_coverage_matrix_marks_all_s01_s33_categories() -> None:
         "omission_missing_action",
         "completion_already_true",
         "stale_telemetry",
+        "moving_settling_control",
         "recent_action_gate_conflict",
         "wrong_target_prevention",
         "vlm_not_required",
@@ -84,10 +85,23 @@ def test_harness_coverage_matrix_marks_all_s01_s33_categories() -> None:
     for step_id, row in matrix["steps"].items():
         for category in matrix["state_categories"]:
             cell = row[category]
-            assert cell["status"] in {"covered", "contract_only", "not_applicable"}, (step_id, category, cell)
+            assert cell["status"] in {
+                "covered",
+                "contract_only",
+                "regression_reference",
+                "not_applicable",
+            }, (step_id, category, cell)
             assert cell["sources"] or cell["reason"], (step_id, category, cell)
     assert matrix["steps"]["S01"]["vlm_not_required"]["status"] == "contract_only"
     assert matrix["steps"]["S01"]["vlm_unavailable"]["status"] == "not_applicable"
+    assert matrix["steps"]["S21"]["moving_settling_control"]["status"] in {
+        "contract_only",
+        "regression_reference",
+    }
+
+    unexecuted_matrix = build_harness_coverage_matrix(suite, case_results=[])
+    assert unexecuted_matrix["covered_cell_count"] == 0
+    assert unexecuted_matrix["regression_reference_cell_count"] >= 0
 
 
 def test_replay_eval_report_includes_issue_312_fixture_regression_sources(tmp_path: Path) -> None:
@@ -109,6 +123,11 @@ def test_replay_eval_report_includes_issue_312_fixture_regression_sources(tmp_pa
     for issue in (294, 298, 300, 306, 310):
         assert all((REPO_ROOT / fixture).exists() for fixture in issue_sources[issue])
     assert matrix["steps"]["S01"]["vlm_unavailable"]["status"] == "not_applicable"
+    assert matrix["steps"]["S21"]["moving_settling_control"]["status"] == "contract_only"
+    assert any(
+        source.get("issue") == 306
+        for source in matrix["steps"]["S21"]["moving_settling_control"]["sources"]
+    )
 
 
 def test_run_replay_eval_suite_is_stable_across_repeated_runs(tmp_path: Path) -> None:

--- a/tests/test_replay_eval.py
+++ b/tests/test_replay_eval.py
@@ -15,6 +15,7 @@ from simtutor.replay_eval import (
     ReplayEvalOracleModel,
     ReplayEvalSuite,
     _extract_case_outcome,
+    build_harness_coverage_matrix,
     load_replay_eval_suite,
     run_replay_eval_suite,
 )
@@ -57,6 +58,53 @@ def test_run_replay_eval_suite_oracle_emits_fixed_summary(tmp_path: Path) -> Non
     assert summary["harness_trace_coverage"] == 1.0
     assert len(report["cases"]) == 5
     assert {case["status"] for case in report["cases"]}.issubset({"passed", "failed"})
+
+
+def test_harness_coverage_matrix_marks_all_s01_s33_categories() -> None:
+    suite = load_replay_eval_suite(SUITE_PATH)
+
+    matrix = build_harness_coverage_matrix(suite)
+
+    assert matrix["step_count"] == 33
+    assert matrix["missing_cell_count"] == 0
+    assert matrix["state_categories"] == [
+        "normal_progression",
+        "omission_missing_action",
+        "completion_already_true",
+        "stale_telemetry",
+        "recent_action_gate_conflict",
+        "wrong_target_prevention",
+        "vlm_not_required",
+        "vlm_required",
+        "vlm_unavailable",
+        "vlm_failed",
+    ]
+    assert sorted(matrix["steps"].keys()) == [f"S{i:02d}" for i in range(1, 34)]
+    for step_id, row in matrix["steps"].items():
+        for category in matrix["state_categories"]:
+            cell = row[category]
+            assert cell["status"] in {"covered", "not_applicable"}, (step_id, category, cell)
+            assert cell["sources"] or cell["reason"], (step_id, category, cell)
+
+
+def test_replay_eval_report_includes_issue_312_fixture_regression_sources(tmp_path: Path) -> None:
+    suite = load_replay_eval_suite(SUITE_PATH)
+
+    report = run_replay_eval_suite(suite, output_dir=tmp_path / "issue312")
+    matrix = report["coverage_matrix"]
+
+    issue_sources: dict[int, set[str]] = {}
+    for row in matrix["steps"].values():
+        for cell in row.values():
+            for source in cell.get("sources", []):
+                issue = source.get("issue")
+                fixture = source.get("fixture")
+                if isinstance(issue, int) and isinstance(fixture, str):
+                    issue_sources.setdefault(issue, set()).add(fixture)
+
+    assert set(issue_sources) >= {294, 298, 300, 306, 310}
+    for issue in (294, 298, 300, 306, 310):
+        assert all((REPO_ROOT / fixture).exists() for fixture in issue_sources[issue])
 
 
 def test_run_replay_eval_suite_is_stable_across_repeated_runs(tmp_path: Path) -> None:

--- a/tests/test_replay_eval.py
+++ b/tests/test_replay_eval.py
@@ -67,6 +67,7 @@ def test_harness_coverage_matrix_marks_all_s01_s33_categories() -> None:
 
     assert matrix["step_count"] == 33
     assert matrix["missing_cell_count"] == 0
+    assert matrix["contract_only_cell_count"] > 0
     assert matrix["state_categories"] == [
         "normal_progression",
         "omission_missing_action",
@@ -83,8 +84,10 @@ def test_harness_coverage_matrix_marks_all_s01_s33_categories() -> None:
     for step_id, row in matrix["steps"].items():
         for category in matrix["state_categories"]:
             cell = row[category]
-            assert cell["status"] in {"covered", "not_applicable"}, (step_id, category, cell)
+            assert cell["status"] in {"covered", "contract_only", "not_applicable"}, (step_id, category, cell)
             assert cell["sources"] or cell["reason"], (step_id, category, cell)
+    assert matrix["steps"]["S01"]["vlm_not_required"]["status"] == "contract_only"
+    assert matrix["steps"]["S01"]["vlm_unavailable"]["status"] == "not_applicable"
 
 
 def test_replay_eval_report_includes_issue_312_fixture_regression_sources(tmp_path: Path) -> None:
@@ -105,6 +108,7 @@ def test_replay_eval_report_includes_issue_312_fixture_regression_sources(tmp_pa
     assert set(issue_sources) >= {294, 298, 300, 306, 310}
     for issue in (294, 298, 300, 306, 310):
         assert all((REPO_ROOT / fixture).exists() for fixture in issue_sources[issue])
+    assert matrix["steps"]["S01"]["vlm_unavailable"]["status"] == "not_applicable"
 
 
 def test_run_replay_eval_suite_is_stable_across_repeated_runs(tmp_path: Path) -> None:
@@ -819,6 +823,7 @@ def test_run_replay_eval_suite_continues_after_case_error(tmp_path: Path) -> Non
     assert failed_case["error"]["stage"] == "execution"
     assert failed_case["error"]["type"] == "RuntimeError"
     assert failed_case["error"]["message"] == "synthetic case failure"
+    assert report["coverage_matrix"]["steps"]["S02"]["normal_progression"]["status"] != "covered"
     passed_case_ids = [case["case_id"] for case in report["cases"] if case["status"] == "passed"]
     assert "noop_2min" in passed_case_ids
     assert len(passed_case_ids) >= 1


### PR DESCRIPTION
## Summary
- add replay-eval coverage tags and a S01-S33 harness coverage matrix in the report
- derive baseline state category coverage from StepHarnessSpec without touching live_dcs
- record fixture-derived regression sources for #294, #298, #300, #306, and #310

## Tests
- python -m pytest -q tests/test_replay_eval.py
- python -m pytest -q tests/test_build_coldstart_state_matrix.py tests/integration/test_coldstart_help_loop.py
- python -m pytest -q tests/test_live_dcs.py::test_live_help_fixture_294_s09_uses_stage_action_hint_for_next_digit tests/test_live_dcs.py::test_live_loop_ignores_stale_s19_visual_facts_for_s21 tests/test_live_dcs.py::test_live_fixture_s18_bit_root_repairs_pb18_to_pb5 tests/test_live_dcs.py::test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting tests/test_live_dcs.py::test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture
- python -m pytest -q --capture=no