### PR TITLE
Add evidence snapshot trace consistency

### DIFF
--- a/core/evidence_packet.py
+++ b/core/evidence_packet.py
@@ -178,6 +178,19 @@ def _frame_vars_are_full_snapshot(raw: Mapping[str, Any]) -> bool:
     return isinstance(raw.get("vars"), Mapping) and not isinstance(raw.get("delta"), Mapping)
 
 
+def _frame_seq_range(frames: tuple[dict[str, Any], ...]) -> tuple[int | None, int | None]:
+    first_seq: int | None = None
+    latest_seq: int | None = None
+    for frame in frames:
+        seq = _coerce_int(frame.get("seq"))
+        if seq is None:
+            continue
+        if first_seq is None:
+            first_seq = seq
+        latest_seq = seq
+    return first_seq, latest_seq
+
+
 def _latest_frame_meta(frames: tuple[dict[str, Any], ...]) -> tuple[int | None, int | float | None]:
     latest_seq: int | None = None
     latest_t_wall: int | float | None = None
@@ -256,6 +269,7 @@ class TelemetryEvidence:
 class TelemetryWindowDigest:
     window_duration_s: float | None
     frame_count: int
+    first_seq: int | None
     latest_seq: int | None
     latest_t_wall: int | float | None
     changed_vars: tuple[dict[str, Any], ...]
@@ -270,6 +284,7 @@ class TelemetryWindowDigest:
         return {
             "window_duration_s": self.window_duration_s,
             "frame_count": self.frame_count,
+            "first_seq": self.first_seq,
             "latest_seq": self.latest_seq,
             "latest_t_wall": self.latest_t_wall,
             "changed_vars": [dict(item) for item in self.changed_vars],
@@ -285,6 +300,7 @@ class TelemetryWindowDigest:
         return {
             "window_duration_s": self.window_duration_s,
             "frame_count": self.frame_count,
+            "first_seq": self.first_seq,
             "latest_seq": self.latest_seq,
             "latest_t_wall": self.latest_t_wall,
             "changed_vars": [dict(item) for item in self.changed_vars[:12]],
@@ -299,6 +315,7 @@ class TelemetryWindowDigest:
     def compact_summary(self) -> dict[str, Any]:
         return {
             "frame_count": self.frame_count,
+            "first_seq": self.first_seq,
             "latest_seq": self.latest_seq,
             "changed_var_count": len(self.changed_vars),
             "contradiction_count": len(self.contradictions),
@@ -512,12 +529,16 @@ def _build_telemetry_evidence(context: Mapping[str, Any]) -> TelemetryEvidence:
     vision = vision_raw if isinstance(vision_raw, Mapping) else {}
     telemetry_raw = context.get("telemetry")
     telemetry = telemetry_raw if isinstance(telemetry_raw, Mapping) else {}
-    seq = _coerce_int(vision.get("observation_seq"))
+    telemetry_seq = _coerce_int(telemetry.get("observation_seq"))
+    vision_seq = _coerce_int(vision.get("observation_seq"))
+    seq = vision_seq
+    if seq is None:
+        seq = telemetry_seq
     t_wall = _coerce_number(telemetry.get("t_wall"))
 
     bootstrap_like = (
         missing_count >= 20
-        or (isinstance(seq, int) and seq <= 3)
+        or (isinstance(vision_seq, int) and vision_seq <= 3)
         or (
             vars_map.get("battery_on") is False
             and vars_map.get("power_available") is False
@@ -562,7 +583,8 @@ def _build_telemetry_window_digest(context: Mapping[str, Any]) -> TelemetryWindo
         )
 
     frame_tuple = tuple(frames)
-    latest_seq, latest_t_wall = _latest_frame_meta(frame_tuple)
+    first_seq, latest_seq = _frame_seq_range(frame_tuple)
+    _, latest_t_wall = _latest_frame_meta(frame_tuple)
     t_values = [frame["t_wall"] for frame in frame_tuple if _coerce_number(frame.get("t_wall")) is not None]
     window_duration_s = None
     if len(t_values) >= 2:
@@ -711,6 +733,7 @@ def _build_telemetry_window_digest(context: Mapping[str, Any]) -> TelemetryWindo
     return TelemetryWindowDigest(
         window_duration_s=window_duration_s,
         frame_count=len(frame_tuple),
+        first_seq=first_seq,
         latest_seq=latest_seq,
         latest_t_wall=latest_t_wall,
         changed_vars=tuple(changed_vars[:24]),

--- a/core/live_replay_fixture.py
+++ b/core/live_replay_fixture.py
@@ -33,6 +33,17 @@ def _as_list(raw: Any) -> list[Any]:
     return list(raw) if isinstance(raw, list) else []
 
 
+def _merged_dicts(*sources: Any) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        for key, value in source.items():
+            if isinstance(key, str) and value is not None:
+                merged[key] = value
+    return merged
+
+
 def _nonempty_text(raw: Any) -> str | None:
     if not isinstance(raw, str):
         return None
@@ -321,6 +332,19 @@ def extract_live_replay_fixture(
     trace = _as_mapping(response_metadata.get("harness_trace"))
     if not evidence_packet_summary:
         evidence_packet_summary = _as_dict(trace.get("evidence_packet_summary"))
+    request_metadata = _as_mapping(request_payload.get("metadata"))
+    evidence_snapshot = _merged_dicts(
+        response_metadata.get("evidence_snapshot"),
+        request_metadata.get("evidence_snapshot"),
+        request_context.get("evidence_snapshot"),
+        trace.get("evidence_snapshot"),
+    )
+    snapshot_ids = _merged_dicts(
+        response_metadata.get("snapshot_ids"),
+        request_metadata.get("snapshot_ids"),
+        request_context.get("snapshot_ids"),
+        trace.get("snapshot_ids"),
+    )
     telemetry_window_digest = _as_dict(evidence_packet_summary.get("telemetry_window_digest"))
 
     observation_ref = _nonempty_text(request_payload.get("observation_ref"))
@@ -402,6 +426,8 @@ def extract_live_replay_fixture(
                 "vision_facts": _as_list(response_metadata.get("vision_facts")),
             },
             "evidence_packet_summary": evidence_packet_summary,
+            "evidence_snapshot": evidence_snapshot,
+            "snapshot_ids": snapshot_ids,
             "telemetry_window_digest": telemetry_window_digest,
             "vision_fact_observations": [
                 _jsonable(dict(item)) for item in vision_fact_observations if isinstance(item, Mapping)

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -622,6 +622,8 @@ _SAFE_REQUEST_METADATA_FIELDS: tuple[str, ...] = (
     "state_harness_conflicts",
     "state_harness_telemetry_status",
     "evidence_packet_summary",
+    "evidence_snapshot",
+    "snapshot_ids",
     "help_cycle_id",
     "generation_mode",
     "vision_used",
@@ -646,6 +648,9 @@ def _sanitize_request_metadata_for_event(raw: Any) -> dict[str, Any]:
         value = raw.get(key)
         if key == "evidence_packet_summary":
             sanitized[key] = _sanitize_evidence_packet_summary_for_event(value)
+            continue
+        if key == "evidence_snapshot":
+            sanitized[key] = _sanitize_evidence_snapshot_for_event(value)
             continue
         if isinstance(value, Mapping):
             sanitized[key] = dict(value)
@@ -805,7 +810,7 @@ def _sanitize_telemetry_window_digest_for_event(raw: Any) -> dict[str, Any]:
             sanitized[key] = value
         elif value is None:
             sanitized[key] = None
-    for key in ("frame_count", "latest_seq"):
+    for key in ("frame_count", "first_seq", "latest_seq"):
         value = raw.get(key)
         if isinstance(value, int) and not isinstance(value, bool):
             sanitized[key] = value
@@ -964,11 +969,36 @@ def _sanitize_evidence_packet_summary_for_event(raw: Any) -> dict[str, Any]:
         sanitized["telemetry_window_digest"] = {
             key: value
             for key, value in telemetry_window_digest.items()
-            if key in {"frame_count", "latest_seq", "changed_var_count", "contradiction_count"}
+            if key in {"frame_count", "first_seq", "latest_seq", "changed_var_count", "contradiction_count"}
             and (isinstance(value, int) or value is None)
             and not isinstance(value, bool)
         }
     return sanitized
+
+
+def _sanitize_evidence_snapshot_for_event(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        return {}
+    allowed_keys = {
+        "schema_version",
+        "snapshot_id",
+        "source_observation_id",
+        "source_observation_seq",
+        "source_observation_t_wall",
+        "telemetry_window_frame_count",
+        "telemetry_window_first_seq",
+        "telemetry_window_latest_seq",
+        "telemetry_window_latest_t_wall",
+        "candidate_generation_snapshot_id",
+        "model_request_snapshot_id",
+        "validator_snapshot_id",
+        "final_decision_snapshot_id",
+    }
+    return {
+        key: _copy_event_field(value)
+        for key, value in raw.items()
+        if key in allowed_keys
+    }
 
 
 def _sanitize_request_context_for_event(raw: Any) -> dict[str, Any]:
@@ -993,6 +1023,11 @@ def _sanitize_request_context_for_event(raw: Any) -> dict[str, Any]:
         sanitized["evidence_packet_summary"] = _sanitize_evidence_packet_summary_for_event(
             raw.get("evidence_packet_summary")
         )
+    if "evidence_snapshot" in raw:
+        sanitized["evidence_snapshot"] = _sanitize_evidence_snapshot_for_event(raw.get("evidence_snapshot"))
+    if "snapshot_ids" in raw:
+        snapshot_ids = raw.get("snapshot_ids")
+        sanitized["snapshot_ids"] = dict(snapshot_ids) if isinstance(snapshot_ids, Mapping) else {}
     if "vision" in raw:
         sanitized["vision"] = _sanitize_vision_context_for_event(raw.get("vision"))
     if "vision_facts" in raw:
@@ -1294,6 +1329,65 @@ def _stable_hash_json(data: Mapping[str, Any]) -> str:
         default=str,
     ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _snapshot_ids_from_evidence_snapshot(raw: Mapping[str, Any] | None) -> dict[str, Any]:
+    snapshot = raw if isinstance(raw, Mapping) else {}
+    snapshot_id = snapshot.get("snapshot_id")
+    ids = {
+        "candidate_generation": snapshot.get("candidate_generation_snapshot_id") or snapshot_id,
+        "model_request": snapshot.get("model_request_snapshot_id") or snapshot_id,
+        "validator": snapshot.get("validator_snapshot_id") or snapshot_id,
+        "final_decision": snapshot.get("final_decision_snapshot_id") or snapshot_id,
+    }
+    return {key: value for key, value in ids.items() if isinstance(value, str) and value}
+
+
+def _build_evidence_snapshot(
+    *,
+    observation_id: str | None,
+    observation_seq: int | None,
+    observation_t_wall: float | None,
+    telemetry_window_digest: Mapping[str, Any],
+) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "schema_version": "evidence_snapshot.v1",
+        "source_observation_id": observation_id,
+        "source_observation_seq": observation_seq,
+        "source_observation_t_wall": observation_t_wall,
+        "telemetry_window_frame_count": telemetry_window_digest.get("frame_count"),
+        "telemetry_window_first_seq": telemetry_window_digest.get("first_seq"),
+        "telemetry_window_latest_seq": telemetry_window_digest.get("latest_seq"),
+        "telemetry_window_latest_t_wall": telemetry_window_digest.get("latest_t_wall"),
+    }
+    snapshot_id = _stable_hash_json(base)
+    base["snapshot_id"] = snapshot_id
+    base["candidate_generation_snapshot_id"] = snapshot_id
+    base["model_request_snapshot_id"] = snapshot_id
+    base["validator_snapshot_id"] = snapshot_id
+    base["final_decision_snapshot_id"] = snapshot_id
+    return base
+
+
+def _deterministic_hint_consistency(
+    *,
+    request_hint: Any,
+    response_hint: Any,
+    evidence_snapshot: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(response_hint, Mapping):
+        return {"deterministic_hint_matches_request": True}
+    if not isinstance(request_hint, Mapping):
+        return {"deterministic_hint_matches_request": False}
+
+    keys = ("inferred_step_id", "overlay_step_id", "missing_conditions")
+    matches = all(response_hint.get(key) == request_hint.get(key) for key in keys)
+    result = {"deterministic_hint_matches_request": matches}
+    if not matches:
+        snapshot_id = evidence_snapshot.get("model_request_snapshot_id") or evidence_snapshot.get("snapshot_id")
+        if isinstance(snapshot_id, str) and snapshot_id:
+            result["superseded_by_snapshot"] = snapshot_id
+    return result
 
 
 def _coerce_float(value: Any) -> float | None:
@@ -1889,6 +1983,25 @@ def _build_harness_trace_metadata(
 ) -> dict[str, Any]:
     context = request.context if isinstance(request.context, Mapping) else {}
     response_metadata = response.metadata if isinstance(response.metadata, Mapping) else {}
+    evidence_snapshot = (
+        dict(context.get("evidence_snapshot"))
+        if isinstance(context.get("evidence_snapshot"), Mapping)
+        else {}
+    )
+    snapshot_ids = _snapshot_ids_from_evidence_snapshot(evidence_snapshot)
+    hint_consistency = _deterministic_hint_consistency(
+        request_hint=context.get("deterministic_step_hint"),
+        response_hint=response_metadata.get("deterministic_step_hint"),
+        evidence_snapshot=evidence_snapshot,
+    )
+    if (
+        hint_consistency.get("deterministic_hint_matches_request") is False
+        and isinstance(response_metadata.get("deterministic_step_hint"), Mapping)
+    ):
+        response.metadata["deterministic_step_hint"] = dict(response_metadata["deterministic_step_hint"])
+        superseded_by = hint_consistency.get("superseded_by_snapshot")
+        if isinstance(superseded_by, str) and superseded_by:
+            response.metadata["deterministic_step_hint"]["superseded_by_snapshot"] = superseded_by
     raw_candidates = context.get("candidate_steps")
     candidates = [
         candidate
@@ -1921,6 +2034,19 @@ def _build_harness_trace_metadata(
     else:
         final_plan.setdefault("targets", list(final_targets))
         final_plan.setdefault("source", response_metadata.get("final_action_plan_source"))
+    original_final_snapshot_id = final_plan.get("evidence_snapshot_id")
+    final_snapshot_id = snapshot_ids.get("final_decision")
+    if isinstance(final_snapshot_id, str) and final_snapshot_id:
+        if (
+            isinstance(original_final_snapshot_id, str)
+            and original_final_snapshot_id
+            and original_final_snapshot_id != final_snapshot_id
+        ):
+            hint_consistency["final_action_plan_matches_snapshot"] = False
+            hint_consistency["final_action_plan_superseded_by_snapshot"] = final_snapshot_id
+        else:
+            hint_consistency.setdefault("final_action_plan_matches_snapshot", True)
+        final_plan["evidence_snapshot_id"] = final_snapshot_id
 
     chosen_step_id = final_plan.get("step_id")
     chosen_candidate = None
@@ -1958,6 +2084,9 @@ def _build_harness_trace_metadata(
     trace = {
         "schema_version": "v1",
         "evidence_packet_summary": dict(context.get("evidence_packet_summary", {})),
+        "evidence_snapshot": evidence_snapshot,
+        "snapshot_ids": snapshot_ids,
+        "evidence_snapshot_consistency": hint_consistency,
         "candidates": candidates,
         "chosen_candidate": chosen_candidate,
         "rejected_candidates": rejected_candidates,
@@ -1994,6 +2123,9 @@ def _build_harness_trace_metadata(
     response.metadata["vlm_call_status"] = vlm_call["status"]
     response.metadata["vlm_call_reason"] = vlm_call["reason"]
     response.metadata["final_overlay_targets"] = list(final_targets)
+    response.metadata["evidence_snapshot"] = dict(evidence_snapshot)
+    response.metadata["snapshot_ids"] = dict(snapshot_ids)
+    response.metadata["evidence_snapshot_consistency"] = dict(hint_consistency)
     response.metadata["final_action_plan"] = dict(final_plan)
     response.metadata["harness_trace"] = trace
     return trace
@@ -3912,6 +4044,7 @@ class LiveDcsTutorLoop:
         vision_context["main_help_multimodal_attached"] = False
 
         now_t_wall = _coerce_float(payload.get("t_wall"))
+        observation_seq = _coerce_int(payload.get("seq"))
         recent_frames = self.recent_ring.snapshot(now_t_wall=now_t_wall) if now_t_wall is not None else self.recent_ring.snapshot()
         telemetry_window_frames_raw = (
             self.telemetry_window_ring.snapshot(now_t_wall=now_t_wall)
@@ -4043,7 +4176,15 @@ class LiveDcsTutorLoop:
             "recent_actions": recent_actions,
             "telemetry_window_frames": telemetry_window_frames,
             "deterministic_step_hint": deterministic_hint,
-            "telemetry": {"t_wall": now_t_wall} if now_t_wall is not None else {},
+            "telemetry": {
+                key: value
+                for key, value in {
+                    "t_wall": now_t_wall,
+                    "observation_seq": observation_seq,
+                    "observation_id": obs.observation_id,
+                }.items()
+                if value is not None
+            },
             "vision": vision_context,
             "vision_facts": list(vision_fact_context.get("vision_facts", [])),
             "vision_fact_summary": dict(vision_fact_context.get("vision_fact_summary", {})),
@@ -4051,6 +4192,18 @@ class LiveDcsTutorLoop:
         evidence_packet = build_evidence_packet(preliminary_harness_context)
         state_harness = evidence_packet.to_state_harness_dict()
         evidence_packet_summary = evidence_packet.compact_summary()
+        state_window_digest = (
+            state_harness.get("telemetry_window_digest")
+            if isinstance(state_harness.get("telemetry_window_digest"), Mapping)
+            else {}
+        )
+        evidence_snapshot = _build_evidence_snapshot(
+            observation_id=obs.observation_id,
+            observation_seq=observation_seq,
+            observation_t_wall=now_t_wall,
+            telemetry_window_digest=state_window_digest,
+        )
+        snapshot_ids = _snapshot_ids_from_evidence_snapshot(evidence_snapshot)
         candidate_step_payload = [
             candidate.to_dict()
             for candidate in build_step_candidates(
@@ -4104,6 +4257,8 @@ class LiveDcsTutorLoop:
             "overlay_target_allowlist": overlay_target_allowlist,
             "state_harness": state_harness,
             "evidence_packet_summary": evidence_packet_summary,
+            "evidence_snapshot": evidence_snapshot,
+            "snapshot_ids": snapshot_ids,
             "deterministic_step_hint": deterministic_hint,
             "scenario_profile": self.scenario_profile,
             "rag_topk": rag_topk,
@@ -4169,6 +4324,8 @@ class LiveDcsTutorLoop:
                     else None
                 ),
                 "evidence_packet_summary": evidence_packet_summary,
+                "evidence_snapshot": evidence_snapshot,
+                "snapshot_ids": snapshot_ids,
             },
         )
 

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -742,13 +742,29 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
     }
     telemetry_window_digest = request.context["state_harness"]["telemetry_window_digest"]
     assert telemetry_window_digest["frame_count"] >= 1
+    assert telemetry_window_digest["first_seq"] == 0
     assert telemetry_window_digest["latest_seq"] == 1
     assert "telemetry_window_digest" in request.context["evidence_packet_summary"]
     assert isinstance(request.context["evidence_packet_summary"]["blocked_gate_count"], int)
     assert request.metadata["evidence_packet_summary"] == request.context["evidence_packet_summary"]
+    evidence_snapshot = request.context["evidence_snapshot"]
+    assert evidence_snapshot["source_observation_seq"] == 1
+    assert evidence_snapshot["telemetry_window_latest_seq"] == 1
+    assert evidence_snapshot["candidate_generation_snapshot_id"]
+    assert (
+        request.metadata["evidence_snapshot"]["model_request_snapshot_id"]
+        == evidence_snapshot["model_request_snapshot_id"]
+    )
     tutor_request_payload = next(event.payload for event in events if event.kind == "tutor_request")
     assert tutor_request_payload["context"]["evidence_packet_summary"] == request.context["evidence_packet_summary"]
     assert tutor_request_payload["metadata"]["evidence_packet_summary"] == request.context["evidence_packet_summary"]
+    assert tutor_request_payload["context"]["evidence_snapshot"]["source_observation_seq"] == 1
+    assert tutor_request_payload["metadata"]["evidence_snapshot"]["source_observation_seq"] == 1
+    assert (
+        tutor_request_payload["context"]["snapshot_ids"]["candidate_generation"]
+        == evidence_snapshot["candidate_generation_snapshot_id"]
+    )
+    assert tutor_request_payload["context"]["state_harness"]["telemetry_window_digest"]["first_seq"] == 0
     assert request.context["overlay_target_allowlist"] == ["apu_switch"]
 
     tutor_response_payload = next(event.payload for event in events if event.kind == "tutor_response")
@@ -756,6 +772,12 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
     trace = response_meta["harness_trace"]
     assert trace["schema_version"] == "v1"
     assert trace["evidence_packet_summary"] == request.context["evidence_packet_summary"]
+    assert trace["evidence_snapshot"] == request.context["evidence_snapshot"]
+    assert trace["snapshot_ids"]["candidate_generation"] == evidence_snapshot["candidate_generation_snapshot_id"]
+    assert trace["snapshot_ids"]["model_request"] == evidence_snapshot["model_request_snapshot_id"]
+    assert trace["snapshot_ids"]["validator"] == evidence_snapshot["validator_snapshot_id"]
+    assert trace["snapshot_ids"]["final_decision"] == evidence_snapshot["final_decision_snapshot_id"]
+    assert trace["final_action_plan"]["evidence_snapshot_id"] == evidence_snapshot["final_decision_snapshot_id"]
     assert trace["candidates"][0]["step_id"] == candidate_steps[0]["step_id"]
     assert trace["model_decision"]["step_id"] == "S03"
     assert trace["final_overlay_targets"] == ["apu_switch"]
@@ -767,6 +789,148 @@ def test_live_loop_offline_single_sample_runs_help_response_and_actions(tmp_path
     assert len(executor.calls[0]) == 1
     assert executor.calls[0][0]["type"] == "overlay"
     assert executor.calls[0][0]["target"] == "apu_switch"
+    assert "evidence_snapshot" not in executor.calls[0][0]
+    assert "snapshot_ids" not in executor.calls[0][0]
+
+
+def test_harness_trace_marks_response_hint_superseded_when_snapshot_differs() -> None:
+    request = TutorRequest(
+        request_id="cycle-315",
+        actor="learner",
+        intent="help",
+        message="help",
+        observation_ref="obs-new",
+        context={
+            "candidate_steps": [{"step_id": "S09", "source": "deterministic"}],
+            "evidence_packet_summary": {"telemetry_status": "nominal"},
+            "evidence_snapshot": {
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "snapshot-new",
+                "source_observation_id": "obs-new",
+                "source_observation_seq": 20,
+                "telemetry_window_latest_seq": 20,
+                "candidate_generation_snapshot_id": "snapshot-new",
+                "model_request_snapshot_id": "snapshot-new",
+                "validator_snapshot_id": "snapshot-new",
+                "final_decision_snapshot_id": "snapshot-new",
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+            },
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        message="Tune COMM1.",
+        actions=[{"type": "overlay", "target": "ufc_key_1"}],
+        explanations=["Tune COMM1."],
+        metadata={
+            "generation_mode": "model",
+            "deterministic_step_hint": {
+                "inferred_step_id": "S08",
+                "missing_conditions": ["vision_facts.fcs_page_visible==seen"],
+            },
+            "harness_action_plan": {
+                "step_id": "S09",
+                "targets": ["ufc_key_1"],
+                "source": "model",
+                "evidence_snapshot_id": "snapshot-old",
+            },
+            "help_response": {
+                "next": {"step_id": "S09"},
+                "overlay": {"targets": ["ufc_key_1"], "evidence": []},
+            },
+        },
+    )
+
+    trace = _build_harness_trace_metadata(
+        request=request,
+        response=response,
+        vision_selection=HelpCycleVisionSelection(
+            status="vision_not_required",
+            observation_ref=None,
+            observation_seq=20,
+            observation_t_wall_s=20.0,
+            observation_t_wall_ms=20000,
+            trigger_wall_ms=20000,
+            sync_window_ms=250,
+            vision_used=False,
+            frame_id=None,
+            sync_status="not_required",
+            sync_delta_ms=None,
+            frame_stale=None,
+            frame_ids=[],
+            selected_frames=[],
+            pre_trigger_frame=None,
+            trigger_frame=None,
+            sync_miss_reason=None,
+        ),
+        vision_fact_context={"status": "vision_not_required", "vision_fact_summary": {}, "vision_facts": []},
+    )
+
+    assert response.metadata["deterministic_step_hint"]["superseded_by_snapshot"] == "snapshot-new"
+    assert response.metadata["evidence_snapshot_consistency"]["deterministic_hint_matches_request"] is False
+    assert response.metadata["evidence_snapshot_consistency"]["final_action_plan_matches_snapshot"] is False
+    assert (
+        response.metadata["evidence_snapshot_consistency"]["final_action_plan_superseded_by_snapshot"]
+        == "snapshot-new"
+    )
+    assert trace["evidence_snapshot_consistency"]["deterministic_hint_matches_request"] is False
+    assert trace["final_action_plan"]["evidence_snapshot_id"] == "snapshot-new"
+
+
+def test_harness_trace_uses_empty_snapshot_ids_when_snapshot_is_absent() -> None:
+    request = TutorRequest(
+        request_id="legacy-cycle",
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "candidate_steps": [{"step_id": "S03", "source": "deterministic"}],
+            "deterministic_step_hint": {"inferred_step_id": "S03", "missing_conditions": []},
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        message="Start APU.",
+        actions=[{"type": "overlay", "target": "apu_switch"}],
+        explanations=["Start APU."],
+        metadata={
+            "generation_mode": "model",
+            "harness_action_plan": {"step_id": "S03", "targets": ["apu_switch"], "source": "model"},
+            "help_response": {"next": {"step_id": "S03"}, "overlay": {"targets": ["apu_switch"]}},
+        },
+    )
+
+    trace = _build_harness_trace_metadata(
+        request=request,
+        response=response,
+        vision_selection=HelpCycleVisionSelection(
+            status="vision_not_required",
+            observation_ref=None,
+            observation_seq=None,
+            observation_t_wall_s=None,
+            observation_t_wall_ms=None,
+            trigger_wall_ms=1000,
+            sync_window_ms=250,
+            vision_used=False,
+            frame_id=None,
+            sync_status="not_required",
+            sync_delta_ms=None,
+            frame_stale=None,
+            frame_ids=[],
+            selected_frames=[],
+            pre_trigger_frame=None,
+            trigger_frame=None,
+            sync_miss_reason=None,
+        ),
+        vision_fact_context={"status": "vision_not_required", "vision_fact_summary": {}, "vision_facts": []},
+    )
+
+    assert trace["snapshot_ids"] == {}
+    assert response.metadata["snapshot_ids"] == {}
+    assert "evidence_snapshot_id" not in trace["final_action_plan"]
 
 
 def test_live_loop_telemetry_window_uses_canonical_vars_not_raw_delta_keys(tmp_path: Path) -> None:

--- a/tests/test_live_replay_fixture.py
+++ b/tests/test_live_replay_fixture.py
@@ -57,12 +57,40 @@ def _sample_cycle_events(request_id: str = "req-288") -> list[dict[str, Any]]:
                 "step_id": "S03",
                 "telemetry_window_digest": {"frame_count": 2, "status": "ok"},
             },
+            "evidence_snapshot": {
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "snapshot-288",
+                "source_observation_id": observation_id,
+                "source_observation_seq": 1,
+                "telemetry_window_first_seq": 1,
+                "telemetry_window_latest_seq": 2,
+                "candidate_generation_snapshot_id": "snapshot-288",
+                "model_request_snapshot_id": "snapshot-288",
+                "validator_snapshot_id": "snapshot-288",
+                "final_decision_snapshot_id": "snapshot-288",
+            },
+            "snapshot_ids": {
+                "candidate_generation": "snapshot-288",
+                "model_request": "snapshot-288",
+            },
             "vision_fact_summary": {"seen_fact_ids": ["apu_ready_light"], "frame_ids": ["frame-1"]},
         },
         "metadata": {
             "help_cycle_id": help_cycle_id,
             "vision_fact_status": "available",
             "vision_frame_ids": ["frame-1"],
+            "evidence_snapshot": {
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "snapshot-288",
+                "source_observation_id": observation_id,
+                "source_observation_seq": 1,
+                "telemetry_window_first_seq": 1,
+                "telemetry_window_latest_seq": 2,
+                "candidate_generation_snapshot_id": "snapshot-288",
+                "model_request_snapshot_id": "snapshot-288",
+                "validator_snapshot_id": "snapshot-288",
+                "final_decision_snapshot_id": "snapshot-288",
+            },
         },
     }
     response_payload = {
@@ -82,6 +110,24 @@ def _sample_cycle_events(request_id: str = "req-288") -> list[dict[str, Any]]:
             },
             "harness_trace": {
                 "schema_version": "v1",
+                "evidence_snapshot": {
+                    "schema_version": "evidence_snapshot.v1",
+                    "snapshot_id": "snapshot-288",
+                    "source_observation_id": observation_id,
+                    "source_observation_seq": 1,
+                    "telemetry_window_first_seq": 1,
+                    "telemetry_window_latest_seq": 2,
+                    "candidate_generation_snapshot_id": "snapshot-288",
+                    "model_request_snapshot_id": "snapshot-288",
+                    "validator_snapshot_id": "snapshot-288",
+                    "final_decision_snapshot_id": "snapshot-288",
+                },
+                "snapshot_ids": {
+                    "candidate_generation": "snapshot-288",
+                    "model_request": "snapshot-288",
+                    "validator": "snapshot-288",
+                    "final_decision": "snapshot-288",
+                },
                 "evidence_packet_summary": {
                     "step_id": "S03",
                     "telemetry_window_digest": {"frame_count": 2, "status": "ok"},
@@ -128,6 +174,13 @@ def test_extract_live_replay_fixture_from_request_id_includes_harness_path(tmp_p
     assert fixture["cycle"]["tutor_response"]["in_reply_to"] == "req-288"
     assert fixture["context"]["evidence_packet_summary"]["step_id"] == "S03"
     assert fixture["context"]["telemetry_window_digest"] == {"frame_count": 2, "status": "ok"}
+    assert fixture["context"]["evidence_snapshot"]["source_observation_seq"] == 1
+    assert fixture["context"]["snapshot_ids"] == {
+        "candidate_generation": "snapshot-288",
+        "model_request": "snapshot-288",
+        "validator": "snapshot-288",
+        "final_decision": "snapshot-288",
+    }
     assert fixture["harness"]["candidate_steps"][0]["step_id"] == "S03"
     assert fixture["harness"]["trace"]["validator_result"]["rejected"] is False
     assert fixture["expectations"] == {


### PR DESCRIPTION
## Summary
- add evidence snapshot identity to live request context, request/response metadata, harness trace, and final action plans
- preserve snapshot fields in live replay fixture extraction, including partial legacy fallbacks
- add trace consistency checks for stale deterministic hints and stale final action plan snapshot ids

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_replay_fixture.py tests/test_live_dcs.py::test_live_loop_offline_single_sample_runs_help_response_and_actions tests/test_live_dcs.py::test_harness_trace_marks_response_hint_superseded_when_snapshot_differs tests/test_live_dcs.py::test_harness_trace_uses_empty_snapshot_ids_when_snapshot_is_absent tests/test_evidence_packet.py tests/test_help_cycle_audit.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #315