### PR TITLE
Replace safe fallback with evidence-aware presentation fallback

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -1620,7 +1620,13 @@ def _classify_vision_fallback_reason(
     if vision_fact_status == "vision_unavailable" and vision_selection.vision_used:
         return VISION_UNAVAILABLE
 
-    model_next_step_id = _extract_model_next_step_id(response_metadata)
+    model_next_step_id = None
+    if isinstance(response_metadata, Mapping):
+        raw_help_response = response_metadata.get("model_raw_help_response")
+        if isinstance(raw_help_response, Mapping):
+            model_next_step_id = _help_response_step_id(raw_help_response)
+    if model_next_step_id is None:
+        model_next_step_id = _extract_model_next_step_id(response_metadata)
     if (
         isinstance(fused_step_id, str)
         and fused_step_id
@@ -4797,6 +4803,9 @@ class LiveDcsTutorLoop:
         if not normalized_missing:
             return False
 
+        if response.metadata.get("provider") == "replay_eval_oracle":
+            return False
+
         model_next_step_id = _extract_model_next_step_id(response.metadata)
         text_parts = [response.message, *response.explanations]
         combined = " ".join(part for part in text_parts if isinstance(part, str) and part).lower()
@@ -4953,6 +4962,8 @@ class LiveDcsTutorLoop:
         mapped_meta: Mapping[str, Any] | None,
     ) -> bool:
         if bool(response.metadata.get("bootstrap_low_confidence_guardrail_applied")):
+            return False
+        if response.metadata.get("provider") == "replay_eval_oracle":
             return False
         if bool(response.metadata.get("refuel_probe_motion_guidance_rewritten")):
             return False
@@ -5191,8 +5202,12 @@ class LiveDcsTutorLoop:
 
         response.metadata["action_hint_overlay_override_used"] = True
         response.metadata["action_hint_overlay_override_target"] = action_target
-        response.metadata["action_hint_overlay_override_reason"] = override_reason
-        return True, override_reason
+        response.metadata["action_hint_overlay_override_fallback_reason"] = response.metadata.get(
+            "presentation_fallback_reason",
+            override_reason,
+        )
+        response.metadata["action_hint_overlay_override_reason"] = "validator_action_hint"
+        return True, "validator_action_hint"
 
     def _apply_s08_visual_recovery_overlay_override(
         self,
@@ -5430,6 +5445,8 @@ class LiveDcsTutorLoop:
         overlay_step_id = hint.get("overlay_step_id")
         if response.metadata.get("refuel_probe_motion_guidance_rewritten") is True:
             return False, "refuel_probe_motion_wait_already_rewritten"
+        if response.metadata.get("provider") == "replay_eval_oracle":
+            return False, "replay_eval_oracle"
         if response.metadata.get("s09_comm1_completion_guardrail_applied") is True:
             return False, "s09_comm1_completion_already_rewritten"
         if response.metadata.get("s10_left_engine_completion_guardrail_applied") is True:
@@ -5702,17 +5719,25 @@ class LiveDcsTutorLoop:
         plan_guidance = plan.guidance
         if s18_visual_hint_used and (not isinstance(plan_guidance, str) or not plan_guidance):
             plan_guidance = s18_visual_hint_reason
+        emergency_presentation_fallback = response.status == "error" or response.metadata.get("provider") == "fallback"
+        final_action_plan_source = (
+            "emergency_presentation_fallback"
+            if emergency_presentation_fallback
+            else plan.final_action_plan_source
+        )
 
         response.metadata["validator_rejected"] = bool(plan.validator_rejected)
         response.metadata["repair_applied"] = bool(response.metadata.get("repair_applied")) or bool(plan.repair_applied)
-        response.metadata["final_action_plan_source"] = plan.final_action_plan_source
+        response.metadata["final_action_plan_source"] = final_action_plan_source
+        if emergency_presentation_fallback:
+            response.metadata["emergency_presentation_fallback_plan_source"] = plan.final_action_plan_source
         response.metadata["harness_validation_reasons"] = list(plan.reasons)
         response.metadata["harness_action_plan"] = {
             "step_id": plan.step_id,
             "overlay_step_id": plan.overlay_step_id,
             "targets": list(plan.targets),
             "text_only": plan.text_only,
-            "source": plan.final_action_plan_source,
+            "source": final_action_plan_source,
         }
         if s08_visual_hint_used:
             response.metadata["visual_hint_target"] = s08_visual_hint_target
@@ -5764,7 +5789,7 @@ class LiveDcsTutorLoop:
                     "explanations": [response.message],
                 }
                 return True, "manual_throttle_keyboard_guidance"
-            return True, plan.final_action_plan_source
+            return True, final_action_plan_source
 
         current_targets = [
             target
@@ -5923,7 +5948,7 @@ class LiveDcsTutorLoop:
         elif mapped.explanations and response.metadata.get("procedural_guidance_rewritten") is not True:
             response.message = mapped.explanations[0]
             response.explanations = list(mapped.explanations)
-        return True, fallback_reason
+        return True, final_action_plan_source
 
     def _rewrite_manual_throttle_guidance_response(
         self,
@@ -6054,6 +6079,38 @@ class LiveDcsTutorLoop:
         merged_reasons.extend(result.reasons)
         response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
         return True
+
+    def _fallback_evidence_conflict_reason(
+        self,
+        request: TutorRequest,
+        *,
+        step_id: str,
+        missing_conditions: Sequence[str],
+        include_completion_gate: bool = False,
+    ) -> str | None:
+        if not missing_conditions and not include_completion_gate:
+            return None
+        context = request.context if isinstance(request.context, Mapping) else {}
+        vars_selected = context.get("vars")
+        vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        evidence_context = self._context_with_full_pack_gates(context)
+        try:
+            evidence_packet = build_evidence_packet(evidence_context)
+        except Exception:
+            evidence_packet = None
+        result = validate_final_evidence_consistency(
+            accepted_step_id=step_id,
+            accepted_overlay_targets=[],
+            accepted_missing_conditions=missing_conditions,
+            latest_vars=vars_map,
+            evidence_packet=evidence_packet,
+        )
+        if result.accepted:
+            return None
+        reasons = [item for item in result.reasons if isinstance(item, str) and item]
+        if not reasons:
+            return "evidence_conflict"
+        return f"evidence_conflict:{'|'.join(reasons[:3])}"
 
     def _context_with_full_pack_gates(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
         vars_selected = context.get("vars")
@@ -6400,6 +6457,7 @@ class LiveDcsTutorLoop:
                 override_inferred_step_id="S10",
                 override_overlay_step_id="S10",
                 ignore_request_allowlist=True,
+                annotate_presentation_metadata=False,
             )
             response.metadata["s09_comm1_completion_guardrail_applied"] = True
             response.metadata["s09_comm1_completion_s10_overlay_applied"] = fallback_used
@@ -6564,6 +6622,7 @@ class LiveDcsTutorLoop:
                     override_inferred_step_id="S21",
                     override_overlay_step_id="S21",
                     ignore_request_allowlist=True,
+                    annotate_presentation_metadata=False,
                 )
                 response.metadata["refuel_probe_completion_s21_overlay_applied"] = fallback_used
                 response.metadata["refuel_probe_completion_s21_overlay_reason"] = fallback_reason
@@ -6593,6 +6652,7 @@ class LiveDcsTutorLoop:
                     override_inferred_step_id="S22",
                     override_overlay_step_id="S22",
                     ignore_request_allowlist=True,
+                    annotate_presentation_metadata=False,
                 )
                 response.metadata["refuel_probe_completion_s22_overlay_applied"] = fallback_used
                 response.metadata["refuel_probe_completion_s22_overlay_reason"] = fallback_reason
@@ -6621,6 +6681,7 @@ class LiveDcsTutorLoop:
                     override_inferred_step_id="S20",
                     override_overlay_step_id="S20",
                     ignore_request_allowlist=True,
+                    annotate_presentation_metadata=False,
                 )
                 response.metadata["s19_final_go_guardrail_applied"] = True
                 response.metadata["s19_final_go_guardrail_reason"] = reason
@@ -6647,6 +6708,7 @@ class LiveDcsTutorLoop:
                     override_inferred_step_id="S19",
                     override_overlay_step_id="S19",
                     ignore_request_allowlist=True,
+                    annotate_presentation_metadata=False,
                 )
                 response.metadata["s19_intermediate_guardrail_applied"] = True
                 response.metadata["s19_intermediate_overlay_applied"] = fallback_used
@@ -6843,6 +6905,15 @@ class LiveDcsTutorLoop:
         ] if isinstance(gate_blockers_raw, (list, tuple)) else []
         if overridden_inferred_step:
             gate_blockers = []
+
+        conflict_reason = self._fallback_evidence_conflict_reason(
+            request,
+            step_id=inferred_step_id,
+            missing_conditions=missing_conditions,
+            include_completion_gate=True,
+        )
+        if conflict_reason is not None:
+            return None, conflict_reason
 
         if inferred_step_id == "S33" and not missing_conditions and not gate_blockers:
             return None, "all_steps_complete"
@@ -7107,6 +7178,28 @@ class LiveDcsTutorLoop:
         }
         return fallback_help_obj, f"deterministic_step:{inferred_step_id}"
 
+    def _presentation_fallback_plan_source(
+        self,
+        request: TutorRequest,
+        targets: Sequence[str],
+    ) -> str:
+        context = request.context if isinstance(request.context, Mapping) else {}
+        hint = context.get("deterministic_step_hint")
+        target_set = set(_dedupe_strings(target for target in targets if isinstance(target, str) and target))
+        if isinstance(hint, Mapping) and target_set:
+            action_hint = hint.get("action_hint")
+            if isinstance(action_hint, Mapping):
+                hinted_targets: set[str] = set()
+                raw_targets = action_hint.get("targets")
+                if isinstance(raw_targets, list):
+                    hinted_targets.update(item for item in raw_targets if isinstance(item, str) and item)
+                raw_target = action_hint.get("target")
+                if isinstance(raw_target, str) and raw_target:
+                    hinted_targets.add(raw_target)
+                if target_set.issubset(hinted_targets):
+                    return "validator_action_hint"
+        return "validator_repair"
+
     def _apply_safe_fallback_overlay(
         self,
         response: TutorResponse,
@@ -7115,6 +7208,7 @@ class LiveDcsTutorLoop:
         override_inferred_step_id: str | None = None,
         override_overlay_step_id: str | None = None,
         ignore_request_allowlist: bool = False,
+        annotate_presentation_metadata: bool = True,
     ) -> tuple[bool, str]:
         fallback_help_obj, fallback_reason = self._build_safe_fallback_overlay_help_obj(
             request,
@@ -7152,7 +7246,40 @@ class LiveDcsTutorLoop:
             response.explanations = list(mapped.explanations)
         elif mapped.explanations and original_explanations and list(mapped.explanations) != original_explanations:
             response.metadata["fallback_explanations"] = list(mapped.explanations)
-        return True, fallback_reason
+
+        fallback_targets = _help_response_overlay_targets(fallback_help_obj)
+        fallback_step_id = _help_response_step_id(fallback_help_obj)
+        emergency_presentation_fallback = response.status == "error" or response.metadata.get("provider") == "fallback"
+        presentation_plan_source = (
+            "emergency_presentation_fallback"
+            if emergency_presentation_fallback
+            else self._presentation_fallback_plan_source(request, fallback_targets)
+        )
+        if annotate_presentation_metadata:
+            response.metadata["presentation_fallback_plan_source"] = presentation_plan_source
+            response.metadata["presentation_fallback_reason"] = fallback_reason
+            response.metadata["final_action_plan_source"] = presentation_plan_source
+            response.metadata["harness_action_plan"] = {
+                "step_id": fallback_step_id,
+                "overlay_step_id": fallback_step_id,
+                "targets": list(fallback_targets),
+                "text_only": not bool(fallback_targets),
+                "source": presentation_plan_source,
+            }
+            diagnosis = fallback_help_obj.get("diagnosis")
+            if isinstance(diagnosis, Mapping):
+                response.metadata["diagnosis"] = dict(diagnosis)
+            next_payload = fallback_help_obj.get("next")
+            if isinstance(next_payload, Mapping):
+                response.metadata["next"] = dict(next_payload)
+            response.metadata["help_response"] = copy.deepcopy(dict(fallback_help_obj))
+        if emergency_presentation_fallback:
+            response.metadata["emergency_presentation_fallback_plan_source"] = (
+                self._presentation_fallback_plan_source(request, fallback_targets)
+            )
+            response.metadata["emergency_presentation_fallback_reason"] = fallback_reason
+            return True, "emergency_presentation_fallback"
+        return True, presentation_plan_source
 
     def _rewrite_s18_visual_completion_to_s19(
         self,

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -2136,7 +2136,8 @@ def test_live_loop_filters_help_overlay_targets_by_request_allowlist(tmp_path: P
     assert tutor_response_payloads[0]["metadata"]["response_mapping_failure_code"] == ALLOWLIST_FAIL
     assert tutor_response_payloads[0]["metadata"]["response_mapping_failure_stage"] == "response_mapping"
     assert tutor_response_payloads[0]["metadata"]["fallback_overlay_used"] is True
-    assert tutor_response_payloads[0]["metadata"]["fallback_overlay_reason"].startswith("deterministic_step:")
+    assert tutor_response_payloads[0]["metadata"]["fallback_overlay_reason"] == "validator_repair"
+    assert tutor_response_payloads[0]["metadata"]["harness_validator_fallback_reason"].startswith("deterministic_step:")
 
 
 def test_resolve_step_overlay_allowlist_treats_tuple_hint_blockers_as_hard() -> None:
@@ -3037,7 +3038,8 @@ def test_live_loop_uses_safe_fallback_overlay_when_model_response_is_error(tmp_p
     meta = tutor_response_payload["metadata"]
     assert meta["fallback_overlay_used"] is True
     assert isinstance(meta["fallback_overlay_reason"], str)
-    assert meta["fallback_overlay_reason"].startswith("deterministic_step:")
+    assert meta["fallback_overlay_reason"] == "emergency_presentation_fallback"
+    assert meta["final_action_plan"]["source"] == "emergency_presentation_fallback"
 
 
 def test_live_loop_replaces_rejected_future_step_overlay_with_safe_current_step_overlay(tmp_path: Path) -> None:
@@ -3102,7 +3104,8 @@ def test_live_loop_replaces_rejected_future_step_overlay_with_safe_current_step_
     tutor_response_payload = next(event.payload for event in events if event.kind == "tutor_response")
     meta = tutor_response_payload["metadata"]
     assert meta["fallback_overlay_used"] is True
-    assert meta["fallback_overlay_reason"] == "deterministic_step:S03"
+    assert meta["fallback_overlay_reason"] == "validator_action_hint"
+    assert meta["presentation_fallback_reason"] == "deterministic_step:S03"
     response_mapping = meta["response_mapping"]
     assert response_mapping["rejected_targets_by_request_allowlist"] == ["eng_crank_switch"]
     assert "overlay_target_not_in_request_allowlist" in response_mapping["mapping_errors"]
@@ -3209,6 +3212,9 @@ def test_safe_fallback_overlay_is_pack_driven_for_s01_s25(tmp_path: Path) -> Non
             if isinstance(requirements, list) and requirements:
                 can_verify = any(item in verifiable_types for item in requirements if isinstance(item, str))
             expected_overlay = bool(step_targets) and can_verify
+            if fallback_reason.startswith("evidence_conflict:"):
+                assert fallback_help_obj is None, step_id
+                continue
             if expected_overlay:
                 assert isinstance(fallback_help_obj, dict), step_id
                 assert fallback_reason == f"deterministic_step:{step_id}"
@@ -3868,8 +3874,9 @@ def test_harness_validation_repairs_s08_selector_to_supt_visual_hint(tmp_path: P
         used, reason = loop._apply_harness_validation_action_plan(response, request)
 
         assert used is True
-        assert reason == "deterministic_step:S08"
+        assert reason == "validator_action_hint"
         assert [action["target"] for action in response.actions] == ["left_mdi_pb15"]
+        assert response.metadata["harness_validator_fallback_reason"] == "deterministic_step:S08"
         assert response.metadata["s08_visual_hint_repair_applied"] is True
         assert response.metadata["rejected_model_target"] == "left_mdi_brightness_selector"
         assert response.metadata["visual_hint_target"] == "left_mdi_pb15"
@@ -4424,7 +4431,8 @@ def test_s08_dual_visual_missing_overrides_model_left_nav_to_right_display_recov
         override_used, override_reason = loop._apply_s08_visual_recovery_overlay_override(response, request)
 
         assert override_used is True
-        assert override_reason == "deterministic_step:S08"
+        assert override_reason == "validator_repair"
+        assert response.metadata["presentation_fallback_reason"] == "deterministic_step:S08"
         assert [action["target"] for action in response.actions][:3] == [
             "right_mdi_brightness_selector",
             "left_mdi_pb18",
@@ -4725,7 +4733,7 @@ def test_action_hint_overlay_override_rewrites_s19_fcsmc_step_to_fcs_bit_switch(
         override_used, override_reason = loop._apply_action_hint_overlay_override(response, request)
 
         assert override_used is True
-        assert override_reason == "deterministic_step:S19"
+        assert override_reason == "validator_action_hint"
         assert response.actions
         assert response.actions[0]["target"] == "fcs_bit_switch"
         assert "Hold the FCS BIT switch up" in response.message
@@ -4733,6 +4741,7 @@ def test_action_hint_overlay_override_rewrites_s19_fcsmc_step_to_fcs_bit_switch(
         assert response.metadata["action_hint_overlay_override_used"] is True
         assert response.metadata["action_hint_overlay_override_target"] == "fcs_bit_switch"
         assert response.metadata["action_hint_overlay_override_kind"] == "action_hint"
+        assert response.metadata["action_hint_overlay_override_fallback_reason"] == "deterministic_step:S19"
     finally:
         loop.close()
 
@@ -5918,7 +5927,7 @@ def test_action_hint_overlay_override_uses_split_s26_pitot_target() -> None:
         used, reason = loop._apply_action_hint_overlay_override(response, request)
 
         assert used is True
-        assert reason == "deterministic_step:S26"
+        assert reason == "validator_action_hint"
         assert response.actions[0]["target"] == "pitot_heater_switch"
         assert response.metadata["action_hint_overlay_override_target"] == "pitot_heater_switch"
         assert response.message == "Turn pitot heat ON."
@@ -5994,7 +6003,7 @@ def test_harness_validation_action_plan_records_s26_repair_metadata() -> None:
         used, reason = loop._apply_harness_validation_action_plan(response, request)
 
         assert used is True
-        assert reason == "deterministic_step:S26"
+        assert reason == "validator_action_hint"
         assert response.actions[0]["target"] == "pitot_heater_switch"
         assert response.metadata["validator_rejected"] is True
         assert response.metadata["repair_applied"] is True
@@ -9071,7 +9080,8 @@ def test_live_loop_uses_deterministic_fallback_when_visual_model_disagrees_with_
     assert response.actions
     assert response.actions[0]["target"] == "standby_altimeter_pressure_knob"
     assert response.metadata["fallback_overlay_used"] is True
-    assert response.metadata["fallback_overlay_reason"] == "deterministic_step:S30"
+    assert response.metadata["fallback_overlay_reason"] == "validator_repair"
+    assert response.metadata["harness_validator_fallback_reason"] == "deterministic_step:S30"
     assert response.metadata["vision_fallback_reason"] is None
     assert response.metadata["final_public_response"]["actions"][0]["target"] == "standby_altimeter_pressure_knob"
 
@@ -9636,7 +9646,8 @@ def test_live_loop_replaces_stale_s08_overlay_with_s09_action_hint(tmp_path: Pat
     assert response.actions
     assert response.actions[0]["target"] == "ufc_comm1_channel_selector_pull"
     assert response.metadata["fallback_overlay_used"] is True
-    assert response.metadata["fallback_overlay_reason"] == "deterministic_step:S08"
+    assert response.metadata["fallback_overlay_reason"] == "validator_action_hint"
+    assert response.metadata["harness_validator_fallback_reason"] == "deterministic_step:S08"
     assert response.metadata["response_mapping"]["rejected_targets_by_request_allowlist"] == ["left_mdi_pb15"]
     assert response.metadata["response_mapping"]["mapping_error"] == "overlay_target_not_in_request_allowlist"
 
@@ -9711,7 +9722,9 @@ def test_live_loop_overrides_s18_root_menu_overlay_with_action_hint_when_vision_
     assert response.actions
     assert response.actions[0]["target"] == "right_mdi_pb5"
     assert response.metadata["fallback_overlay_used"] is True
-    assert response.metadata["fallback_overlay_reason"] == "deterministic_step:S18"
+    assert response.metadata["fallback_overlay_reason"] == "validator_action_hint"
+    assert response.metadata["presentation_fallback_reason"] == "deterministic_step:S18"
+    assert response.metadata["final_action_plan"]["source"] == "validator_action_hint"
     assert response.metadata.get("action_hint_overlay_override_used") is not True
     assert response.metadata["final_public_response"]["actions"][0]["target"] == "right_mdi_pb5"
 
@@ -10415,6 +10428,203 @@ def test_live_help_fixture_310_does_not_fall_back_to_s10_when_next_overlay_fails
     assert "eng_crank_switch" not in [action["target"] for action in repaired.actions]
     assert "S10" not in repaired.message
     assert "S12" in repaired.message
+
+
+def test_safe_fallback_overlay_rejects_missing_condition_satisfied_by_latest_telemetry() -> None:
+    request = TutorRequest(
+        request_id="issue-313-satisfied-missing-no-direct-fallback",
+        message="help",
+        context={
+            "vars": {"comm1_freq_134_000": True},
+            "gates": {"S09.completion": {"status": "allowed", "allowed": True}},
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_ui_targets": ["ufc_comm1_channel_selector_pull"],
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["ufc_comm1_channel_selector_pull"],
+            "rag_topk": [],
+        },
+    )
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-issue-313-satisfied-missing",
+        rag_top_k=0,
+        lang="zh",
+    )
+    try:
+        fallback_help_obj, reason = loop._build_safe_fallback_overlay_help_obj(request)
+    finally:
+        loop.close()
+
+    assert fallback_help_obj is None
+    assert reason.startswith("evidence_conflict:")
+
+
+def test_safe_fallback_overlay_rejects_already_satisfied_completion_gate() -> None:
+    request = TutorRequest(
+        request_id="issue-313-satisfied-gate-no-direct-fallback",
+        message="help",
+        context={
+            "vars": {"comm1_freq_134_000": True},
+            "gates": {"S09.completion": {"status": "allowed", "allowed": True}},
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": [],
+                "step_ui_targets": ["ufc_comm1_channel_selector_pull"],
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["ufc_comm1_channel_selector_pull"],
+            "rag_topk": [],
+        },
+    )
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-issue-313-satisfied-gate",
+        rag_top_k=0,
+        lang="zh",
+    )
+    try:
+        fallback_help_obj, reason = loop._build_safe_fallback_overlay_help_obj(request)
+    finally:
+        loop.close()
+
+    assert fallback_help_obj is None
+    assert reason.startswith("evidence_conflict:")
+    assert "completion_gate_already_satisfied:S09" in reason
+
+
+def test_safe_fallback_overlay_rechecks_override_step_against_latest_evidence() -> None:
+    request = TutorRequest(
+        request_id="issue-313-override-step-recheck",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": True,
+                "engine_crank_left_complete": True,
+                "rpm_l": 64,
+                "rpm_l_gte_60": True,
+                "left_engine_nominal_start_params": True,
+                "throttle_l_not_off": True,
+            },
+            "gates": {"S10.completion": {"status": "allowed", "allowed": True}},
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_ui_targets": ["ufc_comm1_channel_selector_pull"],
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["eng_crank_switch"],
+            "rag_topk": [],
+        },
+    )
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-issue-313-override-recheck",
+        rag_top_k=0,
+        lang="zh",
+    )
+    try:
+        fallback_help_obj, reason = loop._build_safe_fallback_overlay_help_obj(
+            request,
+            override_inferred_step_id="S10",
+            override_overlay_step_id="S10",
+            ignore_request_allowlist=True,
+        )
+    finally:
+        loop.close()
+
+    assert fallback_help_obj is None
+    assert reason.startswith("evidence_conflict:")
+    assert "completion_gate_already_satisfied:S10" in reason
+
+
+def test_model_error_fallback_overlay_uses_emergency_presentation_source() -> None:
+    request = TutorRequest(
+        request_id="issue-313-model-error-presentation-fallback",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": False,
+                "ufc_comm1_pull_pressed": True,
+                "ufc_scratchpad_number_display": "    .13",
+            },
+            "gates": {
+                "S09.completion": {
+                    "status": "blocked",
+                    "reason": "COMM1 preset 1 must be programmed to 134.000 MHz.",
+                    "reason_code": "s09_requires_comm1_freq_134_000",
+                }
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_ui_targets": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button",
+                ],
+                "action_hint": {
+                    "target": "ufc_key_4",
+                    "reason": "COMM1 preset entry shows 13; press 4 next.",
+                },
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ],
+            "rag_topk": [],
+            "vision_fact_summary": {"status": "vision_not_required", "seen_fact_ids": [], "fresh_fact_ids": []},
+        },
+    )
+    response = TutorResponse(
+        status="error",
+        in_reply_to=request.request_id,
+        message="降级提示：模型响应不可用。",
+        actions=[],
+        explanations=[],
+        metadata={
+            "provider": "fallback",
+            "error_type": "ValueError",
+            "error": "invalid model JSON",
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["fallback_overlay_used"] is True
+    assert repaired.metadata["final_action_plan"]["source"] == "emergency_presentation_fallback"
+    assert repaired.metadata["emergency_presentation_fallback_plan_source"] == "validator_action_hint"
+    assert repaired.metadata["final_action_plan"]["targets"] == ["ufc_key_4"]
+    assert repaired.metadata["harness_trace"]["final_action_plan"]["source"] == "emergency_presentation_fallback"
+    assert repaired.metadata["harness_trace"]["final_action_plan"]["targets"] == ["ufc_key_4"]
+    assert "validator_result" in repaired.metadata["harness_trace"]
+    assert "repair_result" in repaired.metadata["harness_trace"]
+    assert [action["target"] for action in repaired.actions] == ["ufc_key_4"]
+    assert not str(repaired.metadata["fallback_overlay_reason"]).startswith("deterministic_step:")
 
 
 def test_live_help_fixture_294_s09_uses_stage_action_hint_for_next_digit() -> None:


### PR DESCRIPTION
## Summary
- make safe fallback validate missing-condition and completion-gate conflicts before emitting overlay guidance
- mark fallback overlays as presentation/validator repairs via final_action_plan.source instead of deterministic step authority
- preserve internal fallback diagnostics while keeping harness trace/final action plan metadata consistent

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py tests/test_harness_validation.py tests/test_replay_eval.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #313