### PR TITLE
Add state-aware harness action planner

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -72,6 +72,15 @@ class EvidenceConsistencyResult:
     reasons: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class _StateActionPlan:
+    targets: tuple[str, ...]
+    guidance: str | None
+    text_only: bool
+    source: str
+    reasons: tuple[str, ...] = ()
+
+
 def _strings(raw: Sequence[str] | set[str] | tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
     if not isinstance(raw, (list, tuple, set)):
         return ()
@@ -371,6 +380,194 @@ def _valid_evidence_refs(
     return valid, tuple(f"unknown_evidence_ref:{ref}" for ref in invalid)
 
 
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    number = _coerce_float(value)
+    return int(number) if number is not None else None
+
+
+def _latest_vars(latest_vars: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    return latest_vars if isinstance(latest_vars, Mapping) else {}
+
+
+def _normalize_ufc_scratchpad_text(vars_map: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for key in (
+        "ufc_scratchpad_string_1_display",
+        "ufc_scratchpad_string_2_display",
+        "ufc_scratchpad_number_display",
+    ):
+        value = vars_map.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    return "".join(parts).replace("。", ".").upper()
+
+
+def _s09_comm1_frequency_complete(vars_map: Mapping[str, Any]) -> bool:
+    if vars_map.get("comm1_freq_134_000") is True:
+        return True
+    value = _coerce_int(vars_map.get("comm1_freq_value"))
+    return value == 13400
+
+
+def _s09_state_action_plan(
+    vars_map: Mapping[str, Any],
+    *,
+    spec: StepHarnessSpec | None,
+    recent_action_targets: Sequence[str] | None,
+) -> _StateActionPlan | None:
+    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
+    if not allowed or _s09_comm1_frequency_complete(vars_map):
+        return None
+
+    scratchpad_text = _normalize_ufc_scratchpad_text(vars_map)
+    compact = scratchpad_text.replace(" ", "")
+    payload = compact[3:] if compact.startswith("1--") else compact
+    recent = set(_strings(recent_action_targets))
+
+    def _target(name: str, guidance: str) -> _StateActionPlan | None:
+        if name not in allowed:
+            return None
+        return _StateActionPlan(
+            targets=(name,),
+            guidance=guidance,
+            text_only=False,
+            source="state_action_planner",
+            reasons=(f"s09_state_target:{name}",),
+        )
+
+    if payload.endswith("134.000"):
+        return _target("ufc_ent_button", "The UFC scratchpad shows 134.000; press ENT to commit the COMM1 preset.")
+    if payload.endswith("13.400") or payload.endswith("1.340") or payload.endswith(".134") or payload.endswith("1.34"):
+        return _target("ufc_key_0", "COMM1 preset entry is partway through 134.000; press 0 next.")
+    if payload.endswith(".13"):
+        return _target("ufc_key_4", "COMM1 preset entry shows 13; press 4 next.")
+    if payload.endswith(".1"):
+        return _target("ufc_key_3", "COMM1 preset entry shows 1; press 3 next.")
+    if payload.endswith("305.000") or payload.endswith("305000"):
+        return _target("ufc_key_1", "COMM1 preset 1 is open with the old 305.000 value; press 1 next.")
+    if vars_map.get("ufc_comm1_pull_pressed") is True or "ufc_comm1_channel_selector_pull" in recent:
+        return _target("ufc_key_1", "COMM1 preset entry is open; start typing 134.000 with key 1.")
+    return _target("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector before entering 134.000.")
+
+
+def _changed_var(evidence_packet: Any, var_name: str) -> Mapping[str, Any] | None:
+    digest = getattr(evidence_packet, "telemetry_window_digest", None)
+    for item in getattr(digest, "changed_vars", ()):
+        if isinstance(item, Mapping) and item.get("var") == var_name:
+            return item
+    return None
+
+
+def _probe_motion_state(
+    step_id: str | None,
+    vars_map: Mapping[str, Any],
+    *,
+    evidence_packet: Any = None,
+) -> str | None:
+    probe_value = _coerce_float(vars_map.get("ext_refuel_probe_value"))
+    switch_value = _coerce_int(vars_map.get("probe_switch_value"))
+    changed = _changed_var(evidence_packet, "ext_refuel_probe_value")
+    first_value = _coerce_float(changed.get("first_value")) if isinstance(changed, Mapping) else None
+    last_value = _coerce_float(changed.get("last_value")) if isinstance(changed, Mapping) else None
+    is_extending = first_value is not None and last_value is not None and last_value > first_value
+    is_retracting = first_value is not None and last_value is not None and last_value < first_value
+
+    if step_id == "S20":
+        if switch_value == 0 and probe_value is not None and 0 < probe_value < 60000 and is_extending:
+            return "s20_extending"
+    if step_id == "S21":
+        near_retract_threshold = probe_value is not None and 5000 < probe_value <= 7000
+        if switch_value == 1 and probe_value is not None and probe_value > 5000 and (
+            is_retracting or near_retract_threshold
+        ):
+            return "s21_retracting"
+    return None
+
+
+def _state_action_plan(
+    *,
+    step_id: str | None,
+    spec: StepHarnessSpec | None,
+    latest_vars: Mapping[str, Any] | None,
+    evidence_packet: Any = None,
+    recent_action_targets: Sequence[str] | None = None,
+    vision_seen_fact_ids: Sequence[str] | None = None,
+    vision_fresh_fact_ids: Sequence[str] | None = None,
+    vision_not_seen_fact_ids: Sequence[str] | None = None,
+) -> _StateActionPlan | None:
+    vars_map = _latest_vars(latest_vars)
+    if step_id == "S09":
+        return _s09_state_action_plan(
+            vars_map,
+            spec=spec,
+            recent_action_targets=recent_action_targets,
+        )
+
+    motion_state = _probe_motion_state(step_id, vars_map, evidence_packet=evidence_packet)
+    if motion_state == "s20_extending":
+        return _StateActionPlan(
+            targets=(),
+            guidance="The refueling probe is extending. Wait until it is fully extended before continuing.",
+            text_only=True,
+            source="state_action_planner_wait",
+            reasons=("probe_motion:s20_extending",),
+        )
+    if motion_state == "s21_retracting":
+        return _StateActionPlan(
+            targets=(),
+            guidance="The refueling probe is retracting. Wait until it is fully stowed before continuing.",
+            text_only=True,
+            source="state_action_planner_wait",
+            reasons=("probe_motion:s21_retracting",),
+        )
+
+    seen_or_fresh = set(_strings(vision_seen_fact_ids)) | set(_strings(vision_fresh_fact_ids))
+    not_seen = set(_strings(vision_not_seen_fact_ids))
+    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
+    if step_id == "S18" and "bit_root_page_visible" in seen_or_fresh and "fcsmc_page_visible" in not_seen:
+        if "right_mdi_pb5" in allowed:
+            return _StateActionPlan(
+                targets=("right_mdi_pb5",),
+                guidance="BIT root is visible; press Right DDI PB5/FCS-MC to enter the FCS-MC BIT page.",
+                text_only=False,
+                source="state_action_planner",
+                reasons=("s18_bit_root_to_pb5",),
+            )
+    if step_id == "S19":
+        if "fcsmc_in_test_visible" in seen_or_fresh:
+            return _StateActionPlan(
+                targets=(),
+                guidance="The FCS BIT is already running. Release the switch and wait for the final GO result.",
+                text_only=True,
+                source="state_action_planner_wait",
+                reasons=("s19_in_test_wait",),
+            )
+        if "fcsmc_intermediate_result_visible" in seen_or_fresh:
+            targets = tuple(target for target in ("fcs_bit_switch", "right_mdi_pb5") if target in allowed)
+            if targets:
+                return _StateActionPlan(
+                    targets=targets,
+                    guidance="Hold the FCS BIT switch up while pressing Right DDI PB5 to start the BIT.",
+                    text_only=False,
+                    source="state_action_planner",
+                    reasons=("s19_intermediate_start_bit",),
+                )
+    return None
+
+
 def plan_harness_action(
     *,
     step_specs: Mapping[str, StepHarnessSpec],
@@ -392,6 +589,9 @@ def plan_harness_action(
     action_hint_step_ids: Sequence[str] | None = None,
     action_hint_fact_rules: Sequence[HarnessActionHintFactRule] | None = None,
     text_guidance_rules: Sequence[HarnessTextGuidanceRule] | None = None,
+    latest_vars: Mapping[str, Any] | None = None,
+    evidence_packet: Any = None,
+    recent_action_targets: Sequence[str] | None = None,
 ) -> HarnessActionPlan:
     reasons: list[str] = []
     rejected_model_step_id: str | None = None
@@ -429,6 +629,32 @@ def plan_harness_action(
 
     spec = step_specs.get(selected_overlay_step_id or "") if selected_overlay_step_id else None
     proposed_targets = _strings(proposed_overlay_targets)
+    state_plan = _state_action_plan(
+        step_id=selected_step_id,
+        spec=spec,
+        latest_vars=latest_vars,
+        evidence_packet=evidence_packet,
+        recent_action_targets=recent_action_targets,
+        vision_seen_fact_ids=vision_seen_fact_ids,
+        vision_fresh_fact_ids=vision_fresh_fact_ids,
+        vision_not_seen_fact_ids=vision_not_seen_fact_ids,
+    )
+    if state_plan is not None and state_plan.text_only:
+        return HarnessActionPlan(
+            step_id=selected_step_id,
+            overlay_step_id=selected_overlay_step_id,
+            targets=(),
+            evidence_refs=(),
+            guidance=state_plan.guidance,
+            text_only=True,
+            validator_rejected=True,
+            repair_applied=True,
+            rejected_model_step_id=rejected_model_step_id,
+            rejected_model_targets=proposed_targets,
+            final_action_plan_source=state_plan.source,
+            reasons=tuple((*reasons, *state_plan.reasons)),
+        )
+
     text_guidance = _text_guidance_for_targets(
         selected_step_id,
         proposed_targets,
@@ -467,12 +693,23 @@ def plan_harness_action(
             use_hint = True
             source = hint_rule_source
 
+    if state_plan is not None and len(state_plan.targets) > 1 and hinted_targets != state_plan.targets:
+        if use_hint and hinted_targets:
+            reasons.append(
+                "action_hint_incomplete_for_state_plan:" + ",".join(hinted_targets)
+            )
+        use_hint = False
+
     if completion_advance is not None:
         base_targets = spec.allowed_overlay_targets if spec is not None else ()
     elif use_hint:
         base_targets = hinted_targets
         if source == "model":
             source = "validator_action_hint"
+    elif state_plan is not None:
+        base_targets = state_plan.targets
+        source = state_plan.source
+        reasons.extend(state_plan.reasons)
     else:
         base_targets = proposed_targets
 
@@ -492,6 +729,29 @@ def plan_harness_action(
             if target not in hinted_target_set
         )
         reasons.extend(f"action_hint_target_mismatch:{target}" for target in rejected_model_targets)
+    elif state_plan is not None and proposed_targets:
+        planned_target_set = set(state_plan.targets)
+        rejected_model_targets = tuple(
+            target for target in proposed_targets
+            if target not in planned_target_set
+        )
+        reasons.extend(f"state_action_target_mismatch:{target}" for target in rejected_model_targets)
+
+    if state_plan is not None and not use_hint and tuple(targets) != state_plan.targets:
+        return HarnessActionPlan(
+            step_id=selected_step_id,
+            overlay_step_id=selected_overlay_step_id,
+            targets=(),
+            evidence_refs=(),
+            guidance=state_plan.guidance,
+            text_only=True,
+            validator_rejected=True,
+            repair_applied=True,
+            rejected_model_step_id=rejected_model_step_id,
+            rejected_model_targets=rejected_model_targets or proposed_targets,
+            final_action_plan_source=state_plan.source,
+            reasons=tuple(reasons),
+        )
 
     if not targets and spec is not None and spec.allowed_overlay_targets and max_overlay_targets > 0:
         repaired_targets, repair_reasons = _filter_targets(
@@ -526,6 +786,13 @@ def plan_harness_action(
         hint_reason = action_hint.get("reason")
         if isinstance(hint_reason, str) and hint_reason:
             guidance = hint_reason
+    if (
+        not use_hint
+        and state_plan is not None
+        and isinstance(state_plan.guidance, str)
+        and state_plan.guidance
+    ):
+        guidance = state_plan.guidance
 
     return HarnessActionPlan(
         step_id=selected_step_id,

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -72,6 +72,15 @@ class EvidenceConsistencyResult:
     reasons: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class _StateActionPlan:
+    targets: tuple[str, ...]
+    guidance: str | None
+    text_only: bool
+    source: str
+    reasons: tuple[str, ...] = ()
+
+
 def _strings(raw: Sequence[str] | set[str] | tuple[str, ...] | list[str] | None) -> tuple[str, ...]:
     if not isinstance(raw, (list, tuple, set)):
         return ()
@@ -371,6 +380,194 @@ def _valid_evidence_refs(
     return valid, tuple(f"unknown_evidence_ref:{ref}" for ref in invalid)
 
 
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    number = _coerce_float(value)
+    return int(number) if number is not None else None
+
+
+def _latest_vars(latest_vars: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    return latest_vars if isinstance(latest_vars, Mapping) else {}
+
+
+def _normalize_ufc_scratchpad_text(vars_map: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for key in (
+        "ufc_scratchpad_string_1_display",
+        "ufc_scratchpad_string_2_display",
+        "ufc_scratchpad_number_display",
+    ):
+        value = vars_map.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    return "".join(parts).replace("。", ".").upper()
+
+
+def _s09_comm1_frequency_complete(vars_map: Mapping[str, Any]) -> bool:
+    if vars_map.get("comm1_freq_134_000") is True:
+        return True
+    value = _coerce_int(vars_map.get("comm1_freq_value"))
+    return value == 13400
+
+
+def _s09_state_action_plan(
+    vars_map: Mapping[str, Any],
+    *,
+    spec: StepHarnessSpec | None,
+    recent_action_targets: Sequence[str] | None,
+) -> _StateActionPlan | None:
+    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
+    if not allowed or _s09_comm1_frequency_complete(vars_map):
+        return None
+
+    scratchpad_text = _normalize_ufc_scratchpad_text(vars_map)
+    compact = scratchpad_text.replace(" ", "")
+    payload = compact[3:] if compact.startswith("1--") else compact
+    recent = set(_strings(recent_action_targets))
+
+    def _target(name: str, guidance: str) -> _StateActionPlan | None:
+        if name not in allowed:
+            return None
+        return _StateActionPlan(
+            targets=(name,),
+            guidance=guidance,
+            text_only=False,
+            source="state_action_planner",
+            reasons=(f"s09_state_target:{name}",),
+        )
+
+    if payload.endswith("134.000"):
+        return _target("ufc_ent_button", "The UFC scratchpad shows 134.000; press ENT to commit the COMM1 preset.")
+    if payload.endswith("13.400") or payload.endswith("1.340") or payload.endswith(".134") or payload.endswith("1.34"):
+        return _target("ufc_key_0", "COMM1 preset entry is partway through 134.000; press 0 next.")
+    if payload.endswith(".13"):
+        return _target("ufc_key_4", "COMM1 preset entry shows 13; press 4 next.")
+    if payload.endswith(".1"):
+        return _target("ufc_key_3", "COMM1 preset entry shows 1; press 3 next.")
+    if payload.endswith("305.000") or payload.endswith("305000"):
+        return _target("ufc_key_1", "COMM1 preset 1 is open with the old 305.000 value; press 1 next.")
+    if vars_map.get("ufc_comm1_pull_pressed") is True or "ufc_comm1_channel_selector_pull" in recent:
+        return _target("ufc_key_1", "COMM1 preset entry is open; start typing 134.000 with key 1.")
+    return _target("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector before entering 134.000.")
+
+
+def _changed_var(evidence_packet: Any, var_name: str) -> Mapping[str, Any] | None:
+    digest = getattr(evidence_packet, "telemetry_window_digest", None)
+    for item in getattr(digest, "changed_vars", ()):
+        if isinstance(item, Mapping) and item.get("var") == var_name:
+            return item
+    return None
+
+
+def _probe_motion_state(
+    step_id: str | None,
+    vars_map: Mapping[str, Any],
+    *,
+    evidence_packet: Any = None,
+) -> str | None:
+    probe_value = _coerce_float(vars_map.get("ext_refuel_probe_value"))
+    switch_value = _coerce_int(vars_map.get("probe_switch_value"))
+    changed = _changed_var(evidence_packet, "ext_refuel_probe_value")
+    first_value = _coerce_float(changed.get("first_value")) if isinstance(changed, Mapping) else None
+    last_value = _coerce_float(changed.get("last_value")) if isinstance(changed, Mapping) else None
+    is_extending = first_value is not None and last_value is not None and last_value > first_value
+    is_retracting = first_value is not None and last_value is not None and last_value < first_value
+
+    if step_id == "S20":
+        if switch_value == 0 and probe_value is not None and 0 < probe_value < 60000 and is_extending:
+            return "s20_extending"
+    if step_id == "S21":
+        near_retract_threshold = probe_value is not None and 5000 < probe_value <= 7000
+        if switch_value == 1 and probe_value is not None and probe_value > 5000 and (
+            is_retracting or near_retract_threshold
+        ):
+            return "s21_retracting"
+    return None
+
+
+def _state_action_plan(
+    *,
+    step_id: str | None,
+    spec: StepHarnessSpec | None,
+    latest_vars: Mapping[str, Any] | None,
+    evidence_packet: Any = None,
+    recent_action_targets: Sequence[str] | None = None,
+    vision_seen_fact_ids: Sequence[str] | None = None,
+    vision_fresh_fact_ids: Sequence[str] | None = None,
+    vision_not_seen_fact_ids: Sequence[str] | None = None,
+) -> _StateActionPlan | None:
+    vars_map = _latest_vars(latest_vars)
+    if step_id == "S09":
+        return _s09_state_action_plan(
+            vars_map,
+            spec=spec,
+            recent_action_targets=recent_action_targets,
+        )
+
+    motion_state = _probe_motion_state(step_id, vars_map, evidence_packet=evidence_packet)
+    if motion_state == "s20_extending":
+        return _StateActionPlan(
+            targets=(),
+            guidance="The refueling probe is extending. Wait until it is fully extended before continuing.",
+            text_only=True,
+            source="state_action_planner_wait",
+            reasons=("probe_motion:s20_extending",),
+        )
+    if motion_state == "s21_retracting":
+        return _StateActionPlan(
+            targets=(),
+            guidance="The refueling probe is retracting. Wait until it is fully stowed before continuing.",
+            text_only=True,
+            source="state_action_planner_wait",
+            reasons=("probe_motion:s21_retracting",),
+        )
+
+    seen_or_fresh = set(_strings(vision_seen_fact_ids)) | set(_strings(vision_fresh_fact_ids))
+    not_seen = set(_strings(vision_not_seen_fact_ids))
+    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
+    if step_id == "S18" and "bit_root_page_visible" in seen_or_fresh and "fcsmc_page_visible" in not_seen:
+        if "right_mdi_pb5" in allowed:
+            return _StateActionPlan(
+                targets=("right_mdi_pb5",),
+                guidance="BIT root is visible; press Right DDI PB5/FCS-MC to enter the FCS-MC BIT page.",
+                text_only=False,
+                source="state_action_planner",
+                reasons=("s18_bit_root_to_pb5",),
+            )
+    if step_id == "S19":
+        if "fcsmc_in_test_visible" in seen_or_fresh:
+            return _StateActionPlan(
+                targets=(),
+                guidance="The FCS BIT is already running. Release the switch and wait for the final GO result.",
+                text_only=True,
+                source="state_action_planner_wait",
+                reasons=("s19_in_test_wait",),
+            )
+        if "fcsmc_intermediate_result_visible" in seen_or_fresh:
+            targets = tuple(target for target in ("fcs_bit_switch", "right_mdi_pb5") if target in allowed)
+            if targets:
+                return _StateActionPlan(
+                    targets=targets,
+                    guidance="Hold the FCS BIT switch up while pressing Right DDI PB5 to start the BIT.",
+                    text_only=False,
+                    source="state_action_planner",
+                    reasons=("s19_intermediate_start_bit",),
+                )
+    return None
+
+
 def plan_harness_action(
     *,
     step_specs: Mapping[str, StepHarnessSpec],
@@ -392,6 +589,9 @@ def plan_harness_action(
     action_hint_step_ids: Sequence[str] | None = None,
     action_hint_fact_rules: Sequence[HarnessActionHintFactRule] | None = None,
     text_guidance_rules: Sequence[HarnessTextGuidanceRule] | None = None,
+    latest_vars: Mapping[str, Any] | None = None,
+    evidence_packet: Any = None,
+    recent_action_targets: Sequence[str] | None = None,
 ) -> HarnessActionPlan:
     reasons: list[str] = []
     rejected_model_step_id: str | None = None
@@ -429,6 +629,32 @@ def plan_harness_action(
 
     spec = step_specs.get(selected_overlay_step_id or "") if selected_overlay_step_id else None
     proposed_targets = _strings(proposed_overlay_targets)
+    state_plan = _state_action_plan(
+        step_id=selected_step_id,
+        spec=spec,
+        latest_vars=latest_vars,
+        evidence_packet=evidence_packet,
+        recent_action_targets=recent_action_targets,
+        vision_seen_fact_ids=vision_seen_fact_ids,
+        vision_fresh_fact_ids=vision_fresh_fact_ids,
+        vision_not_seen_fact_ids=vision_not_seen_fact_ids,
+    )
+    if state_plan is not None and state_plan.text_only:
+        return HarnessActionPlan(
+            step_id=selected_step_id,
+            overlay_step_id=selected_overlay_step_id,
+            targets=(),
+            evidence_refs=(),
+            guidance=state_plan.guidance,
+            text_only=True,
+            validator_rejected=True,
+            repair_applied=True,
+            rejected_model_step_id=rejected_model_step_id,
+            rejected_model_targets=proposed_targets,
+            final_action_plan_source=state_plan.source,
+            reasons=tuple((*reasons, *state_plan.reasons)),
+        )
+
     text_guidance = _text_guidance_for_targets(
         selected_step_id,
         proposed_targets,
@@ -473,6 +699,10 @@ def plan_harness_action(
         base_targets = hinted_targets
         if source == "model":
             source = "validator_action_hint"
+    elif state_plan is not None:
+        base_targets = state_plan.targets
+        source = state_plan.source
+        reasons.extend(state_plan.reasons)
     else:
         base_targets = proposed_targets
 
@@ -492,6 +722,29 @@ def plan_harness_action(
             if target not in hinted_target_set
         )
         reasons.extend(f"action_hint_target_mismatch:{target}" for target in rejected_model_targets)
+    elif state_plan is not None and proposed_targets:
+        planned_target_set = set(state_plan.targets)
+        rejected_model_targets = tuple(
+            target for target in proposed_targets
+            if target not in planned_target_set
+        )
+        reasons.extend(f"state_action_target_mismatch:{target}" for target in rejected_model_targets)
+
+    if state_plan is not None and not use_hint and tuple(targets) != state_plan.targets:
+        return HarnessActionPlan(
+            step_id=selected_step_id,
+            overlay_step_id=selected_overlay_step_id,
+            targets=(),
+            evidence_refs=(),
+            guidance=state_plan.guidance,
+            text_only=True,
+            validator_rejected=True,
+            repair_applied=True,
+            rejected_model_step_id=rejected_model_step_id,
+            rejected_model_targets=rejected_model_targets or proposed_targets,
+            final_action_plan_source=state_plan.source,
+            reasons=tuple(reasons),
+        )
 
     if not targets and spec is not None and spec.allowed_overlay_targets and max_overlay_targets > 0:
         repaired_targets, repair_reasons = _filter_targets(
@@ -526,6 +779,13 @@ def plan_harness_action(
         hint_reason = action_hint.get("reason")
         if isinstance(hint_reason, str) and hint_reason:
             guidance = hint_reason
+    if (
+        not use_hint
+        and state_plan is not None
+        and isinstance(state_plan.guidance, str)
+        and state_plan.guidance
+    ):
+        guidance = state_plan.guidance
 
     return HarnessActionPlan(
         step_id=selected_step_id,

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -5528,6 +5528,33 @@ class LiveDcsTutorLoop:
             if isinstance(raw_not_seen, (list, tuple, set)):
                 vision_not_seen_fact_ids = [item for item in raw_not_seen if isinstance(item, str) and item]
 
+        vars_selected = context.get("vars")
+        vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        state_action_evidence_packet = None
+        if inferred_step_id in {"S20", "S21"}:
+            try:
+                state_action_evidence_packet = build_evidence_packet(self._context_with_full_pack_gates(context))
+            except Exception as exc:
+                response.metadata["state_action_evidence_packet_error"] = f"{type(exc).__name__}: {exc}"
+        recent_action_targets: list[str] = []
+        recent_actions = context.get("recent_actions")
+        if isinstance(recent_actions, Mapping):
+            raw_recent_buttons = recent_actions.get("recent_buttons")
+            if isinstance(raw_recent_buttons, (list, tuple, set)):
+                recent_action_targets.extend(item for item in raw_recent_buttons if isinstance(item, str) and item)
+        if state_action_evidence_packet is not None:
+            packet_targets = getattr(
+                getattr(state_action_evidence_packet, "recent_action_evidence", None),
+                "target_ids",
+                (),
+            )
+            if isinstance(packet_targets, (list, tuple, set)):
+                recent_action_targets.extend(item for item in packet_targets if isinstance(item, str) and item)
+        hint_recent_targets = hint.get("recent_ui_targets")
+        if isinstance(hint_recent_targets, (list, tuple, set)):
+            recent_action_targets.extend(item for item in hint_recent_targets if isinstance(item, str) and item)
+        recent_action_targets = _dedupe_strings(recent_action_targets)
+
         missing_conditions = hint.get("missing_conditions")
         missing_set = {
             item for item in missing_conditions
@@ -5715,6 +5742,9 @@ class LiveDcsTutorLoop:
                 HarnessActionHintFactRule(step_id="S19", fact_id="fcsmc_intermediate_result_visible")
             ],
             text_guidance_rules=manual_text_guidance_rules,
+            latest_vars=vars_map,
+            evidence_packet=state_action_evidence_packet,
+            recent_action_targets=recent_action_targets,
         )
         plan_guidance = plan.guidance
         if s18_visual_hint_used and (not isinstance(plan_guidance, str) or not plan_guidance):
@@ -5778,16 +5808,16 @@ class LiveDcsTutorLoop:
                 if original_explanations and original_explanations != response.explanations:
                     response.metadata["harness_validator_original_explanations"] = original_explanations
                     response.metadata["manual_throttle_guidance_original_explanations"] = original_explanations
+            response.metadata["help_response"] = {
+                "diagnosis": {"step_id": plan.step_id, "error_category": "OM"},
+                "next": {"step_id": plan.step_id},
+                "overlay": {"targets": [], "evidence": []},
+                "explanations": list(response.explanations) or ([response.message] if response.message else []),
+            }
             if plan.step_id in {"S05", "S11"}:
                 response.metadata["manual_throttle_guidance_rewritten"] = True
                 response.metadata["manual_throttle_guidance_step_id"] = plan.step_id
                 response.metadata["manual_throttle_guidance_original_actions"] = original_actions
-                response.metadata["help_response"] = {
-                    "diagnosis": {"step_id": plan.step_id, "error_category": "OM"},
-                    "next": {"step_id": plan.step_id},
-                    "overlay": {"targets": [], "evidence": []},
-                    "explanations": [response.message],
-                }
                 return True, "manual_throttle_keyboard_guidance"
             return True, final_action_plan_source
 

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -5528,6 +5528,33 @@ class LiveDcsTutorLoop:
             if isinstance(raw_not_seen, (list, tuple, set)):
                 vision_not_seen_fact_ids = [item for item in raw_not_seen if isinstance(item, str) and item]
 
+        vars_selected = context.get("vars")
+        vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        state_action_evidence_packet = None
+        if inferred_step_id in {"S20", "S21"}:
+            try:
+                state_action_evidence_packet = build_evidence_packet(self._context_with_full_pack_gates(context))
+            except Exception as exc:
+                response.metadata["state_action_evidence_packet_error"] = f"{type(exc).__name__}: {exc}"
+        recent_action_targets: list[str] = []
+        recent_actions = context.get("recent_actions")
+        if isinstance(recent_actions, Mapping):
+            raw_recent_buttons = recent_actions.get("recent_buttons")
+            if isinstance(raw_recent_buttons, (list, tuple, set)):
+                recent_action_targets.extend(item for item in raw_recent_buttons if isinstance(item, str) and item)
+        if state_action_evidence_packet is not None:
+            packet_targets = getattr(
+                getattr(state_action_evidence_packet, "recent_action_evidence", None),
+                "target_ids",
+                (),
+            )
+            if isinstance(packet_targets, (list, tuple, set)):
+                recent_action_targets.extend(item for item in packet_targets if isinstance(item, str) and item)
+        hint_recent_targets = hint.get("recent_ui_targets")
+        if isinstance(hint_recent_targets, (list, tuple, set)):
+            recent_action_targets.extend(item for item in hint_recent_targets if isinstance(item, str) and item)
+        recent_action_targets = _dedupe_strings(recent_action_targets)
+
         missing_conditions = hint.get("missing_conditions")
         missing_set = {
             item for item in missing_conditions
@@ -5715,6 +5742,9 @@ class LiveDcsTutorLoop:
                 HarnessActionHintFactRule(step_id="S19", fact_id="fcsmc_intermediate_result_visible")
             ],
             text_guidance_rules=manual_text_guidance_rules,
+            latest_vars=vars_map,
+            evidence_packet=state_action_evidence_packet,
+            recent_action_targets=recent_action_targets,
         )
         plan_guidance = plan.guidance
         if s18_visual_hint_used and (not isinstance(plan_guidance, str) or not plan_guidance):
@@ -5767,6 +5797,25 @@ class LiveDcsTutorLoop:
             if original_actions:
                 response.metadata["harness_validator_original_actions"] = original_actions
             response.actions = []
+            if final_action_plan_source == "state_action_planner_wait":
+                if "probe_motion:s20_extending" in plan.reasons:
+                    plan_guidance = (
+                        "受油管正在伸出。请等待它完全伸出后，再继续四落检查。"
+                        if self.lang == "zh"
+                        else "The refueling probe is extending. Wait until it is fully extended before continuing."
+                    )
+                elif "probe_motion:s21_retracting" in plan.reasons:
+                    plan_guidance = (
+                        "受油管正在收起。请等待它完全收好后，再继续下一步。"
+                        if self.lang == "zh"
+                        else "The refueling probe is retracting. Wait until it is fully stowed before continuing."
+                    )
+                elif "s19_in_test_wait" in plan.reasons:
+                    plan_guidance = (
+                        "FCS BIT 已经开始运行。请松开 FCS BIT 开关并等待最终 GO 结果。"
+                        if self.lang == "zh"
+                        else "The FCS BIT is already running. Release the switch and wait for the final GO result."
+                    )
             if isinstance(plan_guidance, str) and plan_guidance:
                 original_message = response.message
                 original_explanations = list(response.explanations)
@@ -5774,20 +5823,26 @@ class LiveDcsTutorLoop:
                 response.explanations = [plan_guidance]
                 if original_message != response.message:
                     response.metadata["harness_validator_original_message"] = original_message
-                    response.metadata["manual_throttle_guidance_original_message"] = original_message
                 if original_explanations and original_explanations != response.explanations:
                     response.metadata["harness_validator_original_explanations"] = original_explanations
-                    response.metadata["manual_throttle_guidance_original_explanations"] = original_explanations
+            response.metadata["help_response"] = {
+                "diagnosis": {"step_id": plan.step_id, "error_category": "OM"},
+                "next": {"step_id": plan.step_id},
+                "overlay": {"targets": [], "evidence": []},
+                "explanations": list(response.explanations) or ([response.message] if response.message else []),
+            }
             if plan.step_id in {"S05", "S11"}:
                 response.metadata["manual_throttle_guidance_rewritten"] = True
                 response.metadata["manual_throttle_guidance_step_id"] = plan.step_id
                 response.metadata["manual_throttle_guidance_original_actions"] = original_actions
-                response.metadata["help_response"] = {
-                    "diagnosis": {"step_id": plan.step_id, "error_category": "OM"},
-                    "next": {"step_id": plan.step_id},
-                    "overlay": {"targets": [], "evidence": []},
-                    "explanations": [response.message],
-                }
+                if "harness_validator_original_message" in response.metadata:
+                    response.metadata["manual_throttle_guidance_original_message"] = response.metadata[
+                        "harness_validator_original_message"
+                    ]
+                if "harness_validator_original_explanations" in response.metadata:
+                    response.metadata["manual_throttle_guidance_original_explanations"] = response.metadata[
+                        "harness_validator_original_explanations"
+                    ]
                 return True, "manual_throttle_keyboard_guidance"
             return True, final_action_plan_source
 

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -298,28 +298,43 @@ def test_plan_harness_action_keeps_s19_intermediate_multi_target_guidance() -> N
 
 
 def test_plan_harness_action_uses_single_current_target_for_s20_to_s27() -> None:
-    plan = plan_harness_action(
-        step_specs={
-            "S26": _spec("S26", ("pitot_heater_switch",)),
-            "S20": _spec("S20", ("refuel_probe_switch",)),
-        },
-        inferred_step_id="S26",
-        model_step_id="S26",
-        proposed_overlay_targets=["refuel_probe_switch"],
-        candidate_step_ids=["S26", "S27"],
-        runtime_overlay_targets=["refuel_probe_switch", "pitot_heater_switch"],
-        request_overlay_targets=["refuel_probe_switch", "pitot_heater_switch"],
-        allowed_evidence_refs=["GATES.S26.completion"],
-        evidence_refs=["GATES.S26.completion"],
-        max_overlay_targets=2,
-        action_hint={"target": "pitot_heater_switch"},
-        action_hint_step_ids=["S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
-    )
+    expected_targets = {
+        "S20": "refuel_probe_switch",
+        "S21": "refuel_probe_switch",
+        "S22": "launch_bar_switch",
+        "S23": "launch_bar_switch",
+        "S24": "arresting_hook_handle",
+        "S25": "arresting_hook_handle",
+        "S26": "pitot_heater_switch",
+        "S27": "flap_switch",
+    }
+    wrong_target = "battery_switch"
+    step_specs = {
+        step_id: _spec(step_id, (target,))
+        for step_id, target in expected_targets.items()
+    }
+    runtime_targets = [wrong_target, *expected_targets.values()]
 
-    assert plan.targets == ("pitot_heater_switch",)
-    assert plan.validator_rejected is True
-    assert plan.repair_applied is True
-    assert plan.final_action_plan_source == "validator_action_hint"
+    for step_id, expected_target in expected_targets.items():
+        plan = plan_harness_action(
+            step_specs=step_specs,
+            inferred_step_id=step_id,
+            model_step_id=step_id,
+            proposed_overlay_targets=[wrong_target],
+            candidate_step_ids=[step_id],
+            runtime_overlay_targets=runtime_targets,
+            request_overlay_targets=runtime_targets,
+            allowed_evidence_refs=[f"GATES.{step_id}.completion"],
+            evidence_refs=[f"GATES.{step_id}.completion"],
+            max_overlay_targets=2,
+            action_hint={"target": expected_target},
+            action_hint_step_ids=["S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
+        )
+
+        assert plan.targets == (expected_target,)
+        assert plan.validator_rejected is True
+        assert plan.repair_applied is True
+        assert plan.final_action_plan_source == "validator_action_hint"
 
 
 def test_plan_harness_action_returns_text_only_for_unhighlightable_manual_control() -> None:
@@ -522,3 +537,289 @@ def test_plan_harness_action_keeps_s18_recovery_pb18_when_bit_root_not_visible()
     assert plan.repair_applied is False
     assert plan.validator_rejected is False
     assert plan.final_action_plan_source == "model"
+
+
+def test_plan_harness_action_uses_s18_visual_state_without_live_hint() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=["right_mdi_pb18"],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        request_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["bit_root_page_visible"],
+        vision_not_seen_fact_ids=["fcsmc_page_visible"],
+    )
+
+    assert plan.targets == ("right_mdi_pb5",)
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "state_action_target_mismatch:right_mdi_pb18" in plan.reasons
+
+
+def test_plan_harness_action_clears_unavailable_s18_state_target() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=["right_mdi_pb18"],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18"],
+        request_overlay_targets=["right_mdi_pb18"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["bit_root_page_visible"],
+        vision_not_seen_fact_ids=["fcsmc_page_visible"],
+    )
+
+    assert plan.text_only is True
+    assert plan.targets == ()
+    assert "PB5" in (plan.guidance or "")
+    assert "target_not_in_runtime_allowlist:right_mdi_pb5" in plan.reasons
+
+
+def test_plan_harness_action_uses_s09_scratchpad_state_without_live_hint() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S09"].allowed_overlay_targets)
+    cases = [
+        ({}, "ufc_comm1_channel_selector_pull"),
+        (
+            {
+                "ufc_comm1_pull_pressed": True,
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "305.000",
+            },
+            "ufc_key_1",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "     .1",
+            },
+            "ufc_key_3",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "    .13",
+            },
+            "ufc_key_4",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "   .134",
+            },
+            "ufc_key_0",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "134.000",
+            },
+            "ufc_ent_button",
+        ),
+    ]
+
+    for vars_map, expected_target in cases:
+        plan = plan_harness_action(
+            step_specs=specs,
+            inferred_step_id="S09",
+            model_step_id="S09",
+            proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+            candidate_step_ids=["S09"],
+            runtime_overlay_targets=allowed_targets,
+            request_overlay_targets=allowed_targets,
+            max_overlay_targets=1,
+            latest_vars={"comm1_freq_134_000": False, **vars_map},
+            recent_action_targets=[],
+        )
+
+        assert plan.targets == (expected_target,)
+        assert plan.final_action_plan_source == "state_action_planner"
+
+
+def test_plan_harness_action_uses_recent_action_for_s09_open_scratchpad() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S09"].allowed_overlay_targets)
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S09",
+        model_step_id="S09",
+        proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        candidate_step_ids=["S09"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=1,
+        latest_vars={"comm1_freq_134_000": False},
+        recent_action_targets=["ufc_comm1_channel_selector_pull"],
+    )
+
+    assert plan.targets == ("ufc_key_1",)
+    assert plan.final_action_plan_source == "state_action_planner"
+
+
+def test_plan_harness_action_clears_unavailable_s09_state_target_instead_of_repairing_to_pull() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
+        )
+    }
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S09",
+        model_step_id="S09",
+        proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        candidate_step_ids=["S09"],
+        runtime_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        request_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        max_overlay_targets=1,
+        latest_vars={
+            "comm1_freq_134_000": False,
+            "ufc_scratchpad_string_1_display": "1-",
+            "ufc_scratchpad_string_2_display": "-",
+            "ufc_scratchpad_number_display": "     .1",
+        },
+    )
+
+    assert plan.text_only is True
+    assert plan.targets == ()
+    assert "press 3 next" in (plan.guidance or "")
+    assert "target_not_in_runtime_allowlist:ufc_key_3" in plan.reasons
+    assert plan.final_action_plan_source == "state_action_planner"
+
+
+def test_plan_harness_action_returns_text_only_when_probe_is_already_moving() -> None:
+    cases = [
+        (
+            "S20",
+            {"probe_switch_value": 0, "ext_refuel_probe_value": 12000},
+            [
+                {"seq": 1, "t_wall": 1.0, "vars": {"ext_refuel_probe_value": 8000}},
+                {"seq": 2, "t_wall": 2.0, "vars": {"ext_refuel_probe_value": 12000}},
+            ],
+            "extending",
+        ),
+        (
+            "S21",
+            {"probe_switch_value": 1, "ext_refuel_probe_value": 5600},
+            [
+                {"seq": 1, "t_wall": 1.0, "vars": {"ext_refuel_probe_value": 6200}},
+                {"seq": 2, "t_wall": 2.0, "vars": {"ext_refuel_probe_value": 5600}},
+            ],
+            "retracting",
+        ),
+    ]
+
+    for step_id, vars_map, frames, expected_word in cases:
+        packet = build_evidence_packet({"vars": vars_map, "telemetry_window_frames": frames})
+        plan = plan_harness_action(
+            step_specs={step_id: _spec(step_id, ("refuel_probe_switch",))},
+            inferred_step_id=step_id,
+            model_step_id=step_id,
+            proposed_overlay_targets=["refuel_probe_switch"],
+            candidate_step_ids=[step_id],
+            runtime_overlay_targets=["refuel_probe_switch"],
+            request_overlay_targets=["refuel_probe_switch"],
+            max_overlay_targets=1,
+            latest_vars=vars_map,
+            evidence_packet=packet,
+        )
+
+        assert plan.text_only is True
+        assert plan.targets == ()
+        assert expected_word in (plan.guidance or "")
+        assert plan.final_action_plan_source == "state_action_planner_wait"
+
+
+def test_plan_harness_action_clears_partial_s19_multi_target_plan() -> None:
+    plan = plan_harness_action(
+        step_specs={"S19": _spec("S19", ("fcs_bit_switch", "right_mdi_pb5"))},
+        inferred_step_id="S19",
+        model_step_id="S19",
+        proposed_overlay_targets=["right_mdi_pb5"],
+        candidate_step_ids=["S19"],
+        runtime_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        request_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["fcsmc_intermediate_result_visible"],
+    )
+
+    assert plan.text_only is True
+    assert plan.targets == ()
+    assert "PB5" in (plan.guidance or "")
+    assert "target_dropped_by_max_overlay_targets:right_mdi_pb5" in plan.reasons
+
+
+def test_plan_harness_action_expands_incomplete_s19_intermediate_hint_to_atomic_pair() -> None:
+    plan = plan_harness_action(
+        step_specs={"S19": _spec("S19", ("fcs_bit_switch", "right_mdi_pb5"))},
+        inferred_step_id="S19",
+        model_step_id="S19",
+        proposed_overlay_targets=["fcs_bit_switch"],
+        candidate_step_ids=["S19"],
+        runtime_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        request_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        max_overlay_targets=2,
+        vision_seen_fact_ids=["fcsmc_intermediate_result_visible"],
+        action_hint={"target": "fcs_bit_switch"},
+        action_hint_fact_rules=[
+            HarnessActionHintFactRule(step_id="S19", fact_id="fcsmc_intermediate_result_visible")
+        ],
+    )
+
+    assert plan.text_only is False
+    assert plan.targets == ("fcs_bit_switch", "right_mdi_pb5")
+    assert "action_hint_incomplete_for_state_plan:fcs_bit_switch" in plan.reasons
+    assert plan.final_action_plan_source == "state_action_planner"

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -298,28 +298,43 @@ def test_plan_harness_action_keeps_s19_intermediate_multi_target_guidance() -> N
 
 
 def test_plan_harness_action_uses_single_current_target_for_s20_to_s27() -> None:
-    plan = plan_harness_action(
-        step_specs={
-            "S26": _spec("S26", ("pitot_heater_switch",)),
-            "S20": _spec("S20", ("refuel_probe_switch",)),
-        },
-        inferred_step_id="S26",
-        model_step_id="S26",
-        proposed_overlay_targets=["refuel_probe_switch"],
-        candidate_step_ids=["S26", "S27"],
-        runtime_overlay_targets=["refuel_probe_switch", "pitot_heater_switch"],
-        request_overlay_targets=["refuel_probe_switch", "pitot_heater_switch"],
-        allowed_evidence_refs=["GATES.S26.completion"],
-        evidence_refs=["GATES.S26.completion"],
-        max_overlay_targets=2,
-        action_hint={"target": "pitot_heater_switch"},
-        action_hint_step_ids=["S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
-    )
+    expected_targets = {
+        "S20": "refuel_probe_switch",
+        "S21": "refuel_probe_switch",
+        "S22": "launch_bar_switch",
+        "S23": "launch_bar_switch",
+        "S24": "arresting_hook_handle",
+        "S25": "arresting_hook_handle",
+        "S26": "pitot_heater_switch",
+        "S27": "flap_switch",
+    }
+    wrong_target = "battery_switch"
+    step_specs = {
+        step_id: _spec(step_id, (target,))
+        for step_id, target in expected_targets.items()
+    }
+    runtime_targets = [wrong_target, *expected_targets.values()]
 
-    assert plan.targets == ("pitot_heater_switch",)
-    assert plan.validator_rejected is True
-    assert plan.repair_applied is True
-    assert plan.final_action_plan_source == "validator_action_hint"
+    for step_id, expected_target in expected_targets.items():
+        plan = plan_harness_action(
+            step_specs=step_specs,
+            inferred_step_id=step_id,
+            model_step_id=step_id,
+            proposed_overlay_targets=[wrong_target],
+            candidate_step_ids=[step_id],
+            runtime_overlay_targets=runtime_targets,
+            request_overlay_targets=runtime_targets,
+            allowed_evidence_refs=[f"GATES.{step_id}.completion"],
+            evidence_refs=[f"GATES.{step_id}.completion"],
+            max_overlay_targets=2,
+            action_hint={"target": expected_target},
+            action_hint_step_ids=["S20", "S21", "S22", "S23", "S24", "S25", "S26", "S27"],
+        )
+
+        assert plan.targets == (expected_target,)
+        assert plan.validator_rejected is True
+        assert plan.repair_applied is True
+        assert plan.final_action_plan_source == "validator_action_hint"
 
 
 def test_plan_harness_action_returns_text_only_for_unhighlightable_manual_control() -> None:
@@ -522,3 +537,266 @@ def test_plan_harness_action_keeps_s18_recovery_pb18_when_bit_root_not_visible()
     assert plan.repair_applied is False
     assert plan.validator_rejected is False
     assert plan.final_action_plan_source == "model"
+
+
+def test_plan_harness_action_uses_s18_visual_state_without_live_hint() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=["right_mdi_pb18"],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        request_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["bit_root_page_visible"],
+        vision_not_seen_fact_ids=["fcsmc_page_visible"],
+    )
+
+    assert plan.targets == ("right_mdi_pb5",)
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "state_action_target_mismatch:right_mdi_pb18" in plan.reasons
+
+
+def test_plan_harness_action_clears_unavailable_s18_state_target() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=["right_mdi_pb18"],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18"],
+        request_overlay_targets=["right_mdi_pb18"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["bit_root_page_visible"],
+        vision_not_seen_fact_ids=["fcsmc_page_visible"],
+    )
+
+    assert plan.text_only is True
+    assert plan.targets == ()
+    assert "PB5" in (plan.guidance or "")
+    assert "target_not_in_runtime_allowlist:right_mdi_pb5" in plan.reasons
+
+
+def test_plan_harness_action_uses_s09_scratchpad_state_without_live_hint() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S09"].allowed_overlay_targets)
+    cases = [
+        ({}, "ufc_comm1_channel_selector_pull"),
+        (
+            {
+                "ufc_comm1_pull_pressed": True,
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "305.000",
+            },
+            "ufc_key_1",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "     .1",
+            },
+            "ufc_key_3",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "    .13",
+            },
+            "ufc_key_4",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "   .134",
+            },
+            "ufc_key_0",
+        ),
+        (
+            {
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "134.000",
+            },
+            "ufc_ent_button",
+        ),
+    ]
+
+    for vars_map, expected_target in cases:
+        plan = plan_harness_action(
+            step_specs=specs,
+            inferred_step_id="S09",
+            model_step_id="S09",
+            proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+            candidate_step_ids=["S09"],
+            runtime_overlay_targets=allowed_targets,
+            request_overlay_targets=allowed_targets,
+            max_overlay_targets=1,
+            latest_vars={"comm1_freq_134_000": False, **vars_map},
+            recent_action_targets=[],
+        )
+
+        assert plan.targets == (expected_target,)
+        assert plan.final_action_plan_source == "state_action_planner"
+
+
+def test_plan_harness_action_uses_recent_action_for_s09_open_scratchpad() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S09"].allowed_overlay_targets)
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S09",
+        model_step_id="S09",
+        proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        candidate_step_ids=["S09"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=1,
+        latest_vars={"comm1_freq_134_000": False},
+        recent_action_targets=["ufc_comm1_channel_selector_pull"],
+    )
+
+    assert plan.targets == ("ufc_key_1",)
+    assert plan.final_action_plan_source == "state_action_planner"
+
+
+def test_plan_harness_action_clears_unavailable_s09_state_target_instead_of_repairing_to_pull() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
+        )
+    }
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S09",
+        model_step_id="S09",
+        proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        candidate_step_ids=["S09"],
+        runtime_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        request_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        max_overlay_targets=1,
+        latest_vars={
+            "comm1_freq_134_000": False,
+            "ufc_scratchpad_string_1_display": "1-",
+            "ufc_scratchpad_string_2_display": "-",
+            "ufc_scratchpad_number_display": "     .1",
+        },
+    )
+
+    assert plan.text_only is True
+    assert plan.targets == ()
+    assert "press 3 next" in (plan.guidance or "")
+    assert "target_not_in_runtime_allowlist:ufc_key_3" in plan.reasons
+    assert plan.final_action_plan_source == "state_action_planner"
+
+
+def test_plan_harness_action_returns_text_only_when_probe_is_already_moving() -> None:
+    cases = [
+        (
+            "S20",
+            {"probe_switch_value": 0, "ext_refuel_probe_value": 12000},
+            [
+                {"seq": 1, "t_wall": 1.0, "vars": {"ext_refuel_probe_value": 8000}},
+                {"seq": 2, "t_wall": 2.0, "vars": {"ext_refuel_probe_value": 12000}},
+            ],
+            "extending",
+        ),
+        (
+            "S21",
+            {"probe_switch_value": 1, "ext_refuel_probe_value": 5600},
+            [
+                {"seq": 1, "t_wall": 1.0, "vars": {"ext_refuel_probe_value": 6200}},
+                {"seq": 2, "t_wall": 2.0, "vars": {"ext_refuel_probe_value": 5600}},
+            ],
+            "retracting",
+        ),
+    ]
+
+    for step_id, vars_map, frames, expected_word in cases:
+        packet = build_evidence_packet({"vars": vars_map, "telemetry_window_frames": frames})
+        plan = plan_harness_action(
+            step_specs={step_id: _spec(step_id, ("refuel_probe_switch",))},
+            inferred_step_id=step_id,
+            model_step_id=step_id,
+            proposed_overlay_targets=["refuel_probe_switch"],
+            candidate_step_ids=[step_id],
+            runtime_overlay_targets=["refuel_probe_switch"],
+            request_overlay_targets=["refuel_probe_switch"],
+            max_overlay_targets=1,
+            latest_vars=vars_map,
+            evidence_packet=packet,
+        )
+
+        assert plan.text_only is True
+        assert plan.targets == ()
+        assert expected_word in (plan.guidance or "")
+        assert plan.final_action_plan_source == "state_action_planner_wait"
+
+
+def test_plan_harness_action_clears_partial_s19_multi_target_plan() -> None:
+    plan = plan_harness_action(
+        step_specs={"S19": _spec("S19", ("fcs_bit_switch", "right_mdi_pb5"))},
+        inferred_step_id="S19",
+        model_step_id="S19",
+        proposed_overlay_targets=["right_mdi_pb5"],
+        candidate_step_ids=["S19"],
+        runtime_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        request_overlay_targets=["fcs_bit_switch", "right_mdi_pb5"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["fcsmc_intermediate_result_visible"],
+    )
+
+    assert plan.text_only is True
+    assert plan.targets == ()
+    assert "PB5" in (plan.guidance or "")
+    assert "target_dropped_by_max_overlay_targets:right_mdi_pb5" in plan.reasons

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -6013,6 +6013,83 @@ def test_harness_validation_action_plan_records_s26_repair_metadata() -> None:
         loop.close()
 
 
+def test_harness_validation_action_plan_waits_without_highlight_for_s20_probe_moving() -> None:
+    response = TutorResponse(
+        message="Extend the refuel probe.",
+        explanations=["Extend the refuel probe."],
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "refuel_probe_switch",
+                "element_id": "pnt_probe",
+            }
+        ],
+        metadata={
+            "next": {"step_id": "S20"},
+            "diagnosis": {"step_id": "S20", "error_category": "OM"},
+            "help_response": {
+                "diagnosis": {"step_id": "S20", "error_category": "OM"},
+                "next": {"step_id": "S20"},
+                "overlay": {
+                    "targets": ["refuel_probe_switch"],
+                    "evidence": [
+                        {
+                            "target": "refuel_probe_switch",
+                            "type": "gate",
+                            "ref": "GATES.S20.completion",
+                            "quote": "blocked",
+                        }
+                    ],
+                },
+                "explanations": ["Extend the refuel probe."],
+            },
+        },
+    )
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "vars": {
+                "probe_switch_value": 0,
+                "ext_refuel_probe_value": 12000,
+                "probe_extended": False,
+            },
+            "telemetry_window_frames": [
+                {"seq": 1, "t_wall": 1.0, "vars": {"ext_refuel_probe_value": 8000}},
+                {"seq": 2, "t_wall": 2.0, "vars": {"ext_refuel_probe_value": 12000}},
+            ],
+            "overlay_target_allowlist": ["refuel_probe_switch"],
+            "gates": {"S20.completion": {"status": "blocked"}},
+            "deterministic_step_hint": {
+                "inferred_step_id": "S20",
+                "overlay_step_id": "S20",
+                "missing_conditions": ["vars.ext_refuel_probe_value in [60000,65535]"],
+            },
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(Path("/dev/null")),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+    )
+    try:
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "state_action_planner_wait"
+        assert response.actions == []
+        assert response.metadata["harness_action_plan"]["text_only"] is True
+        assert response.metadata["final_action_plan_source"] == "state_action_planner_wait"
+        assert response.metadata["help_response"]["overlay"]["targets"] == []
+    finally:
+        loop.close()
+
+
 def test_harness_validation_action_plan_rewrites_manual_throttle_to_text_only() -> None:
     response = TutorResponse(
         message="Highlight throttle.",

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -6013,6 +6013,86 @@ def test_harness_validation_action_plan_records_s26_repair_metadata() -> None:
         loop.close()
 
 
+def test_harness_validation_action_plan_waits_without_highlight_for_s20_probe_moving() -> None:
+    response = TutorResponse(
+        message="Extend the refuel probe.",
+        explanations=["Extend the refuel probe."],
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "refuel_probe_switch",
+                "element_id": "pnt_probe",
+            }
+        ],
+        metadata={
+            "next": {"step_id": "S20"},
+            "diagnosis": {"step_id": "S20", "error_category": "OM"},
+            "help_response": {
+                "diagnosis": {"step_id": "S20", "error_category": "OM"},
+                "next": {"step_id": "S20"},
+                "overlay": {
+                    "targets": ["refuel_probe_switch"],
+                    "evidence": [
+                        {
+                            "target": "refuel_probe_switch",
+                            "type": "gate",
+                            "ref": "GATES.S20.completion",
+                            "quote": "blocked",
+                        }
+                    ],
+                },
+                "explanations": ["Extend the refuel probe."],
+            },
+        },
+    )
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "vars": {
+                "probe_switch_value": 0,
+                "ext_refuel_probe_value": 12000,
+                "probe_extended": False,
+            },
+            "telemetry_window_frames": [
+                {"seq": 1, "t_wall": 1.0, "vars": {"ext_refuel_probe_value": 8000}},
+                {"seq": 2, "t_wall": 2.0, "vars": {"ext_refuel_probe_value": 12000}},
+            ],
+            "overlay_target_allowlist": ["refuel_probe_switch"],
+            "gates": {"S20.completion": {"status": "blocked"}},
+            "deterministic_step_hint": {
+                "inferred_step_id": "S20",
+                "overlay_step_id": "S20",
+                "missing_conditions": ["vars.ext_refuel_probe_value in [60000,65535]"],
+            },
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(Path("/dev/null")),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+    )
+    try:
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "state_action_planner_wait"
+        assert response.actions == []
+        assert response.metadata["harness_action_plan"]["text_only"] is True
+        assert response.metadata["final_action_plan_source"] == "state_action_planner_wait"
+        assert response.metadata["help_response"]["overlay"]["targets"] == []
+        assert "正在伸出" in response.message
+        assert "manual_throttle_guidance_original_message" not in response.metadata
+        assert "manual_throttle_guidance_original_explanations" not in response.metadata
+    finally:
+        loop.close()
+
+
 def test_harness_validation_action_plan_rewrites_manual_throttle_to_text_only() -> None:
     response = TutorResponse(
         message="Highlight throttle.",


### PR DESCRIPTION
## Summary
- add state-aware harness action planning for S09 staged UFC input, S18 BIT-root PB5 repair, S19 intermediate/in-test handling, and S20/S21 moving-probe wait guidance
- pass latest vars, recent actions, and EvidencePacket into harness validation from live_dcs
- clear/text-only state plans when required targets are unavailable or multi-target plans would be partially highlighted

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_live_dcs.py -k 'harness_validation_action_plan or plan_harness_action or s09 or s18 or s19 or refuel_probe or manual_throttle'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #314