### PR TITLE
Add replay eval fixture sources for CI

### DIFF
--- a/artifacts/live_fixtures/644fac65-eb37-4de1-a591-fd1de392c647.fixture.json
+++ b/artifacts/live_fixtures/644fac65-eb37-4de1-a591-fd1de392c647.fixture.json
@@ -1,0 +1,4083 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 1,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 1,
+        "contradiction_count": 0,
+        "frame_count": 20,
+        "latest_seq": 9824
+      },
+      "vision_fresh_count": 6,
+      "vision_seen_count": 6,
+      "vision_status": "available"
+    },
+    "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:59431",
+          "raw_delta_count": 1,
+          "seq": 9824
+        },
+        "observation_id": "632353de-03a7-49bd-883d-4c8c17969c2b",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41565
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 9824,
+          "t_wall": 1779045062.6004815,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 296,
+            "temp_r": 296,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-17T19:11:02.600481+00:00",
+        "version": "v1"
+      }
+    ],
+    "telemetry_window_digest": {
+      "changed_var_count": 1,
+      "contradiction_count": 0,
+      "frame_count": 20,
+      "latest_seq": 9824
+    },
+    "vision": {
+      "frame_ids": [
+        "1779045062695_000060"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779045062695_000060",
+        "frame_ids": [
+          "1779045062695_000060"
+        ],
+        "frame_stale": false,
+        "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+        "observation_seq": 9824,
+        "observation_t_wall_ms": 1779045062600,
+        "observation_t_wall_s": 1779045062.6004815,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779045062695,
+            "channel": "composite_panel",
+            "frame_id": "1779045062695_000060",
+            "frame_seq": 60,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045062695_000060_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045062695_000060.png",
+            "sync_delta_ms": 92,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 92,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779045062695,
+          "channel": "composite_panel",
+          "frame_id": "1779045062695_000060",
+          "frame_seq": 60,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045062695_000060_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045062695_000060.png",
+          "sync_delta_ms": 92,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779045062603,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779045062695_000060"
+        ],
+        "fresh_fact_ids": [
+          "fcs_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "not_seen_fact_ids": [
+          "tac_page_visible",
+          "supt_page_visible",
+          "fcs_page_x_marks_visible",
+          "fcsmc_page_visible",
+          "fcsmc_intermediate_result_visible",
+          "fcsmc_in_test_visible",
+          "fcsmc_final_go_result_visible"
+        ],
+        "seen_fact_ids": [
+          "fcs_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "status": "available",
+        "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": [
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "tac_page_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "supt_page_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "fcs_page_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "fcs_page_x_marks_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "bit_root_page_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "fcsmc_page_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "fcsmc_intermediate_result_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "fcsmc_in_test_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 600000,
+          "expires_at_wall_ms": 1779045662603,
+          "fact_id": "fcsmc_final_go_result_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "not_seen",
+          "sticky": true
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "hsi_page_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "hsi_map_layer_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "ins_grnd_alignment_text_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045064603,
+          "fact_id": "ins_ok_text_visible",
+          "observed_at_wall_ms": 1779045062603,
+          "source_frame_id": "1779045062695_000060",
+          "state": "seen",
+          "sticky": false
+        }
+      ]
+    },
+    "vision_fact_observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "frame_ids": [
+            "1779045062695_000060"
+          ],
+          "observation_kind": "vision_fact"
+        },
+        "observation_id": "94cc6830-d10f-48b0-9fd4-1ca53c185941",
+        "payload": {
+          "facts": [
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "tac_page_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "supt_page_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_x_marks_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "bit_root_page_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_page_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_intermediate_result_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_in_test_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 600000,
+              "fact_id": "fcsmc_final_go_result_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "not_seen",
+              "sticky": true
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_page_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_map_layer_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_grnd_alignment_text_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_ok_text_visible",
+              "observed_at_wall_ms": 1779045062603,
+              "result_kind": null,
+              "source_frame_id": "1779045062695_000060",
+              "state": "seen",
+              "sticky": false
+            }
+          ],
+          "frame_ids": [
+            "1779045062695_000060"
+          ],
+          "metadata": {
+            "coerced_source_frame_fact_ids": [],
+            "coerced_source_frame_fact_ids_alias_of": "ignored_legacy_source_frame_fact_ids",
+            "configured_fact_count": 13,
+            "ignored_legacy_source_frame_fact_ids": [],
+            "ignored_model_fact_fields": {},
+            "raw_fact_count": 13,
+            "raw_llm_text": "{\"facts\":[{\"fact_id\":\"tac_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"supt_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_x_marks_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"bit_root_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_intermediate_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_in_test_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_final_go_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_map_layer_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_grnd_alignment_text_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_ok_text_visible\",\"state\":\"seen\",\"evidence_note\":\"\"}]}",
+            "sanitized_fact_count": 13,
+            "skipped_incomplete_mapping_fact_count": 0,
+            "skipped_non_mapping_fact_count": 0,
+            "skipped_unknown_fact_id_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045062695_000060"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+              "uncertain_fact_ids": []
+            }
+          },
+          "observation_id": "94cc6830-d10f-48b0-9fd4-1ca53c185941",
+          "schema_version": "v2",
+          "session_id": "sess-live",
+          "source": "vision_fact_extractor",
+          "summary": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+          "timestamp": "2026-05-17T19:11:09.515912+00:00",
+          "trigger_wall_ms": 1779045062603
+        },
+        "procedure_hint": null,
+        "source": "vision_fact_extractor",
+        "tags": [],
+        "timestamp": "2026-05-17T19:11:09.515912+00:00",
+        "version": "v1"
+      }
+    ]
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "kind": "tutor_request",
+        "lineno": 10258,
+        "metadata": {
+          "frame_id": "1779045062695_000060",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 92,
+          "vision_fact_extractor_used": true,
+          "vision_fact_status": "available",
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "right_mdi_pb5"
+              },
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S18",
+              "missing_conditions_count": 1,
+              "observability": "partial",
+              "observability_status": "partial",
+              "overlay_step_id": "S18",
+              "recent_ui_targets": [
+                "takeoff_trim_button"
+              ],
+              "requires_visual_confirmation": true,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 9824
+              },
+              "vision_fresh_count": 6,
+              "vision_seen_count": 6,
+              "vision_status": "available"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 24.051345417769785,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_105",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 106,
+                "score": 20.74820609602476,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_105"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_10",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "3. Step Criticality",
+                "score": 20.169931721198378,
+                "section": "3. Step Criticality",
+                "snippet_id": "fa18c_error_coding_guide_10"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_12",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q12. Sequence Mini-Task 2",
+                "score": 18.21894244493854,
+                "section": "Q12. Sequence Mini-Task 2",
+                "snippet_id": "fa18c_coldstart_quiz_12"
+              },
+              {
+                "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+                "doc_id": "fa18c_fcs_bit_procedure_note",
+                "score": 18.196064173149253,
+                "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vision_facts.fcsmc_page_visible==seen"
+                ],
+                "overlay_step_id": "S18",
+                "role": "candidate_not_authoritative",
+                "step_id": "S18"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 9824,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": true,
+                    "last_value": false,
+                    "latest_transition_age_s": 0.89,
+                    "transition_count": 1,
+                    "var": "takeoff_trim_pressed"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9824,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 9824,
+                "latest_t_wall": 1779045062.6004815,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.928
+              },
+              "vision_evidence": {
+                "confidence": "high",
+                "fresh_fact_ids": [
+                  "bit_root_page_visible",
+                  "fcs_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "late_display_anchors": [
+                  "bit_root_page_visible",
+                  "fcs_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_page_visible",
+                  "supt_page_visible",
+                  "tac_page_visible"
+                ],
+                "seen_fact_ids": [
+                  "bit_root_page_visible",
+                  "fcs_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "source_status": "available",
+                "visual_candidate_steps": [
+                  "S08",
+                  "S09",
+                  "S12",
+                  "S13"
+                ]
+              }
+            },
+            "vision": {
+              "frame_id": "1779045062695_000060",
+              "frame_ids": [
+                "1779045062695_000060"
+              ],
+              "frame_stale": false,
+              "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+              "observation_seq": 9824,
+              "observation_t_wall_ms": 1779045062600,
+              "observation_t_wall_s": 1779045062.6004815,
+              "status": "partial",
+              "sync_delta_ms": 92,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779045062603,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045062695_000060"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "fact_id": "tac_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "supt_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_x_marks_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "bit_root_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_in_test_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_map_layer_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_ok_text_visible",
+                "frame_ids": null,
+                "status": null
+              }
+            ]
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 9824
+              },
+              "vision_fresh_count": 6,
+              "vision_seen_count": 6,
+              "vision_status": "available"
+            },
+            "frame_id": "1779045062695_000060",
+            "fused_missing_conditions": [
+              "vision_facts.fcsmc_page_visible==seen"
+            ],
+            "fused_step_id": "S18",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_startup_master_1"
+            ],
+            "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+            "prompt_tokens_est": 1134,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "source_chunk_refs": [
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_105",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_12",
+              "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 92,
+            "vision_fact_seen_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045062695_000060"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779045062695_000060"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+          "request_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "timestamp": "2026-05-17T19:11:09.548436+00:00",
+          "version": "v1"
+        },
+        "related_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "vision_refs": [
+          "1779045062695_000060"
+        ]
+      },
+      {
+        "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "kind": "overlay_requested",
+        "lineno": 10259,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779045062695_000060",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 92,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "e4a2e205-effd-4c66-a329-1826b6278e11",
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779045062695_000060",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 92,
+          "target": "pnt_234",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "kind": "overlay_requested",
+        "lineno": 10260,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779045062695_000060",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 92,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "67155107-0c4f-4bbd-abc5-44b8ae03a3d7",
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779045062695_000060",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 92,
+          "target": "pnt_96",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "kind": "tutor_response",
+        "lineno": 10261,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779045062695_000060",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 92,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_96",
+              "evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "right_mdi_pb18"
+              ],
+              "frame_id": "1779045062695_000060",
+              "fused_missing_conditions": [
+                "vision_facts.fcsmc_page_visible==seen"
+              ],
+              "fused_step_id": "S18",
+              "generation_mode": "model",
+              "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 92,
+              "target": "right_mdi_pb18",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779045062695_000060"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+            "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+          ],
+          "in_reply_to": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "message": "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+          "metadata": {
+            "allowed_evidence_ref_count": 131,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "ad311d68-a2cd-4f97-9771-2eecc2759a82",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S18",
+              "missing_conditions": [
+                "vision_facts.fcsmc_page_visible==seen"
+              ],
+              "observability": "partial",
+              "observability_status": "partial",
+              "recent_ui_targets": [
+                "takeoff_trim_button"
+              ],
+              "requires_visual_confirmation": true,
+              "step_evidence_requirements": [
+                "delta",
+                "gate",
+                "visual"
+              ],
+              "step_ui_targets": [
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ]
+            },
+            "diagnosis": {
+              "error_category": "CO",
+              "step_id": "S18"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_strength": "limited",
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "overlay_step_id": null,
+              "source": "model",
+              "step_id": "S18",
+              "targets": [
+                "right_mdi_pb18"
+              ],
+              "text_only": false
+            },
+            "final_overlay_targets": [
+              "right_mdi_pb18"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_96",
+                  "evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "right_mdi_pb18"
+                  ],
+                  "frame_id": "1779045062695_000060",
+                  "fused_missing_conditions": [
+                    "vision_facts.fcsmc_page_visible==seen"
+                  ],
+                  "fused_step_id": "S18",
+                  "generation_mode": "model",
+                  "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "model",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 92,
+                  "target": "right_mdi_pb18",
+                  "type": "overlay",
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779045062695_000060"
+                    ],
+                    "fresh_fact_ids": [
+                      "fcs_page_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "tac_page_visible",
+                      "supt_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible",
+                      "fcsmc_final_go_result_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "fcs_page_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+                "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+              ],
+              "message": "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+              "next": {
+                "step_id": "S18"
+              }
+            },
+            "frame_id": "1779045062695_000060",
+            "fused_missing_conditions": [
+              "vision_facts.fcsmc_page_visible==seen"
+            ],
+            "fused_step_id": "S18",
+            "generation_mode": "model",
+            "generation_prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+            "generation_prompt_tokens_est": 1134,
+            "generation_prompt_trimmed": true,
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_brightness_selector",
+                    "right_mdi_brightness_selector",
+                    "ampcd_off_brightness_knob",
+                    "hud_symbology_brightness_knob",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15",
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.ins_ok_text_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.ins_ok_text_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.ins_ok_text_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.ins_ok_text_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S18",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "right_mdi_pb18",
+                  "right_mdi_pb5"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S18",
+                "supporting_evidence_refs": []
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 1,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 1,
+                  "contradiction_count": 0,
+                  "frame_count": 20,
+                  "latest_seq": 9824
+                },
+                "vision_fresh_count": 6,
+                "vision_seen_count": 6,
+                "vision_status": "available"
+              },
+              "final_action_plan": {
+                "overlay_step_id": null,
+                "source": "model",
+                "step_id": "S18",
+                "targets": [
+                  "right_mdi_pb18"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "right_mdi_pb18"
+              ],
+              "message_category": "model",
+              "model_decision": {
+                "evidence_refs": [
+                  "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "right_mdi_pb18"
+                ],
+                "status": "ok",
+                "step_id": "S18"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": false,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": null
+              },
+              "schema_version": "v1",
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "extractor_used": true,
+                "frame_ids": [
+                  "1779045062695_000060"
+                ],
+                "reason": "missing_pre_trigger_frame",
+                "status": "called",
+                "sync_delta_ms": 92,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "available",
+                "vision_status": "partial"
+              }
+            },
+            "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+              ],
+              "next": {
+                "step_id": "S18"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+                    "target": "right_mdi_pb18",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "right_mdi_pb18"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+              ],
+              "next": {
+                "step_id": "S18"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+                    "target": "right_mdi_pb18",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "right_mdi_pb18"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4976,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "model",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S18"
+            },
+            "model_raw_explanations": [
+              "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+              ],
+              "next": {
+                "step_id": "S18"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+                    "target": "right_mdi_pb18",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "right_mdi_pb18"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S18"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779045062695_000060"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779045062695_000060",
+            "next": {
+              "step_id": "S18"
+            },
+            "observability_status": "partial",
+            "prompt_budget_used": 5509,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "VISION_FACTS.tac_page_visible@1779045062695_000060",
+                "VISION_FACTS.supt_page_visible@1779045062695_000060"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 3,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "right_mdi_pb5",
+              "prompt_chars": 4534,
+              "prompt_tokens_est": 1134,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 1,
+              "rag_snippet_ids": [
+                "fa18c_startup_master_1"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [
+                "S08",
+                "S09",
+                "S12",
+                "S13"
+              ],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_overlay_enum",
+                "trimmed_rag_snippets",
+                "compact_template"
+              ],
+              "vision_fact_seen_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "vision_fact_status": "available"
+            },
+            "prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+            "prompt_tokens_est": 1134,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+            "request_prompt_tokens_est": 1134,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": true,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 131,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S18"
+              },
+              "evidence_strength": "limited",
+              "next": {
+                "step_id": "S18"
+              },
+              "observability_status": "partial",
+              "requires_visual_confirmation": true
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "state_key": "4cdcbec64e13f45f354882cc675b61de8be35a03b1f971de2affc68af69a89b4",
+            "sync_delta_ms": 92,
+            "vision": {
+              "frame_id": "1779045062695_000060",
+              "frame_ids": [
+                "1779045062695_000060"
+              ],
+              "frame_stale": false,
+              "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+              "observation_seq": 9824,
+              "observation_t_wall_ms": 1779045062600,
+              "observation_t_wall_s": 1779045062.6004815,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779045062695,
+                  "channel": "composite_panel",
+                  "frame_id": "1779045062695_000060",
+                  "frame_seq": 60,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045062695_000060_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045062695_000060.png",
+                  "sync_delta_ms": 92,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 92,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779045062695,
+                "channel": "composite_panel",
+                "frame_id": "1779045062695_000060",
+                "frame_seq": 60,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045062695_000060_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045062695_000060.png",
+                "sync_delta_ms": 92,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779045062603,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S08"
+            ],
+            "vision_fact_extractor_used": true,
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045062695_000060"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "tac_page_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "supt_page_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "fcs_page_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "fcs_page_x_marks_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "bit_root_page_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "fcsmc_page_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "fcsmc_in_test_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 600000,
+                "expires_at_wall_ms": 1779045662603,
+                "fact_id": "fcsmc_final_go_result_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "not_seen",
+                "sticky": true
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "hsi_page_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "hsi_map_layer_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045064603,
+                "fact_id": "ins_ok_text_visible",
+                "observed_at_wall_ms": 1779045062603,
+                "source_frame_id": "1779045062695_000060",
+                "state": "seen",
+                "sticky": false
+              }
+            ],
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779045062695_000060"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "missing_pre_trigger_frame",
+            "vlm_call_status": "called"
+          },
+          "response_id": "f07478b3-a031-4eee-83b7-12e621ade1fd",
+          "status": "ok",
+          "timestamp": "2026-05-17T19:11:14.526667+00:00",
+          "version": "v1"
+        },
+        "related_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "vision_refs": [
+          "1779045062695_000060"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "right_mdi_pb5"
+          },
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S18",
+          "missing_conditions_count": 1,
+          "observability": "partial",
+          "observability_status": "partial",
+          "overlay_step_id": "S18",
+          "recent_ui_targets": [
+            "takeoff_trim_button"
+          ],
+          "requires_visual_confirmation": true,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 9824
+          },
+          "vision_fresh_count": 6,
+          "vision_seen_count": 6,
+          "vision_status": "available"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 24.051345417769785,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_105",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 106,
+            "score": 20.74820609602476,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_105"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_10",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "3. Step Criticality",
+            "score": 20.169931721198378,
+            "section": "3. Step Criticality",
+            "snippet_id": "fa18c_error_coding_guide_10"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_12",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q12. Sequence Mini-Task 2",
+            "score": 18.21894244493854,
+            "section": "Q12. Sequence Mini-Task 2",
+            "snippet_id": "fa18c_coldstart_quiz_12"
+          },
+          {
+            "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+            "doc_id": "fa18c_fcs_bit_procedure_note",
+            "score": 18.196064173149253,
+            "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vision_facts.fcsmc_page_visible==seen"
+            ],
+            "overlay_step_id": "S18",
+            "role": "candidate_not_authoritative",
+            "step_id": "S18"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 9824,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": true,
+                "last_value": false,
+                "latest_transition_age_s": 0.89,
+                "transition_count": 1,
+                "var": "takeoff_trim_pressed"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9824,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 9824,
+            "latest_t_wall": 1779045062.6004815,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.928
+          },
+          "vision_evidence": {
+            "confidence": "high",
+            "fresh_fact_ids": [
+              "bit_root_page_visible",
+              "fcs_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "late_display_anchors": [
+              "bit_root_page_visible",
+              "fcs_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "fcs_page_x_marks_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_page_visible",
+              "supt_page_visible",
+              "tac_page_visible"
+            ],
+            "seen_fact_ids": [
+              "bit_root_page_visible",
+              "fcs_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "source_status": "available",
+            "visual_candidate_steps": [
+              "S08",
+              "S09",
+              "S12",
+              "S13"
+            ]
+          }
+        },
+        "vision": {
+          "frame_id": "1779045062695_000060",
+          "frame_ids": [
+            "1779045062695_000060"
+          ],
+          "frame_stale": false,
+          "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+          "observation_seq": 9824,
+          "observation_t_wall_ms": 1779045062600,
+          "observation_t_wall_s": 1779045062.6004815,
+          "status": "partial",
+          "sync_delta_ms": 92,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779045062603,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779045062695_000060"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "fact_id": "tac_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "supt_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_x_marks_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "bit_root_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_in_test_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_map_layer_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_ok_text_visible",
+            "frame_ids": null,
+            "status": null
+          }
+        ]
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 9824
+          },
+          "vision_fresh_count": 6,
+          "vision_seen_count": 6,
+          "vision_status": "available"
+        },
+        "frame_id": "1779045062695_000060",
+        "fused_missing_conditions": [
+          "vision_facts.fcsmc_page_visible==seen"
+        ],
+        "fused_step_id": "S18",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_startup_master_1"
+        ],
+        "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+        "prompt_tokens_est": 1134,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "source_chunk_refs": [
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_105",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_12",
+          "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 92,
+        "vision_fact_seen_ids": [
+          "fcs_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779045062695_000060"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779045062695_000060"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+      "request_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+      "timestamp": "2026-05-17T19:11:09.548436+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_96",
+          "evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779045062695_000060",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 92,
+          "target": "right_mdi_pb18",
+          "type": "overlay",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+        "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+      ],
+      "in_reply_to": "644fac65-eb37-4de1-a591-fd1de392c647",
+      "message": "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+      "metadata": {
+        "allowed_evidence_ref_count": 131,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "ad311d68-a2cd-4f97-9771-2eecc2759a82",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S18",
+          "missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "observability": "partial",
+          "observability_status": "partial",
+          "recent_ui_targets": [
+            "takeoff_trim_button"
+          ],
+          "requires_visual_confirmation": true,
+          "step_evidence_requirements": [
+            "delta",
+            "gate",
+            "visual"
+          ],
+          "step_ui_targets": [
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ]
+        },
+        "diagnosis": {
+          "error_category": "CO",
+          "step_id": "S18"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_strength": "limited",
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "overlay_step_id": null,
+          "source": "model",
+          "step_id": "S18",
+          "targets": [
+            "right_mdi_pb18"
+          ],
+          "text_only": false
+        },
+        "final_overlay_targets": [
+          "right_mdi_pb18"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_96",
+              "evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "right_mdi_pb18"
+              ],
+              "frame_id": "1779045062695_000060",
+              "fused_missing_conditions": [
+                "vision_facts.fcsmc_page_visible==seen"
+              ],
+              "fused_step_id": "S18",
+              "generation_mode": "model",
+              "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 92,
+              "target": "right_mdi_pb18",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779045062695_000060"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+            "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+          ],
+          "message": "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。",
+          "next": {
+            "step_id": "S18"
+          }
+        },
+        "frame_id": "1779045062695_000060",
+        "fused_missing_conditions": [
+          "vision_facts.fcsmc_page_visible==seen"
+        ],
+        "fused_step_id": "S18",
+        "generation_mode": "model",
+        "generation_prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+        "generation_prompt_tokens_est": 1134,
+        "generation_prompt_trimmed": true,
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S08",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.ins_ok_text_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.ins_ok_text_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.ins_ok_text_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.ins_ok_text_visible"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S18",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "right_mdi_pb18",
+              "right_mdi_pb5"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S18",
+            "supporting_evidence_refs": []
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 1,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 1,
+              "contradiction_count": 0,
+              "frame_count": 20,
+              "latest_seq": 9824
+            },
+            "vision_fresh_count": 6,
+            "vision_seen_count": 6,
+            "vision_status": "available"
+          },
+          "final_action_plan": {
+            "overlay_step_id": null,
+            "source": "model",
+            "step_id": "S18",
+            "targets": [
+              "right_mdi_pb18"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "message_category": "model",
+          "model_decision": {
+            "evidence_refs": [
+              "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "right_mdi_pb18"
+            ],
+            "status": "ok",
+            "step_id": "S18"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": false,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": null
+          },
+          "schema_version": "v1",
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "extractor_used": true,
+            "frame_ids": [
+              "1779045062695_000060"
+            ],
+            "reason": "missing_pre_trigger_frame",
+            "status": "called",
+            "sync_delta_ms": 92,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "available",
+            "vision_status": "partial"
+          }
+        },
+        "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+          ],
+          "next": {
+            "step_id": "S18"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+                "target": "right_mdi_pb18",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "right_mdi_pb18"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+          ],
+          "next": {
+            "step_id": "S18"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+                "target": "right_mdi_pb18",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "right_mdi_pb18"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4976,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "model",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S18"
+        },
+        "model_raw_explanations": [
+          "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+          ],
+          "next": {
+            "step_id": "S18"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+                "target": "right_mdi_pb18",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "right_mdi_pb18"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S18"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779045062695_000060"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779045062695_000060",
+        "next": {
+          "step_id": "S18"
+        },
+        "observability_status": "partial",
+        "prompt_budget_used": 5509,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "VISION_FACTS.tac_page_visible@1779045062695_000060",
+            "VISION_FACTS.supt_page_visible@1779045062695_000060"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 3,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "right_mdi_pb5",
+          "prompt_chars": 4534,
+          "prompt_tokens_est": 1134,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 1,
+          "rag_snippet_ids": [
+            "fa18c_startup_master_1"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [
+            "S08",
+            "S09",
+            "S12",
+            "S13"
+          ],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_overlay_enum",
+            "trimmed_rag_snippets",
+            "compact_template"
+          ],
+          "vision_fact_seen_ids": [
+            "fcs_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "vision_fact_status": "available"
+        },
+        "prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+        "prompt_tokens_est": 1134,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "498722bb1f0fcd694f3089cdc3f168577bf40ca563b52d902cd2444dc83e977d",
+        "request_prompt_tokens_est": 1134,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": true,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 131,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S18"
+          },
+          "evidence_strength": "limited",
+          "next": {
+            "step_id": "S18"
+          },
+          "observability_status": "partial",
+          "requires_visual_confirmation": true
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "state_key": "4cdcbec64e13f45f354882cc675b61de8be35a03b1f971de2affc68af69a89b4",
+        "sync_delta_ms": 92,
+        "vision": {
+          "frame_id": "1779045062695_000060",
+          "frame_ids": [
+            "1779045062695_000060"
+          ],
+          "frame_stale": false,
+          "observation_ref": "632353de-03a7-49bd-883d-4c8c17969c2b",
+          "observation_seq": 9824,
+          "observation_t_wall_ms": 1779045062600,
+          "observation_t_wall_s": 1779045062.6004815,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779045062695,
+              "channel": "composite_panel",
+              "frame_id": "1779045062695_000060",
+              "frame_seq": 60,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045062695_000060_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045062695_000060.png",
+              "sync_delta_ms": 92,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 92,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779045062695,
+            "channel": "composite_panel",
+            "frame_id": "1779045062695_000060",
+            "frame_seq": 60,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045062695_000060_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045062695_000060.png",
+            "sync_delta_ms": 92,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779045062603,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S08"
+        ],
+        "vision_fact_extractor_used": true,
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779045062695_000060"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "tac_page_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "supt_page_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "fcs_page_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "fcs_page_x_marks_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "bit_root_page_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "fcsmc_page_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "fcsmc_in_test_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 600000,
+            "expires_at_wall_ms": 1779045662603,
+            "fact_id": "fcsmc_final_go_result_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "not_seen",
+            "sticky": true
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "hsi_page_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "hsi_map_layer_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045064603,
+            "fact_id": "ins_ok_text_visible",
+            "observed_at_wall_ms": 1779045062603,
+            "source_frame_id": "1779045062695_000060",
+            "state": "seen",
+            "sticky": false
+          }
+        ],
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779045062695_000060"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "missing_pre_trigger_frame",
+        "vlm_call_status": "called"
+      },
+      "response_id": "f07478b3-a031-4eee-83b7-12e621ade1fd",
+      "status": "ok",
+      "timestamp": "2026-05-17T19:11:14.526667+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S18",
+    "expected_overlay_target_ids": [
+      "right_mdi_pb18"
+    ],
+    "final_response_source": "model",
+    "llm_decision_status": "accepted",
+    "vlm_call_status": "called"
+  },
+  "extraction_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "left_mdi_brightness_selector",
+          "right_mdi_brightness_selector",
+          "ampcd_off_brightness_knob",
+          "hud_symbology_brightness_knob",
+          "left_mdi_pb18",
+          "left_mdi_pb15",
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S08",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.ins_ok_text_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.ins_ok_text_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.ins_ok_text_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.ins_ok_text_visible"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S18",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "overlay_step_id": null,
+      "source": "model",
+      "step_id": "S18",
+      "targets": [
+        "right_mdi_pb18"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "right_mdi_pb18"
+      ],
+      "status": "ok",
+      "step_id": "S18"
+    },
+    "repair_result": {
+      "applied": false,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": null
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S08",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.ins_ok_text_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.ins_ok_text_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.ins_ok_text_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.ins_ok_text_visible"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S18",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S18",
+        "supporting_evidence_refs": []
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 1,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 1,
+          "contradiction_count": 0,
+          "frame_count": 20,
+          "latest_seq": 9824
+        },
+        "vision_fresh_count": 6,
+        "vision_seen_count": 6,
+        "vision_status": "available"
+      },
+      "final_action_plan": {
+        "overlay_step_id": null,
+        "source": "model",
+        "step_id": "S18",
+        "targets": [
+          "right_mdi_pb18"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "right_mdi_pb18"
+      ],
+      "message_category": "model",
+      "model_decision": {
+        "evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible@1779045062695_000060"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "right_mdi_pb18"
+        ],
+        "status": "ok",
+        "step_id": "S18"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": false,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": null
+      },
+      "schema_version": "v1",
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "extractor_used": true,
+        "frame_ids": [
+          "1779045062695_000060"
+        ],
+        "reason": "missing_pre_trigger_frame",
+        "status": "called",
+        "sync_delta_ms": 92,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "available",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S18"
+      },
+      "explanations": [
+        "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+      ],
+      "next": {
+        "step_id": "S18"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+            "target": "right_mdi_pb18",
+            "type": "visual"
+          }
+        ],
+        "targets": [
+          "right_mdi_pb18"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S18"
+      },
+      "explanations": [
+        "当前处于 S18 阶段，右 DDI 显示 BIT root 页面。请左键点击右 MDI PB18 进入 FCS-MC 页面。"
+      ],
+      "next": {
+        "step_id": "S18"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VISION_FACTS.bit_root_page_visible@1779045062695_000060",
+            "target": "right_mdi_pb18",
+            "type": "visual"
+          }
+        ],
+        "targets": [
+          "right_mdi_pb18"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "644fac65-eb37-4de1-a591-fd1de392c647",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 13303,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260517_190017.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/8931fe82-2c72-4fbe-ab49-c78690820773.fixture.json
+++ b/artifacts/live_fixtures/8931fe82-2c72-4fbe-ab49-c78690820773.fixture.json
@@ -1,0 +1,4582 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 1,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "frame_count": 20,
+        "latest_seq": 6410
+      },
+      "vision_fresh_count": 5,
+      "vision_seen_count": 5,
+      "vision_status": "available"
+    },
+    "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 2,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:61286",
+          "raw_delta_count": 2,
+          "seq": 6410
+        },
+        "observation_id": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_RIGHT",
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 2,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 2,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_RIGHT",
+                "ui_targets": [],
+                "value": 39047
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41343
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 6410,
+          "t_wall": 1779037955.3069358,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": false,
+            "comm1_freq_value": 30500,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": false,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 0,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 0.0,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 0,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 0,
+            "rpm_l_gte_25": false,
+            "rpm_l_gte_60": false,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 10,
+            "temp_r": 309,
+            "throttle_l_not_off": false,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-17T17:12:35.306935+00:00",
+        "version": "v1"
+      }
+    ],
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "frame_count": 20,
+      "latest_seq": 6410
+    },
+    "vision": {
+      "frame_ids": [
+        "1779037955374_000029"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779037955374_000029",
+        "frame_ids": [
+          "1779037955374_000029"
+        ],
+        "frame_stale": false,
+        "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+        "observation_seq": 6410,
+        "observation_t_wall_ms": 1779037955307,
+        "observation_t_wall_s": 1779037955.3069358,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779037955374,
+            "channel": "composite_panel",
+            "frame_id": "1779037955374_000029",
+            "frame_seq": 29,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779037955374_000029_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779037955374_000029.png",
+            "sync_delta_ms": 97,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 97,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779037955374,
+          "channel": "composite_panel",
+          "frame_id": "1779037955374_000029",
+          "frame_seq": 29,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779037955374_000029_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779037955374_000029.png",
+          "sync_delta_ms": 97,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779037955277,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779037955374_000029"
+        ],
+        "fresh_fact_ids": [
+          "fcs_page_visible",
+          "fcs_page_x_marks_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible"
+        ],
+        "not_seen_fact_ids": [
+          "tac_page_visible",
+          "supt_page_visible",
+          "fcsmc_page_visible",
+          "fcsmc_intermediate_result_visible",
+          "fcsmc_in_test_visible",
+          "fcsmc_final_go_result_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "seen_fact_ids": [
+          "fcs_page_visible",
+          "fcs_page_x_marks_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible"
+        ],
+        "status": "available",
+        "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": [
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "tac_page_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "supt_page_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "fcs_page_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "fcs_page_x_marks_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "bit_root_page_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "fcsmc_page_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "fcsmc_intermediate_result_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "fcsmc_in_test_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 600000,
+          "expires_at_wall_ms": 1779038555277,
+          "fact_id": "fcsmc_final_go_result_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": true
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "hsi_page_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "hsi_map_layer_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "ins_grnd_alignment_text_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779037957277,
+          "fact_id": "ins_ok_text_visible",
+          "observed_at_wall_ms": 1779037955277,
+          "source_frame_id": "1779037955374_000029",
+          "state": "not_seen",
+          "sticky": false
+        }
+      ]
+    },
+    "vision_fact_observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "frame_ids": [
+            "1779037955374_000029"
+          ],
+          "observation_kind": "vision_fact"
+        },
+        "observation_id": "a5f9fbe8-6fb5-4c9b-a5ef-e244abc21d6d",
+        "payload": {
+          "facts": [
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "tac_page_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "supt_page_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_x_marks_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "bit_root_page_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_page_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_intermediate_result_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_in_test_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 600000,
+              "fact_id": "fcsmc_final_go_result_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": true
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_page_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_map_layer_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_grnd_alignment_text_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_ok_text_visible",
+              "observed_at_wall_ms": 1779037955277,
+              "result_kind": null,
+              "source_frame_id": "1779037955374_000029",
+              "state": "not_seen",
+              "sticky": false
+            }
+          ],
+          "frame_ids": [
+            "1779037955374_000029"
+          ],
+          "metadata": {
+            "coerced_source_frame_fact_ids": [],
+            "coerced_source_frame_fact_ids_alias_of": "ignored_legacy_source_frame_fact_ids",
+            "configured_fact_count": 13,
+            "ignored_legacy_source_frame_fact_ids": [],
+            "ignored_model_fact_fields": {},
+            "raw_fact_count": 13,
+            "raw_llm_text": "{\"facts\":[{\"fact_id\":\"tac_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"supt_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_x_marks_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"bit_root_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_intermediate_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_in_test_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_final_go_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_map_layer_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_grnd_alignment_text_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_ok_text_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"}]}",
+            "sanitized_fact_count": 13,
+            "skipped_incomplete_mapping_fact_count": 0,
+            "skipped_non_mapping_fact_count": 0,
+            "skipped_unknown_fact_id_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779037955374_000029"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            }
+          },
+          "observation_id": "a5f9fbe8-6fb5-4c9b-a5ef-e244abc21d6d",
+          "schema_version": "v2",
+          "session_id": "sess-live",
+          "source": "vision_fact_extractor",
+          "summary": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "timestamp": "2026-05-17T17:12:42.247528+00:00",
+          "trigger_wall_ms": 1779037955277
+        },
+        "procedure_hint": null,
+        "source": "vision_fact_extractor",
+        "tags": [],
+        "timestamp": "2026-05-17T17:12:42.247528+00:00",
+        "version": "v1"
+      }
+    ]
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "kind": "tutor_request",
+        "lineno": 6755,
+        "metadata": {
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_status": "available",
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "ufc_comm1_channel_selector_pull"
+              },
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S09",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S09",
+              "recent_ui_targets": [
+                "left_mdi_pb15"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 6410
+              },
+              "vision_fresh_count": 5,
+              "vision_seen_count": 5,
+              "vision_status": "available"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 15.98560009496923,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_5",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+                "score": 14.558960000687737,
+                "section": "Phase P3 – Displays & Communications (S08–S09)",
+                "snippet_id": "Appendix - Training Task Syllabus_5"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.29554266378183,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_10",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "3. Step Criticality",
+                "score": 13.120994677243015,
+                "section": "3. Step Criticality",
+                "snippet_id": "fa18c_error_coding_guide_10"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 93,
+                "score": 12.536685340631566,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.comm1_freq_134_000==true"
+                ],
+                "overlay_step_id": "S09",
+                "role": "candidate_not_authoritative",
+                "step_id": "S09"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 6410,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6410,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 6410,
+                "latest_t_wall": 1779037955.3069358,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.173
+              },
+              "vision_evidence": {
+                "confidence": "high",
+                "fresh_fact_ids": [
+                  "bit_root_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible"
+                ],
+                "late_display_anchors": [
+                  "bit_root_page_visible",
+                  "fcs_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible",
+                  "supt_page_visible",
+                  "tac_page_visible"
+                ],
+                "seen_fact_ids": [
+                  "bit_root_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible"
+                ],
+                "source_status": "available",
+                "visual_candidate_steps": [
+                  "S08",
+                  "S09",
+                  "S12",
+                  "S13"
+                ]
+              }
+            },
+            "vision": {
+              "frame_id": "1779037955374_000029",
+              "frame_ids": [
+                "1779037955374_000029"
+              ],
+              "frame_stale": false,
+              "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+              "observation_seq": 6410,
+              "observation_t_wall_ms": 1779037955307,
+              "observation_t_wall_s": 1779037955.3069358,
+              "status": "partial",
+              "sync_delta_ms": 97,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779037955277,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779037955374_000029"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "fact_id": "tac_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "supt_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_x_marks_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "bit_root_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_in_test_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_map_layer_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_ok_text_visible",
+                "frame_ids": null,
+                "status": null
+              }
+            ]
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 6410
+              },
+              "vision_fresh_count": 5,
+              "vision_seen_count": 5,
+              "vision_status": "available"
+            },
+            "frame_id": "1779037955374_000029",
+            "fused_missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "fused_step_id": "S09",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_startup_master_1"
+            ],
+            "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+            "prompt_tokens_est": 1096,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "source_chunk_refs": [
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 97,
+            "vision_fact_seen_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779037955374_000029"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779037955374_000029"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+          "request_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "timestamp": "2026-05-17T17:12:42.284058+00:00",
+          "version": "v1"
+        },
+        "related_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "vision_refs": [
+          "1779037955374_000029"
+        ]
+      },
+      {
+        "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "kind": "overlay_requested",
+        "lineno": 6756,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "68e6e4f3-3d4f-4bd7-8889-05e072dabe79",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 97,
+          "target": "pnt_51",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "kind": "overlay_requested",
+        "lineno": 6757,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "b6e281a2-4647-4d54-b1cf-43e33e3fd774",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 97,
+          "target": "pnt_124",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "kind": "overlay_requested",
+        "lineno": 6758,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "692d711e-9cc6-4a48-af92-2d71f042569e",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 97,
+          "target": "pnt_111",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "kind": "tutor_response",
+        "lineno": 6759,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1"
+              ],
+              "frame_id": "1779037955374_000029",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 97,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779037955374_000029"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            },
+            {
+              "element_id": "pnt_111",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1"
+              ],
+              "frame_id": "1779037955374_000029",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 97,
+              "target": "ufc_key_1",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779037955374_000029"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+          ],
+          "in_reply_to": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+          "metadata": {
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "736cc68e-031e-4b7f-b692-052ff32beaba",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S09",
+              "missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "left_mdi_pb15"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "delta",
+                "rag"
+              ],
+              "step_ui_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ]
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S09"
+            },
+            "evidence_guardrail_applied": true,
+            "evidence_guardrail_reasons": [
+              "invalid_target_evidence_refs:ufc_comm1_channel_selector_pull"
+            ],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "failure_code": "evidence_fail",
+            "failure_codes": [
+              "evidence_fail"
+            ],
+            "failure_stage": "evidence_guardrail",
+            "fallback_overlay_reason": "deterministic_step:S09",
+            "fallback_overlay_used": true,
+            "final_action_plan": {
+              "overlay_step_id": "S09",
+              "source": "validator_repair",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "validator_repair",
+            "final_overlay_targets": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_124",
+                  "evidence_refs": [
+                    "VARS.left_ddi_on"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1"
+                  ],
+                  "frame_id": "1779037955374_000029",
+                  "fused_missing_conditions": [
+                    "vars.comm1_freq_134_000==true"
+                  ],
+                  "fused_step_id": "S09",
+                  "generation_mode": "model",
+                  "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 97,
+                  "target": "ufc_comm1_channel_selector_pull",
+                  "type": "overlay",
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779037955374_000029"
+                    ],
+                    "fresh_fact_ids": [
+                      "fcs_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "tac_page_visible",
+                      "supt_page_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible",
+                      "fcsmc_final_go_result_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "fcs_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                },
+                {
+                  "element_id": "pnt_111",
+                  "evidence_refs": [
+                    "VARS.left_ddi_on"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1"
+                  ],
+                  "frame_id": "1779037955374_000029",
+                  "fused_missing_conditions": [
+                    "vars.comm1_freq_134_000==true"
+                  ],
+                  "fused_step_id": "S09",
+                  "generation_mode": "model",
+                  "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 97,
+                  "target": "ufc_key_1",
+                  "type": "overlay",
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779037955374_000029"
+                    ],
+                    "fresh_fact_ids": [
+                      "fcs_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "tac_page_visible",
+                      "supt_page_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible",
+                      "fcsmc_final_go_result_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "fcs_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+              ],
+              "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+              "next": {
+                "step_id": "S09"
+              }
+            },
+            "frame_id": "1779037955374_000029",
+            "fused_missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "fused_step_id": "S09",
+            "generation_mode": "model",
+            "generation_prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+            "generation_prompt_tokens_est": 1096,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S09",
+              "source": "validator_repair",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_brightness_selector",
+                    "right_mdi_brightness_selector",
+                    "ampcd_off_brightness_knob",
+                    "hud_symbology_brightness_knob",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15",
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "GATES.S09.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "GATES.S09.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": [
+                    "GATES.S10.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S11",
+                  "supporting_evidence_refs": [
+                    "GATES.S11.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.86,
+                "proposed_next_action_target_ids": [
+                  "ufc_comm1_channel_selector_pull",
+                  "ufc_key_1",
+                  "ufc_key_3",
+                  "ufc_key_4",
+                  "ufc_key_0",
+                  "ufc_ent_button"
+                ],
+                "role": "candidate",
+                "source": "visual_anchor",
+                "step_id": "S09",
+                "supporting_evidence_refs": [
+                  "VISION_FACTS.bit_root_page_visible",
+                  "VISION_FACTS.fcs_page_visible",
+                  "VISION_FACTS.hsi_map_layer_visible",
+                  "VISION_FACTS.hsi_page_visible"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 1,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "frame_count": 20,
+                  "latest_seq": 6410
+                },
+                "vision_fresh_count": 5,
+                "vision_seen_count": 5,
+                "vision_status": "available"
+              },
+              "final_action_plan": {
+                "overlay_step_id": "S09",
+                "source": "validator_repair",
+                "step_id": "S09",
+                "targets": [
+                  "ufc_comm1_channel_selector_pull",
+                  "ufc_key_1"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [],
+                "generation_mode": "model",
+                "overlay_targets": [],
+                "status": "ok",
+                "step_id": "S09"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "validator_repair"
+              },
+              "schema_version": "v1",
+              "validator_result": {
+                "fallback_overlay_reason": "deterministic_step:S09",
+                "fallback_overlay_used": true,
+                "reasons": [
+                  "target_dropped_by_max_overlay_targets:ufc_key_3",
+                  "target_dropped_by_max_overlay_targets:ufc_key_4",
+                  "target_dropped_by_max_overlay_targets:ufc_key_0",
+                  "target_dropped_by_max_overlay_targets:ufc_ent_button"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "extractor_used": true,
+                "frame_ids": [
+                  "1779037955374_000029"
+                ],
+                "reason": "missing_pre_trigger_frame",
+                "status": "called",
+                "sync_delta_ms": 97,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "available",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "target_dropped_by_max_overlay_targets:ufc_key_3",
+              "target_dropped_by_max_overlay_targets:ufc_key_4",
+              "target_dropped_by_max_overlay_targets:ufc_key_0",
+              "target_dropped_by_max_overlay_targets:ufc_ent_button"
+            ],
+            "harness_validator_fallback_reason": "deterministic_step:S09",
+            "harness_validator_mapping": {
+              "allowed_evidence_ref_count": 130,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "next": {
+                "step_id": "S09"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "请先操作 ufc_comm1_channel_selector_pull。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.left_ddi_on",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "var"
+                  },
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.left_ddi_on",
+                    "target": "ufc_key_1",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull",
+                  "ufc_key_1"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "gates_summary.S09.completion",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4406,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S09"
+            },
+            "model_raw_explanations": [
+              "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+              "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+                "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S09"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779037955374_000029"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779037955374_000029",
+            "next": {
+              "step_id": "S09"
+            },
+            "observability_status": "observable",
+            "procedural_guidance_original_explanations": [
+              "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+              "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+            ],
+            "procedural_guidance_original_message": "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+            "procedural_guidance_rewrite_reason": "s09_comm1_frequency_guidance",
+            "procedural_guidance_rewritten": true,
+            "prompt_budget_used": 955,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "VISION_FACTS.tac_page_visible@1779037955374_000029",
+                "VISION_FACTS.supt_page_visible@1779037955374_000029"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 3,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 2,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "ufc_comm1_channel_selector_pull",
+              "prompt_chars": 4381,
+              "prompt_tokens_est": 1096,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 1,
+              "rag_snippet_ids": [
+                "fa18c_startup_master_1"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [
+                "S08",
+                "S09",
+                "S12",
+                "S13"
+              ],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_overlay_enum",
+                "trimmed_rag_snippets",
+                "compact_template"
+              ],
+              "vision_fact_seen_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "vision_fact_status": "available"
+            },
+            "prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+            "prompt_tokens_est": 1096,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+            "request_prompt_tokens_est": 1096,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "next": {
+                "step_id": "S09"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "state_key": "1e8dbb7e22d244cb8792aa149dc873906b34d3c0c1dc77544b5d0697c92cafc9",
+            "sync_delta_ms": 97,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779037955374_000029",
+              "frame_ids": [
+                "1779037955374_000029"
+              ],
+              "frame_stale": false,
+              "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+              "observation_seq": 6410,
+              "observation_t_wall_ms": 1779037955307,
+              "observation_t_wall_s": 1779037955.3069358,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779037955374,
+                  "channel": "composite_panel",
+                  "frame_id": "1779037955374_000029",
+                  "frame_seq": 29,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779037955374_000029_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779037955374_000029.png",
+                  "sync_delta_ms": 97,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 97,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779037955374,
+                "channel": "composite_panel",
+                "frame_id": "1779037955374_000029",
+                "frame_seq": 29,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779037955374_000029_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779037955374_000029.png",
+                "sync_delta_ms": 97,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779037955277,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S08"
+            ],
+            "vision_fact_extractor_used": true,
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779037955374_000029"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "tac_page_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "supt_page_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "fcs_page_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "fcs_page_x_marks_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "bit_root_page_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "fcsmc_page_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "fcsmc_in_test_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 600000,
+                "expires_at_wall_ms": 1779038555277,
+                "fact_id": "fcsmc_final_go_result_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": true
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "hsi_page_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "hsi_map_layer_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779037957277,
+                "fact_id": "ins_ok_text_visible",
+                "observed_at_wall_ms": 1779037955277,
+                "source_frame_id": "1779037955374_000029",
+                "state": "not_seen",
+                "sticky": false
+              }
+            ],
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779037955374_000029"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "missing_pre_trigger_frame",
+            "vlm_call_status": "called"
+          },
+          "response_id": "507e3726-bab2-4d2c-852b-aa600bb3b3a9",
+          "status": "ok",
+          "timestamp": "2026-05-17T17:12:46.691368+00:00",
+          "version": "v1"
+        },
+        "related_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "vision_refs": [
+          "1779037955374_000029"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "ufc_comm1_channel_selector_pull"
+          },
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S09",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S09",
+          "recent_ui_targets": [
+            "left_mdi_pb15"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 6410
+          },
+          "vision_fresh_count": 5,
+          "vision_seen_count": 5,
+          "vision_status": "available"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 15.98560009496923,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_5",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+            "score": 14.558960000687737,
+            "section": "Phase P3 – Displays & Communications (S08–S09)",
+            "snippet_id": "Appendix - Training Task Syllabus_5"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.29554266378183,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_10",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "3. Step Criticality",
+            "score": 13.120994677243015,
+            "section": "3. Step Criticality",
+            "snippet_id": "fa18c_error_coding_guide_10"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 93,
+            "score": 12.536685340631566,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "overlay_step_id": "S09",
+            "role": "candidate_not_authoritative",
+            "step_id": "S09"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 6410,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6410,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 6410,
+            "latest_t_wall": 1779037955.3069358,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.173
+          },
+          "vision_evidence": {
+            "confidence": "high",
+            "fresh_fact_ids": [
+              "bit_root_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible"
+            ],
+            "late_display_anchors": [
+              "bit_root_page_visible",
+              "fcs_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "fcsmc_final_go_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible",
+              "supt_page_visible",
+              "tac_page_visible"
+            ],
+            "seen_fact_ids": [
+              "bit_root_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible"
+            ],
+            "source_status": "available",
+            "visual_candidate_steps": [
+              "S08",
+              "S09",
+              "S12",
+              "S13"
+            ]
+          }
+        },
+        "vision": {
+          "frame_id": "1779037955374_000029",
+          "frame_ids": [
+            "1779037955374_000029"
+          ],
+          "frame_stale": false,
+          "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+          "observation_seq": 6410,
+          "observation_t_wall_ms": 1779037955307,
+          "observation_t_wall_s": 1779037955.3069358,
+          "status": "partial",
+          "sync_delta_ms": 97,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779037955277,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779037955374_000029"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "fact_id": "tac_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "supt_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_x_marks_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "bit_root_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_in_test_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_map_layer_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_ok_text_visible",
+            "frame_ids": null,
+            "status": null
+          }
+        ]
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 6410
+          },
+          "vision_fresh_count": 5,
+          "vision_seen_count": 5,
+          "vision_status": "available"
+        },
+        "frame_id": "1779037955374_000029",
+        "fused_missing_conditions": [
+          "vars.comm1_freq_134_000==true"
+        ],
+        "fused_step_id": "S09",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_startup_master_1"
+        ],
+        "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+        "prompt_tokens_est": 1096,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "source_chunk_refs": [
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 97,
+        "vision_fact_seen_ids": [
+          "fcs_page_visible",
+          "fcs_page_x_marks_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible"
+        ],
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779037955374_000029"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779037955374_000029"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+      "request_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+      "timestamp": "2026-05-17T17:12:42.284058+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_124",
+          "evidence_refs": [
+            "VARS.left_ddi_on"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 97,
+          "target": "ufc_comm1_channel_selector_pull",
+          "type": "overlay",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        {
+          "element_id": "pnt_111",
+          "evidence_refs": [
+            "VARS.left_ddi_on"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "frame_id": "1779037955374_000029",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 97,
+          "target": "ufc_key_1",
+          "type": "overlay",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+      ],
+      "in_reply_to": "8931fe82-2c72-4fbe-ab49-c78690820773",
+      "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+      "metadata": {
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "736cc68e-031e-4b7f-b692-052ff32beaba",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S09",
+          "missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "left_mdi_pb15"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "delta",
+            "rag"
+          ],
+          "step_ui_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ]
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S09"
+        },
+        "evidence_guardrail_applied": true,
+        "evidence_guardrail_reasons": [
+          "invalid_target_evidence_refs:ufc_comm1_channel_selector_pull"
+        ],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "failure_code": "evidence_fail",
+        "failure_codes": [
+          "evidence_fail"
+        ],
+        "failure_stage": "evidence_guardrail",
+        "fallback_overlay_reason": "deterministic_step:S09",
+        "fallback_overlay_used": true,
+        "final_action_plan": {
+          "overlay_step_id": "S09",
+          "source": "validator_repair",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "validator_repair",
+        "final_overlay_targets": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1"
+              ],
+              "frame_id": "1779037955374_000029",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 97,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779037955374_000029"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            },
+            {
+              "element_id": "pnt_111",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1"
+              ],
+              "frame_id": "1779037955374_000029",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 97,
+              "target": "ufc_key_1",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779037955374_000029"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
+          ],
+          "message": "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。",
+          "next": {
+            "step_id": "S09"
+          }
+        },
+        "frame_id": "1779037955374_000029",
+        "fused_missing_conditions": [
+          "vars.comm1_freq_134_000==true"
+        ],
+        "fused_step_id": "S09",
+        "generation_mode": "model",
+        "generation_prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+        "generation_prompt_tokens_est": 1096,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S09",
+          "source": "validator_repair",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S08",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "GATES.S09.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "GATES.S09.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S10",
+              "supporting_evidence_refs": [
+                "GATES.S10.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S11",
+              "supporting_evidence_refs": [
+                "GATES.S11.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.86,
+            "proposed_next_action_target_ids": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0",
+              "ufc_ent_button"
+            ],
+            "role": "candidate",
+            "source": "visual_anchor",
+            "step_id": "S09",
+            "supporting_evidence_refs": [
+              "VISION_FACTS.bit_root_page_visible",
+              "VISION_FACTS.fcs_page_visible",
+              "VISION_FACTS.hsi_map_layer_visible",
+              "VISION_FACTS.hsi_page_visible"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 1,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "frame_count": 20,
+              "latest_seq": 6410
+            },
+            "vision_fresh_count": 5,
+            "vision_seen_count": 5,
+            "vision_status": "available"
+          },
+          "final_action_plan": {
+            "overlay_step_id": "S09",
+            "source": "validator_repair",
+            "step_id": "S09",
+            "targets": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [],
+            "generation_mode": "model",
+            "overlay_targets": [],
+            "status": "ok",
+            "step_id": "S09"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "validator_repair"
+          },
+          "schema_version": "v1",
+          "validator_result": {
+            "fallback_overlay_reason": "deterministic_step:S09",
+            "fallback_overlay_used": true,
+            "reasons": [
+              "target_dropped_by_max_overlay_targets:ufc_key_3",
+              "target_dropped_by_max_overlay_targets:ufc_key_4",
+              "target_dropped_by_max_overlay_targets:ufc_key_0",
+              "target_dropped_by_max_overlay_targets:ufc_ent_button"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "extractor_used": true,
+            "frame_ids": [
+              "1779037955374_000029"
+            ],
+            "reason": "missing_pre_trigger_frame",
+            "status": "called",
+            "sync_delta_ms": 97,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "available",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "target_dropped_by_max_overlay_targets:ufc_key_3",
+          "target_dropped_by_max_overlay_targets:ufc_key_4",
+          "target_dropped_by_max_overlay_targets:ufc_key_0",
+          "target_dropped_by_max_overlay_targets:ufc_ent_button"
+        ],
+        "harness_validator_fallback_reason": "deterministic_step:S09",
+        "harness_validator_mapping": {
+          "allowed_evidence_ref_count": 130,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "next": {
+            "step_id": "S09"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "请先操作 ufc_comm1_channel_selector_pull。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.left_ddi_on",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "var"
+              },
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.left_ddi_on",
+                "target": "ufc_key_1",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "gates_summary.S09.completion",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4406,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S09"
+        },
+        "model_raw_explanations": [
+          "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+          "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+            "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S09"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779037955374_000029"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779037955374_000029",
+        "next": {
+          "step_id": "S09"
+        },
+        "observability_status": "observable",
+        "procedural_guidance_original_explanations": [
+          "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+          "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+        ],
+        "procedural_guidance_original_message": "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+        "procedural_guidance_rewrite_reason": "s09_comm1_frequency_guidance",
+        "procedural_guidance_rewritten": true,
+        "prompt_budget_used": 955,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "VISION_FACTS.tac_page_visible@1779037955374_000029",
+            "VISION_FACTS.supt_page_visible@1779037955374_000029"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 3,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 2,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "ufc_comm1_channel_selector_pull",
+          "prompt_chars": 4381,
+          "prompt_tokens_est": 1096,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 1,
+          "rag_snippet_ids": [
+            "fa18c_startup_master_1"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [
+            "S08",
+            "S09",
+            "S12",
+            "S13"
+          ],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_overlay_enum",
+            "trimmed_rag_snippets",
+            "compact_template"
+          ],
+          "vision_fact_seen_ids": [
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "vision_fact_status": "available"
+        },
+        "prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+        "prompt_tokens_est": 1096,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "04597a0364d86fcceb5dcfacc6e63180456f4a13bb5378808c6b744b707cfe6c",
+        "request_prompt_tokens_est": 1096,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "next": {
+            "step_id": "S09"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "state_key": "1e8dbb7e22d244cb8792aa149dc873906b34d3c0c1dc77544b5d0697c92cafc9",
+        "sync_delta_ms": 97,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779037955374_000029",
+          "frame_ids": [
+            "1779037955374_000029"
+          ],
+          "frame_stale": false,
+          "observation_ref": "8993ade2-5ed2-4ba1-bf00-63488a41c879",
+          "observation_seq": 6410,
+          "observation_t_wall_ms": 1779037955307,
+          "observation_t_wall_s": 1779037955.3069358,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779037955374,
+              "channel": "composite_panel",
+              "frame_id": "1779037955374_000029",
+              "frame_seq": 29,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779037955374_000029_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779037955374_000029.png",
+              "sync_delta_ms": 97,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 97,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779037955374,
+            "channel": "composite_panel",
+            "frame_id": "1779037955374_000029",
+            "frame_seq": 29,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779037955374_000029_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779037955374_000029.png",
+            "sync_delta_ms": 97,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779037955277,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S08"
+        ],
+        "vision_fact_extractor_used": true,
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779037955374_000029"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,supt_page_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "tac_page_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "supt_page_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "fcs_page_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "fcs_page_x_marks_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "bit_root_page_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "fcsmc_page_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "fcsmc_in_test_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 600000,
+            "expires_at_wall_ms": 1779038555277,
+            "fact_id": "fcsmc_final_go_result_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": true
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "hsi_page_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "hsi_map_layer_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779037957277,
+            "fact_id": "ins_ok_text_visible",
+            "observed_at_wall_ms": 1779037955277,
+            "source_frame_id": "1779037955374_000029",
+            "state": "not_seen",
+            "sticky": false
+          }
+        ],
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779037955374_000029"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "missing_pre_trigger_frame",
+        "vlm_call_status": "called"
+      },
+      "response_id": "507e3726-bab2-4d2c-852b-aa600bb3b3a9",
+      "status": "ok",
+      "timestamp": "2026-05-17T17:12:46.691368+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S09",
+    "expected_overlay_target_ids": [
+      "ufc_comm1_channel_selector_pull",
+      "ufc_key_1"
+    ],
+    "final_response_source": "validator_repair",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "called"
+  },
+  "extraction_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "left_mdi_brightness_selector",
+          "right_mdi_brightness_selector",
+          "ampcd_off_brightness_knob",
+          "hud_symbology_brightness_knob",
+          "left_mdi_pb18",
+          "left_mdi_pb15",
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S08",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "GATES.S09.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "GATES.S09.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S11",
+        "supporting_evidence_refs": [
+          "GATES.S11.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "overlay_step_id": "S09",
+      "source": "validator_repair",
+      "step_id": "S09",
+      "targets": [
+        "ufc_comm1_channel_selector_pull",
+        "ufc_key_1"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [],
+      "generation_mode": "model",
+      "overlay_targets": [],
+      "status": "ok",
+      "step_id": "S09"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "validator_repair"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S08",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "GATES.S09.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "GATES.S09.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S10",
+          "supporting_evidence_refs": [
+            "GATES.S10.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S11",
+          "supporting_evidence_refs": [
+            "GATES.S11.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 1,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "frame_count": 20,
+          "latest_seq": 6410
+        },
+        "vision_fresh_count": 5,
+        "vision_seen_count": 5,
+        "vision_status": "available"
+      },
+      "final_action_plan": {
+        "overlay_step_id": "S09",
+        "source": "validator_repair",
+        "step_id": "S09",
+        "targets": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ufc_comm1_channel_selector_pull",
+        "ufc_key_1"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [],
+        "generation_mode": "model",
+        "overlay_targets": [],
+        "status": "ok",
+        "step_id": "S09"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "validator_repair"
+      },
+      "schema_version": "v1",
+      "validator_result": {
+        "fallback_overlay_reason": "deterministic_step:S09",
+        "fallback_overlay_used": true,
+        "reasons": [
+          "target_dropped_by_max_overlay_targets:ufc_key_3",
+          "target_dropped_by_max_overlay_targets:ufc_key_4",
+          "target_dropped_by_max_overlay_targets:ufc_key_0",
+          "target_dropped_by_max_overlay_targets:ufc_ent_button"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "extractor_used": true,
+        "frame_ids": [
+          "1779037955374_000029"
+        ],
+        "reason": "missing_pre_trigger_frame",
+        "status": "called",
+        "sync_delta_ms": 97,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "available",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "deterministic_step:S09",
+      "fallback_overlay_used": true,
+      "reasons": [
+        "target_dropped_by_max_overlay_targets:ufc_key_3",
+        "target_dropped_by_max_overlay_targets:ufc_key_4",
+        "target_dropped_by_max_overlay_targets:ufc_key_0",
+        "target_dropped_by_max_overlay_targets:ufc_ent_button"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "请先操作 ufc_comm1_channel_selector_pull。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.left_ddi_on",
+            "target": "ufc_comm1_channel_selector_pull",
+            "type": "var"
+          },
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.left_ddi_on",
+            "target": "ufc_key_1",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "需要更多信息/请确认: ufc_comm1_channel_selector_pull",
+        "当前步骤 S09 未完成，需将 COMM1 预设 1 编程为 134.000 MHz。请操作 UFC COMM1 通道选择器。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [],
+        "targets": []
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "8931fe82-2c72-4fbe-ab49-c78690820773",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 7520,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260517_170452.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json
+++ b/artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json
@@ -1,0 +1,3932 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 1,
+        "contradiction_count": 0,
+        "frame_count": 20,
+        "latest_seq": 9676
+      },
+      "vision_fresh_count": 7,
+      "vision_seen_count": 7,
+      "vision_status": "available"
+    },
+    "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 2,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:61258",
+          "raw_delta_count": 2,
+          "seq": 9676
+        },
+        "observation_id": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE",
+              "EXT_REFUEL_PROBE"
+            ],
+            "delta_count": 2,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 2,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41380
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "EXT_REFUEL_PROBE",
+                "ui_targets": [],
+                "value": 5606
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 9676,
+          "t_wall": 1779101317.0063336,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 5606,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": false,
+            "probe_extended": false,
+            "probe_retracted": false,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 297,
+            "temp_r": 324,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-18T10:48:37.006333+00:00",
+        "version": "v1"
+      }
+    ],
+    "telemetry_window_digest": {
+      "changed_var_count": 1,
+      "contradiction_count": 0,
+      "frame_count": 20,
+      "latest_seq": 9676
+    },
+    "vision": {
+      "frame_ids": [
+        "1779101317066_000096"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779101317066_000096",
+        "frame_ids": [
+          "1779101317066_000096"
+        ],
+        "frame_stale": false,
+        "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+        "observation_seq": 9676,
+        "observation_t_wall_ms": 1779101317006,
+        "observation_t_wall_s": 1779101317.0063336,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779101317066,
+            "channel": "composite_panel",
+            "frame_id": "1779101317066_000096",
+            "frame_seq": 96,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779101317066_000096_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779101317066_000096.png",
+            "sync_delta_ms": 60,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 60,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779101317066,
+          "channel": "composite_panel",
+          "frame_id": "1779101317066_000096",
+          "frame_seq": 96,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779101317066_000096_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779101317066_000096.png",
+          "sync_delta_ms": 60,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779101317006,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779101317066_000096"
+        ],
+        "fresh_fact_ids": [
+          "fcs_page_visible",
+          "fcsmc_page_visible",
+          "fcsmc_final_go_result_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "not_seen_fact_ids": [
+          "tac_page_visible",
+          "supt_page_visible",
+          "fcs_page_x_marks_visible",
+          "bit_root_page_visible",
+          "fcsmc_intermediate_result_visible",
+          "fcsmc_in_test_visible"
+        ],
+        "seen_fact_ids": [
+          "fcs_page_visible",
+          "fcsmc_page_visible",
+          "fcsmc_final_go_result_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "status": "available",
+        "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": [
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "tac_page_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "supt_page_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "fcs_page_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "fcs_page_x_marks_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "bit_root_page_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "fcsmc_page_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "fcsmc_intermediate_result_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "fcsmc_in_test_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 600000,
+          "expires_at_wall_ms": 1779101917006,
+          "fact_id": "fcsmc_final_go_result_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "result_kind": "final_go",
+          "source_frame_id": "1779101317066_000096",
+          "state": "seen",
+          "sticky": true
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "hsi_page_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "hsi_map_layer_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "ins_grnd_alignment_text_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779101319006,
+          "fact_id": "ins_ok_text_visible",
+          "observed_at_wall_ms": 1779101317006,
+          "source_frame_id": "1779101317066_000096",
+          "state": "seen",
+          "sticky": false
+        }
+      ]
+    },
+    "vision_fact_observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "frame_ids": [
+            "1779101317066_000096"
+          ],
+          "observation_kind": "vision_fact"
+        },
+        "observation_id": "e185329c-5428-43fa-8ad5-e2fd50597142",
+        "payload": {
+          "facts": [
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "tac_page_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "supt_page_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_x_marks_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "bit_root_page_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_page_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_intermediate_result_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_in_test_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 600000,
+              "fact_id": "fcsmc_final_go_result_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "seen",
+              "sticky": true
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_page_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_map_layer_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_grnd_alignment_text_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_ok_text_visible",
+              "observed_at_wall_ms": 1779101317006,
+              "result_kind": null,
+              "source_frame_id": "1779101317066_000096",
+              "state": "seen",
+              "sticky": false
+            }
+          ],
+          "frame_ids": [
+            "1779101317066_000096"
+          ],
+          "metadata": {
+            "coerced_source_frame_fact_ids": [],
+            "coerced_source_frame_fact_ids_alias_of": "ignored_legacy_source_frame_fact_ids",
+            "configured_fact_count": 13,
+            "ignored_legacy_source_frame_fact_ids": [],
+            "ignored_model_fact_fields": {},
+            "raw_fact_count": 13,
+            "raw_llm_text": "{\"facts\":[{\"fact_id\":\"tac_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"supt_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_x_marks_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"bit_root_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_intermediate_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_in_test_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_final_go_result_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_map_layer_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_grnd_alignment_text_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_ok_text_visible\",\"state\":\"seen\",\"evidence_note\":\"\"}]}",
+            "sanitized_fact_count": 13,
+            "skipped_incomplete_mapping_fact_count": 0,
+            "skipped_non_mapping_fact_count": 0,
+            "skipped_unknown_fact_id_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779101317066_000096"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            }
+          },
+          "observation_id": "e185329c-5428-43fa-8ad5-e2fd50597142",
+          "schema_version": "v2",
+          "session_id": "sess-live",
+          "source": "vision_fact_extractor",
+          "summary": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "timestamp": "2026-05-18T10:48:43.905677+00:00",
+          "trigger_wall_ms": 1779101317006
+        },
+        "procedure_hint": null,
+        "source": "vision_fact_extractor",
+        "tags": [],
+        "timestamp": "2026-05-18T10:48:43.905677+00:00",
+        "version": "v1"
+      }
+    ]
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+        "kind": "tutor_request",
+        "lineno": 10151,
+        "metadata": {
+          "frame_id": "1779101317066_000096",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 60,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_status": "available",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779101317066_000096"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "refuel_probe_switch"
+              },
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S21",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S21",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "refuel_probe_switch"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 9676
+              },
+              "vision_fresh_count": 7,
+              "vision_seen_count": 7,
+              "vision_status": "available"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_error_coding_guide_6",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.4 Parameter / Setting Error (PA)",
+                "score": 18.169210482199993,
+                "section": "2.4 Parameter / Setting Error (PA)",
+                "snippet_id": "fa18c_error_coding_guide_6"
+              },
+              {
+                "chunk_id": "fa18c_nasatlx_vr_0",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "score": 17.54182199533863,
+                "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "snippet_id": "fa18c_nasatlx_vr_0"
+              },
+              {
+                "chunk_id": "fa18c_scoring_sheet_template_2",
+                "doc_id": "fa18c_scoring_sheet_template",
+                "page_or_heading": "2. Step-Level Coding",
+                "score": 15.035058283635504,
+                "section": "2. Step-Level Coding",
+                "snippet_id": "fa18c_scoring_sheet_template_2"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.70514828499053,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_82",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 83,
+                "score": 13.45923683847562,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_82"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.ext_refuel_probe_value in [0,5000]"
+                ],
+                "overlay_step_id": "S21",
+                "role": "candidate_not_authoritative",
+                "step_id": "S21"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 9676,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": 14587,
+                    "last_value": 5606,
+                    "latest_transition_age_s": 0.0,
+                    "transition_count": 19,
+                    "var": "ext_refuel_probe_value"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9676,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 9676,
+                "latest_t_wall": 1779101317.0063336,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.056
+              },
+              "vision_evidence": {
+                "confidence": "high",
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "late_display_anchors": [
+                  "fcs_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "bit_root_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "supt_page_visible",
+                  "tac_page_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "source_status": "available",
+                "visual_candidate_steps": [
+                  "S12",
+                  "S13",
+                  "S18",
+                  "S19",
+                  "S20"
+                ]
+              }
+            },
+            "vision": {
+              "frame_id": "1779101317066_000096",
+              "frame_ids": [
+                "1779101317066_000096"
+              ],
+              "frame_stale": false,
+              "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+              "observation_seq": 9676,
+              "observation_t_wall_ms": 1779101317006,
+              "observation_t_wall_s": 1779101317.0063336,
+              "status": "partial",
+              "sync_delta_ms": 60,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779101317006,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779101317066_000096"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "fact_id": "tac_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "supt_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_x_marks_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "bit_root_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_in_test_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_map_layer_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_ok_text_visible",
+                "frame_ids": null,
+                "status": null
+              }
+            ]
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 9676
+              },
+              "vision_fresh_count": 7,
+              "vision_seen_count": 7,
+              "vision_status": "available"
+            },
+            "frame_id": "1779101317066_000096",
+            "fused_missing_conditions": [
+              "vars.ext_refuel_probe_value in [0,5000]"
+            ],
+            "fused_step_id": "S21",
+            "grounding_cache_hit": true,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_error_coding_guide_6"
+            ],
+            "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+            "prompt_tokens_est": 1189,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "source_chunk_refs": [
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_6",
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+              "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_82"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 60,
+            "vision_fact_seen_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779101317066_000096"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779101317066_000096"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+          "request_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+          "timestamp": "2026-05-18T10:48:43.932706+00:00",
+          "version": "v1"
+        },
+        "related_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+        "vision_refs": [
+          "1779101317066_000096"
+        ]
+      },
+      {
+        "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+        "kind": "overlay_requested",
+        "lineno": 10152,
+        "metadata": {
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779101317066_000096",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 60,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779101317066_000096"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "0825bbe3-6756-491e-b5d1-86cbd63d0745",
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779101317066_000096",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 60,
+          "target": "pnt_341",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779101317066_000096"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+        "kind": "tutor_response",
+        "lineno": 10153,
+        "metadata": {
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779101317066_000096",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 60,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779101317066_000096"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_341",
+              "evidence_refs": [
+                "GATES.S21.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "refuel_probe_switch"
+              ],
+              "frame_id": "1779101317066_000096",
+              "fused_missing_conditions": [
+                "vars.ext_refuel_probe_value in [0,5000]"
+              ],
+              "fused_step_id": "S21",
+              "generation_mode": "model",
+              "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 60,
+              "target": "refuel_probe_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779101317066_000096"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": "vision_conflict_unresolved",
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+          ],
+          "in_reply_to": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+          "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+          "metadata": {
+            "completion_conflict_original_explanations": [
+              "需要更多信息/请确认: refuel_probe_switch",
+              "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+            ],
+            "completion_conflict_original_message": "需要更多信息/请确认: refuel_probe_switch",
+            "completion_conflict_original_next": {
+              "step_id": "S20"
+            },
+            "completion_conflict_rewritten": true,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "c86a7170-aa6a-43b1-ab86-f33381f66f8a",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S20",
+              "missing_conditions": [
+                "vars.ext_refuel_probe_value in [60000,65535]"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate"
+              ],
+              "step_ui_targets": [
+                "refuel_probe_switch"
+              ]
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S21"
+            },
+            "evidence_guardrail_applied": true,
+            "evidence_guardrail_reasons": [
+              "invalid_target_evidence_refs:refuel_probe_switch"
+            ],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "failure_code": "evidence_fail",
+            "failure_codes": [
+              "evidence_fail",
+              "vision_conflict_unresolved"
+            ],
+            "failure_stage": "evidence_guardrail",
+            "fallback_explanations": [
+              "请先操作 refuel_probe_switch。"
+            ],
+            "fallback_message": "请先操作 refuel_probe_switch。",
+            "fallback_overlay_reason": "deterministic_step:S21",
+            "fallback_overlay_used": true,
+            "fallback_response_mapping": {
+              "allowed_evidence_ref_count": 130,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S21"
+              },
+              "next": {
+                "step_id": "S21"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_action_plan": {
+              "overlay_step_id": null,
+              "source": "model",
+              "step_id": "S21",
+              "targets": [
+                "refuel_probe_switch"
+              ],
+              "text_only": false
+            },
+            "final_overlay_targets": [
+              "refuel_probe_switch"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_341",
+                  "evidence_refs": [
+                    "GATES.S21.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "refuel_probe_switch"
+                  ],
+                  "frame_id": "1779101317066_000096",
+                  "fused_missing_conditions": [
+                    "vars.ext_refuel_probe_value in [0,5000]"
+                  ],
+                  "fused_step_id": "S21",
+                  "generation_mode": "model",
+                  "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "completion_conflict_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 60,
+                  "target": "refuel_probe_switch",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_ignored_count": 0,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779101317066_000096"
+                    ],
+                    "fresh_fact_ids": [
+                      "fcs_page_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_final_go_result_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "tac_page_visible",
+                      "supt_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "bit_root_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "fcs_page_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_final_go_result_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": "vision_conflict_unresolved",
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S21"
+              },
+              "explanations": [
+                "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+              ],
+              "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+              "next": {
+                "step_id": "S21"
+              }
+            },
+            "frame_id": "1779101317066_000096",
+            "fused_missing_conditions": [
+              "vars.ext_refuel_probe_value in [0,5000]"
+            ],
+            "fused_step_id": "S21",
+            "generation_mode": "model",
+            "generation_prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+            "generation_prompt_tokens_est": 1189,
+            "generation_prompt_trimmed": true,
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.92,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "sticky_state",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.fcsmc_final_go_result_visible",
+                    "VISION_FACTS.fcsmc_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.ins_ok_text_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S21",
+                  "supporting_evidence_refs": [
+                    "GATES.S21.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S21",
+                  "supporting_evidence_refs": [
+                    "GATES.S21.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "pitot_heater_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S26",
+                  "supporting_evidence_refs": [
+                    "GATES.S26.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "parking_brake_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S28",
+                  "supporting_evidence_refs": [
+                    "GATES.S28.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "refuel_probe_switch"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S21",
+                "supporting_evidence_refs": [
+                  "GATES.S21.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 1,
+                  "contradiction_count": 0,
+                  "frame_count": 20,
+                  "latest_seq": 9676
+                },
+                "vision_fresh_count": 7,
+                "vision_seen_count": 7,
+                "vision_status": "available"
+              },
+              "final_action_plan": {
+                "overlay_step_id": null,
+                "source": "model",
+                "step_id": "S21",
+                "targets": [
+                  "refuel_probe_switch"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "refuel_probe_switch"
+              ],
+              "message_category": "completion_conflict_repair",
+              "model_decision": {
+                "evidence_refs": [],
+                "generation_mode": "model",
+                "overlay_targets": [],
+                "status": "ok",
+                "step_id": "S20"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "deterministic_step:S21"
+              },
+              "schema_version": "v1",
+              "validator_result": {
+                "fallback_overlay_reason": "deterministic_step:S21",
+                "fallback_overlay_used": true,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": true,
+                "extractor_used": true,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779101317066_000096"
+                ],
+                "ignored_fact_count": 0,
+                "reason": "missing_pre_trigger_frame",
+                "status": "called",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 60,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "available",
+                "vision_status": "partial"
+              }
+            },
+            "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "explanations": [
+                "需要更多信息/请确认: refuel_probe_switch",
+                "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+              ],
+              "next": {
+                "step_id": "S20"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "explanations": [
+                "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+              ],
+              "next": {
+                "step_id": "S20"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "gates_summary",
+                    "target": "refuel_probe_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "refuel_probe_switch"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 3775,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "completion_conflict_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S20"
+            },
+            "model_raw_explanations": [
+              "需要更多信息/请确认: refuel_probe_switch",
+              "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "explanations": [
+                "需要更多信息/请确认: refuel_probe_switch",
+                "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+              ],
+              "next": {
+                "step_id": "S20"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S20"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779101317066_000096"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779101317066_000096",
+            "next": {
+              "step_id": "S21"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 933,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "RAG_SNIPPETS.fa18c_error_coding_guide_6",
+                "VISION_FACTS.tac_page_visible@1779101317066_000096",
+                "VISION_FACTS.supt_page_visible@1779101317066_000096"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 3,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "refuel_probe_switch",
+              "prompt_chars": 4756,
+              "prompt_tokens_est": 1189,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 1,
+              "rag_snippet_ids": [
+                "fa18c_error_coding_guide_6"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [
+                "S12",
+                "S13",
+                "S18",
+                "S19",
+                "S20"
+              ],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_rag_snippets",
+                "compact_template"
+              ],
+              "vision_fact_seen_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "vision_fact_status": "available"
+            },
+            "prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+            "prompt_tokens_est": 1189,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+            "request_prompt_tokens_est": 1189,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "next": {
+                "step_id": "S20"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "state_key": "db9e9ca1d9482d0cfd4a3be5ebabb1947f2bb85c1b52ae4e703e51cd47c80296",
+            "sync_delta_ms": 60,
+            "vision": {
+              "frame_id": "1779101317066_000096",
+              "frame_ids": [
+                "1779101317066_000096"
+              ],
+              "frame_stale": false,
+              "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+              "observation_seq": 9676,
+              "observation_t_wall_ms": 1779101317006,
+              "observation_t_wall_s": 1779101317.0063336,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779101317066,
+                  "channel": "composite_panel",
+                  "frame_id": "1779101317066_000096",
+                  "frame_seq": 96,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779101317066_000096_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779101317066_000096.png",
+                  "sync_delta_ms": 60,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 60,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779101317066,
+                "channel": "composite_panel",
+                "frame_id": "1779101317066_000096",
+                "frame_seq": 96,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779101317066_000096_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779101317066_000096.png",
+                "sync_delta_ms": 60,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779101317006,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S08"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": true,
+            "vision_fact_ignored_count": 0,
+            "vision_fact_status": "available",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779101317066_000096"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "tac_page_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "supt_page_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "fcs_page_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "fcs_page_x_marks_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "bit_root_page_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "fcsmc_page_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "fcsmc_in_test_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 600000,
+                "expires_at_wall_ms": 1779101917006,
+                "fact_id": "fcsmc_final_go_result_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "result_kind": "final_go",
+                "source_frame_id": "1779101317066_000096",
+                "state": "seen",
+                "sticky": true
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "hsi_page_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "hsi_map_layer_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779101319006,
+                "fact_id": "ins_ok_text_visible",
+                "observed_at_wall_ms": 1779101317006,
+                "source_frame_id": "1779101317066_000096",
+                "state": "seen",
+                "sticky": false
+              }
+            ],
+            "vision_fallback_reason": "vision_conflict_unresolved",
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779101317066_000096"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "missing_pre_trigger_frame",
+            "vlm_call_status": "called"
+          },
+          "response_id": "85376608-3115-4cb6-8a5a-dc80a6b742ab",
+          "status": "ok",
+          "timestamp": "2026-05-18T10:48:47.710239+00:00",
+          "version": "v1"
+        },
+        "related_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+        "vision_refs": [
+          "1779101317066_000096"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "refuel_probe_switch"
+          },
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S21",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S21",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "refuel_probe_switch"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 9676
+          },
+          "vision_fresh_count": 7,
+          "vision_seen_count": 7,
+          "vision_status": "available"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_error_coding_guide_6",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.4 Parameter / Setting Error (PA)",
+            "score": 18.169210482199993,
+            "section": "2.4 Parameter / Setting Error (PA)",
+            "snippet_id": "fa18c_error_coding_guide_6"
+          },
+          {
+            "chunk_id": "fa18c_nasatlx_vr_0",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "score": 17.54182199533863,
+            "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "snippet_id": "fa18c_nasatlx_vr_0"
+          },
+          {
+            "chunk_id": "fa18c_scoring_sheet_template_2",
+            "doc_id": "fa18c_scoring_sheet_template",
+            "page_or_heading": "2. Step-Level Coding",
+            "score": 15.035058283635504,
+            "section": "2. Step-Level Coding",
+            "snippet_id": "fa18c_scoring_sheet_template_2"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.70514828499053,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_82",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 83,
+            "score": 13.45923683847562,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_82"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.ext_refuel_probe_value in [0,5000]"
+            ],
+            "overlay_step_id": "S21",
+            "role": "candidate_not_authoritative",
+            "step_id": "S21"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 9676,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": 14587,
+                "last_value": 5606,
+                "latest_transition_age_s": 0.0,
+                "transition_count": 19,
+                "var": "ext_refuel_probe_value"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9676,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 9676,
+            "latest_t_wall": 1779101317.0063336,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.056
+          },
+          "vision_evidence": {
+            "confidence": "high",
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "late_display_anchors": [
+              "fcs_page_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "bit_root_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_intermediate_result_visible",
+              "supt_page_visible",
+              "tac_page_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "source_status": "available",
+            "visual_candidate_steps": [
+              "S12",
+              "S13",
+              "S18",
+              "S19",
+              "S20"
+            ]
+          }
+        },
+        "vision": {
+          "frame_id": "1779101317066_000096",
+          "frame_ids": [
+            "1779101317066_000096"
+          ],
+          "frame_stale": false,
+          "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+          "observation_seq": 9676,
+          "observation_t_wall_ms": 1779101317006,
+          "observation_t_wall_s": 1779101317.0063336,
+          "status": "partial",
+          "sync_delta_ms": 60,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779101317006,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779101317066_000096"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "fact_id": "tac_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "supt_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_x_marks_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "bit_root_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_in_test_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_map_layer_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_ok_text_visible",
+            "frame_ids": null,
+            "status": null
+          }
+        ]
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 9676
+          },
+          "vision_fresh_count": 7,
+          "vision_seen_count": 7,
+          "vision_status": "available"
+        },
+        "frame_id": "1779101317066_000096",
+        "fused_missing_conditions": [
+          "vars.ext_refuel_probe_value in [0,5000]"
+        ],
+        "fused_step_id": "S21",
+        "grounding_cache_hit": true,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_error_coding_guide_6"
+        ],
+        "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+        "prompt_tokens_est": 1189,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "source_chunk_refs": [
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_6",
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+          "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_82"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 60,
+        "vision_fact_seen_ids": [
+          "fcs_page_visible",
+          "fcsmc_page_visible",
+          "fcsmc_final_go_result_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779101317066_000096"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779101317066_000096"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+      "request_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+      "timestamp": "2026-05-18T10:48:43.932706+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_341",
+          "evidence_refs": [
+            "GATES.S21.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779101317066_000096",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 60,
+          "target": "refuel_probe_switch",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779101317066_000096"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+      ],
+      "in_reply_to": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+      "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+      "metadata": {
+        "completion_conflict_original_explanations": [
+          "需要更多信息/请确认: refuel_probe_switch",
+          "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+        ],
+        "completion_conflict_original_message": "需要更多信息/请确认: refuel_probe_switch",
+        "completion_conflict_original_next": {
+          "step_id": "S20"
+        },
+        "completion_conflict_rewritten": true,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "c86a7170-aa6a-43b1-ab86-f33381f66f8a",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S20",
+          "missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate"
+          ],
+          "step_ui_targets": [
+            "refuel_probe_switch"
+          ]
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S21"
+        },
+        "evidence_guardrail_applied": true,
+        "evidence_guardrail_reasons": [
+          "invalid_target_evidence_refs:refuel_probe_switch"
+        ],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "failure_code": "evidence_fail",
+        "failure_codes": [
+          "evidence_fail",
+          "vision_conflict_unresolved"
+        ],
+        "failure_stage": "evidence_guardrail",
+        "fallback_explanations": [
+          "请先操作 refuel_probe_switch。"
+        ],
+        "fallback_message": "请先操作 refuel_probe_switch。",
+        "fallback_overlay_reason": "deterministic_step:S21",
+        "fallback_overlay_used": true,
+        "fallback_response_mapping": {
+          "allowed_evidence_ref_count": 130,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S21"
+          },
+          "next": {
+            "step_id": "S21"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_action_plan": {
+          "overlay_step_id": null,
+          "source": "model",
+          "step_id": "S21",
+          "targets": [
+            "refuel_probe_switch"
+          ],
+          "text_only": false
+        },
+        "final_overlay_targets": [
+          "refuel_probe_switch"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_341",
+              "evidence_refs": [
+                "GATES.S21.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "refuel_probe_switch"
+              ],
+              "frame_id": "1779101317066_000096",
+              "fused_missing_conditions": [
+                "vars.ext_refuel_probe_value in [0,5000]"
+              ],
+              "fused_step_id": "S21",
+              "generation_mode": "model",
+              "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 60,
+              "target": "refuel_probe_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779101317066_000096"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": "vision_conflict_unresolved",
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S21"
+          },
+          "explanations": [
+            "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+          ],
+          "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+          "next": {
+            "step_id": "S21"
+          }
+        },
+        "frame_id": "1779101317066_000096",
+        "fused_missing_conditions": [
+          "vars.ext_refuel_probe_value in [0,5000]"
+        ],
+        "fused_step_id": "S21",
+        "generation_mode": "model",
+        "generation_prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+        "generation_prompt_tokens_est": 1189,
+        "generation_prompt_trimmed": true,
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.92,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "sticky_state",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.fcsmc_final_go_result_visible",
+                "VISION_FACTS.fcsmc_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.ins_ok_text_visible"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S21",
+              "supporting_evidence_refs": [
+                "GATES.S21.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S21",
+              "supporting_evidence_refs": [
+                "GATES.S21.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "pitot_heater_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S26",
+              "supporting_evidence_refs": [
+                "GATES.S26.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "parking_brake_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S28",
+              "supporting_evidence_refs": [
+                "GATES.S28.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "refuel_probe_switch"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S21",
+            "supporting_evidence_refs": [
+              "GATES.S21.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 1,
+              "contradiction_count": 0,
+              "frame_count": 20,
+              "latest_seq": 9676
+            },
+            "vision_fresh_count": 7,
+            "vision_seen_count": 7,
+            "vision_status": "available"
+          },
+          "final_action_plan": {
+            "overlay_step_id": null,
+            "source": "model",
+            "step_id": "S21",
+            "targets": [
+              "refuel_probe_switch"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "message_category": "completion_conflict_repair",
+          "model_decision": {
+            "evidence_refs": [],
+            "generation_mode": "model",
+            "overlay_targets": [],
+            "status": "ok",
+            "step_id": "S20"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "deterministic_step:S21"
+          },
+          "schema_version": "v1",
+          "validator_result": {
+            "fallback_overlay_reason": "deterministic_step:S21",
+            "fallback_overlay_used": true,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": true,
+            "extractor_used": true,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779101317066_000096"
+            ],
+            "ignored_fact_count": 0,
+            "reason": "missing_pre_trigger_frame",
+            "status": "called",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 60,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "available",
+            "vision_status": "partial"
+          }
+        },
+        "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "explanations": [
+            "需要更多信息/请确认: refuel_probe_switch",
+            "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+          ],
+          "next": {
+            "step_id": "S20"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "explanations": [
+            "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+          ],
+          "next": {
+            "step_id": "S20"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "gates_summary",
+                "target": "refuel_probe_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "refuel_probe_switch"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 3775,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "completion_conflict_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S20"
+        },
+        "model_raw_explanations": [
+          "需要更多信息/请确认: refuel_probe_switch",
+          "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "explanations": [
+            "需要更多信息/请确认: refuel_probe_switch",
+            "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+          ],
+          "next": {
+            "step_id": "S20"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S20"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779101317066_000096"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779101317066_000096",
+        "next": {
+          "step_id": "S21"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 933,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "RAG_SNIPPETS.fa18c_error_coding_guide_6",
+            "VISION_FACTS.tac_page_visible@1779101317066_000096",
+            "VISION_FACTS.supt_page_visible@1779101317066_000096"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 3,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "refuel_probe_switch",
+          "prompt_chars": 4756,
+          "prompt_tokens_est": 1189,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 1,
+          "rag_snippet_ids": [
+            "fa18c_error_coding_guide_6"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [
+            "S12",
+            "S13",
+            "S18",
+            "S19",
+            "S20"
+          ],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_rag_snippets",
+            "compact_template"
+          ],
+          "vision_fact_seen_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "vision_fact_status": "available"
+        },
+        "prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+        "prompt_tokens_est": 1189,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "8d10d0572ffb613e9bf552b2254034c97b6af88905699156c3cb46920e36afaf",
+        "request_prompt_tokens_est": 1189,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "next": {
+            "step_id": "S20"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "state_key": "db9e9ca1d9482d0cfd4a3be5ebabb1947f2bb85c1b52ae4e703e51cd47c80296",
+        "sync_delta_ms": 60,
+        "vision": {
+          "frame_id": "1779101317066_000096",
+          "frame_ids": [
+            "1779101317066_000096"
+          ],
+          "frame_stale": false,
+          "observation_ref": "95eafb4b-a972-4ff3-b763-6d0761d7f171",
+          "observation_seq": 9676,
+          "observation_t_wall_ms": 1779101317006,
+          "observation_t_wall_s": 1779101317.0063336,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779101317066,
+              "channel": "composite_panel",
+              "frame_id": "1779101317066_000096",
+              "frame_seq": 96,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779101317066_000096_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779101317066_000096.png",
+              "sync_delta_ms": 60,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 60,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779101317066,
+            "channel": "composite_panel",
+            "frame_id": "1779101317066_000096",
+            "frame_seq": 96,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779101317066_000096_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779101317066_000096.png",
+            "sync_delta_ms": 60,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779101317006,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S08"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": true,
+        "vision_fact_ignored_count": 0,
+        "vision_fact_status": "available",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779101317066_000096"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "tac_page_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "supt_page_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "fcs_page_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "fcs_page_x_marks_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "bit_root_page_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "fcsmc_page_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "fcsmc_in_test_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 600000,
+            "expires_at_wall_ms": 1779101917006,
+            "fact_id": "fcsmc_final_go_result_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "result_kind": "final_go",
+            "source_frame_id": "1779101317066_000096",
+            "state": "seen",
+            "sticky": true
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "hsi_page_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "hsi_map_layer_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779101319006,
+            "fact_id": "ins_ok_text_visible",
+            "observed_at_wall_ms": 1779101317006,
+            "source_frame_id": "1779101317066_000096",
+            "state": "seen",
+            "sticky": false
+          }
+        ],
+        "vision_fallback_reason": "vision_conflict_unresolved",
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779101317066_000096"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "missing_pre_trigger_frame",
+        "vlm_call_status": "called"
+      },
+      "response_id": "85376608-3115-4cb6-8a5a-dc80a6b742ab",
+      "status": "ok",
+      "timestamp": "2026-05-18T10:48:47.710239+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S21",
+    "expected_overlay_target_ids": [
+      "refuel_probe_switch"
+    ],
+    "final_response_source": "deterministic_step:S21",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "called"
+  },
+  "extraction_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.92,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "sticky_state",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.fcsmc_final_go_result_visible",
+          "VISION_FACTS.fcsmc_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.ins_ok_text_visible"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S21",
+        "supporting_evidence_refs": [
+          "GATES.S21.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S21",
+        "supporting_evidence_refs": [
+          "GATES.S21.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "pitot_heater_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S26",
+        "supporting_evidence_refs": [
+          "GATES.S26.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "parking_brake_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S28",
+        "supporting_evidence_refs": [
+          "GATES.S28.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "overlay_step_id": null,
+      "source": "model",
+      "step_id": "S21",
+      "targets": [
+        "refuel_probe_switch"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [],
+      "generation_mode": "model",
+      "overlay_targets": [],
+      "status": "ok",
+      "step_id": "S20"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "deterministic_step:S21"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.92,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "sticky_state",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.fcsmc_final_go_result_visible",
+            "VISION_FACTS.fcsmc_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.ins_ok_text_visible"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S21",
+          "supporting_evidence_refs": [
+            "GATES.S21.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S21",
+          "supporting_evidence_refs": [
+            "GATES.S21.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "pitot_heater_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S26",
+          "supporting_evidence_refs": [
+            "GATES.S26.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "parking_brake_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S28",
+          "supporting_evidence_refs": [
+            "GATES.S28.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S21",
+        "supporting_evidence_refs": [
+          "GATES.S21.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 1,
+          "contradiction_count": 0,
+          "frame_count": 20,
+          "latest_seq": 9676
+        },
+        "vision_fresh_count": 7,
+        "vision_seen_count": 7,
+        "vision_status": "available"
+      },
+      "final_action_plan": {
+        "overlay_step_id": null,
+        "source": "model",
+        "step_id": "S21",
+        "targets": [
+          "refuel_probe_switch"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "refuel_probe_switch"
+      ],
+      "message_category": "completion_conflict_repair",
+      "model_decision": {
+        "evidence_refs": [],
+        "generation_mode": "model",
+        "overlay_targets": [],
+        "status": "ok",
+        "step_id": "S20"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "deterministic_step:S21"
+      },
+      "schema_version": "v1",
+      "validator_result": {
+        "fallback_overlay_reason": "deterministic_step:S21",
+        "fallback_overlay_used": true,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": true,
+        "extractor_used": true,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779101317066_000096"
+        ],
+        "ignored_fact_count": 0,
+        "reason": "missing_pre_trigger_frame",
+        "status": "called",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 60,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "available",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "deterministic_step:S21",
+      "fallback_overlay_used": true,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S20"
+      },
+      "explanations": [
+        "需要更多信息/请确认: refuel_probe_switch",
+        "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+      ],
+      "next": {
+        "step_id": "S20"
+      },
+      "overlay": {
+        "evidence": [],
+        "targets": []
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S20"
+      },
+      "explanations": [
+        "需要更多信息/请确认: refuel_probe_switch",
+        "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 以伸出加油探头。"
+      ],
+      "next": {
+        "step_id": "S20"
+      },
+      "overlay": {
+        "evidence": [],
+        "targets": []
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "99b112ae-ea07-4f5f-a561-71e99fdc2581",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 10442,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260518_103842.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/c2849a41-0f9b-4440-b926-52a9695cd871.fixture.json
+++ b/artifacts/live_fixtures/c2849a41-0f9b-4440-b926-52a9695cd871.fixture.json
@@ -1,0 +1,3843 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "frame_count": 20,
+        "latest_seq": 12642
+      },
+      "vision_fresh_count": 7,
+      "vision_seen_count": 7,
+      "vision_status": "available"
+    },
+    "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:59431",
+          "raw_delta_count": 1,
+          "seq": 12642
+        },
+        "observation_id": "4f6aede7-c06f-43f6-9056-7d857322574a",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41414
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 12642,
+          "t_wall": 1779045232.7113395,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 296,
+            "temp_r": 296,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-17T19:13:52.712345+00:00",
+        "version": "v1"
+      }
+    ],
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "frame_count": 20,
+      "latest_seq": 12642
+    },
+    "vision": {
+      "frame_ids": [
+        "1779045232773_000068"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779045232773_000068",
+        "frame_ids": [
+          "1779045232773_000068"
+        ],
+        "frame_stale": false,
+        "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+        "observation_seq": 12642,
+        "observation_t_wall_ms": 1779045232711,
+        "observation_t_wall_s": 1779045232.7113395,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779045232773,
+            "channel": "composite_panel",
+            "frame_id": "1779045232773_000068",
+            "frame_seq": 68,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045232773_000068_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045232773_000068.png",
+            "sync_delta_ms": 97,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 97,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779045232773,
+          "channel": "composite_panel",
+          "frame_id": "1779045232773_000068",
+          "frame_seq": 68,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045232773_000068_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045232773_000068.png",
+          "sync_delta_ms": 97,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779045232676,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779045232773_000068"
+        ],
+        "fresh_fact_ids": [
+          "fcs_page_visible",
+          "fcsmc_page_visible",
+          "fcsmc_final_go_result_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "not_seen_fact_ids": [
+          "tac_page_visible",
+          "supt_page_visible",
+          "fcs_page_x_marks_visible",
+          "bit_root_page_visible",
+          "fcsmc_intermediate_result_visible",
+          "fcsmc_in_test_visible"
+        ],
+        "seen_fact_ids": [
+          "fcs_page_visible",
+          "fcsmc_page_visible",
+          "fcsmc_final_go_result_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "status": "available",
+        "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": [
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "tac_page_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "supt_page_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "fcs_page_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "fcs_page_x_marks_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "bit_root_page_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "fcsmc_page_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "fcsmc_intermediate_result_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "fcsmc_in_test_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 600000,
+          "expires_at_wall_ms": 1779045832676,
+          "fact_id": "fcsmc_final_go_result_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "result_kind": "final_go",
+          "source_frame_id": "1779045232773_000068",
+          "state": "seen",
+          "sticky": true
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "hsi_page_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "hsi_map_layer_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "ins_grnd_alignment_text_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779045234676,
+          "fact_id": "ins_ok_text_visible",
+          "observed_at_wall_ms": 1779045232676,
+          "source_frame_id": "1779045232773_000068",
+          "state": "seen",
+          "sticky": false
+        }
+      ]
+    },
+    "vision_fact_observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "frame_ids": [
+            "1779045232773_000068"
+          ],
+          "observation_kind": "vision_fact"
+        },
+        "observation_id": "96401968-4d70-46a9-bb4e-70f5c42d6e5a",
+        "payload": {
+          "facts": [
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "tac_page_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "supt_page_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_x_marks_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "bit_root_page_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_page_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_intermediate_result_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_in_test_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 600000,
+              "fact_id": "fcsmc_final_go_result_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "seen",
+              "sticky": true
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_page_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_map_layer_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_grnd_alignment_text_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_ok_text_visible",
+              "observed_at_wall_ms": 1779045232676,
+              "result_kind": null,
+              "source_frame_id": "1779045232773_000068",
+              "state": "seen",
+              "sticky": false
+            }
+          ],
+          "frame_ids": [
+            "1779045232773_000068"
+          ],
+          "metadata": {
+            "coerced_source_frame_fact_ids": [],
+            "coerced_source_frame_fact_ids_alias_of": "ignored_legacy_source_frame_fact_ids",
+            "configured_fact_count": 13,
+            "ignored_legacy_source_frame_fact_ids": [],
+            "ignored_model_fact_fields": {},
+            "raw_fact_count": 13,
+            "raw_llm_text": "{\"facts\":[{\"fact_id\":\"tac_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"supt_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_x_marks_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"bit_root_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_intermediate_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_in_test_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_final_go_result_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_map_layer_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_grnd_alignment_text_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_ok_text_visible\",\"state\":\"seen\",\"evidence_note\":\"\"}]}",
+            "sanitized_fact_count": 13,
+            "skipped_incomplete_mapping_fact_count": 0,
+            "skipped_non_mapping_fact_count": 0,
+            "skipped_unknown_fact_id_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045232773_000068"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            }
+          },
+          "observation_id": "96401968-4d70-46a9-bb4e-70f5c42d6e5a",
+          "schema_version": "v2",
+          "session_id": "sess-live",
+          "source": "vision_fact_extractor",
+          "summary": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "timestamp": "2026-05-17T19:13:59.550739+00:00",
+          "trigger_wall_ms": 1779045232676
+        },
+        "procedure_hint": null,
+        "source": "vision_fact_extractor",
+        "tags": [],
+        "timestamp": "2026-05-17T19:13:59.550739+00:00",
+        "version": "v1"
+      }
+    ]
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+        "kind": "tutor_request",
+        "lineno": 13122,
+        "metadata": {
+          "frame_id": "1779045232773_000068",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_status": "available",
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045232773_000068"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "refuel_probe_switch"
+              },
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S21",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S21",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "refuel_probe_switch"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 12642
+              },
+              "vision_fresh_count": 7,
+              "vision_seen_count": 7,
+              "vision_status": "available"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_error_coding_guide_6",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.4 Parameter / Setting Error (PA)",
+                "score": 18.169210482199993,
+                "section": "2.4 Parameter / Setting Error (PA)",
+                "snippet_id": "fa18c_error_coding_guide_6"
+              },
+              {
+                "chunk_id": "fa18c_nasatlx_vr_0",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "score": 17.54182199533863,
+                "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "snippet_id": "fa18c_nasatlx_vr_0"
+              },
+              {
+                "chunk_id": "fa18c_scoring_sheet_template_2",
+                "doc_id": "fa18c_scoring_sheet_template",
+                "page_or_heading": "2. Step-Level Coding",
+                "score": 15.035058283635504,
+                "section": "2. Step-Level Coding",
+                "snippet_id": "fa18c_scoring_sheet_template_2"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.70514828499053,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_82",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 83,
+                "score": 13.45923683847562,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_82"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.ext_refuel_probe_value in [0,5000]"
+                ],
+                "overlay_step_id": "S21",
+                "role": "candidate_not_authoritative",
+                "step_id": "S21"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 12642,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12642,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 12642,
+                "latest_t_wall": 1779045232.7113395,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.681
+              },
+              "vision_evidence": {
+                "confidence": "high",
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "late_display_anchors": [
+                  "fcs_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "bit_root_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "supt_page_visible",
+                  "tac_page_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "source_status": "available",
+                "visual_candidate_steps": [
+                  "S12",
+                  "S13",
+                  "S18",
+                  "S19",
+                  "S20"
+                ]
+              }
+            },
+            "vision": {
+              "frame_id": "1779045232773_000068",
+              "frame_ids": [
+                "1779045232773_000068"
+              ],
+              "frame_stale": false,
+              "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+              "observation_seq": 12642,
+              "observation_t_wall_ms": 1779045232711,
+              "observation_t_wall_s": 1779045232.7113395,
+              "status": "partial",
+              "sync_delta_ms": 97,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779045232676,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045232773_000068"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "fact_id": "tac_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "supt_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_x_marks_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "bit_root_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_in_test_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_map_layer_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_ok_text_visible",
+                "frame_ids": null,
+                "status": null
+              }
+            ]
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "frame_count": 20,
+                "latest_seq": 12642
+              },
+              "vision_fresh_count": 7,
+              "vision_seen_count": 7,
+              "vision_status": "available"
+            },
+            "frame_id": "1779045232773_000068",
+            "fused_missing_conditions": [
+              "vars.ext_refuel_probe_value in [0,5000]"
+            ],
+            "fused_step_id": "S21",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_error_coding_guide_6"
+            ],
+            "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+            "prompt_tokens_est": 1150,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "source_chunk_refs": [
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_6",
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+              "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_82"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 97,
+            "vision_fact_seen_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045232773_000068"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779045232773_000068"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+          "request_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+          "timestamp": "2026-05-17T19:13:59.588788+00:00",
+          "version": "v1"
+        },
+        "related_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+        "vision_refs": [
+          "1779045232773_000068"
+        ]
+      },
+      {
+        "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+        "kind": "overlay_requested",
+        "lineno": 13123,
+        "metadata": {
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779045232773_000068",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045232773_000068"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "41b0fdb7-4eb0-46c9-9569-5f23f8815160",
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779045232773_000068",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 97,
+          "target": "pnt_341",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045232773_000068"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+        "kind": "tutor_response",
+        "lineno": 13124,
+        "metadata": {
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779045232773_000068",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 97,
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045232773_000068"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_341",
+              "evidence_refs": [
+                "GATES.S21.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "refuel_probe_switch"
+              ],
+              "frame_id": "1779045232773_000068",
+              "fused_missing_conditions": [
+                "vars.ext_refuel_probe_value in [0,5000]"
+              ],
+              "fused_step_id": "S21",
+              "generation_mode": "model",
+              "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 97,
+              "target": "refuel_probe_switch",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779045232773_000068"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": "vision_conflict_unresolved",
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+          ],
+          "in_reply_to": "c2849a41-0f9b-4440-b926-52a9695cd871",
+          "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+          "metadata": {
+            "completion_conflict_original_explanations": [
+              "需要更多信息/请确认: refuel_probe_switch",
+              "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+            ],
+            "completion_conflict_original_message": "需要更多信息/请确认: refuel_probe_switch",
+            "completion_conflict_original_next": {
+              "step_id": "S20"
+            },
+            "completion_conflict_rewritten": true,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "516a332f-56bf-4510-a566-65abe9786228",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S20",
+              "missing_conditions": [
+                "vars.ext_refuel_probe_value in [60000,65535]"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate"
+              ],
+              "step_ui_targets": [
+                "refuel_probe_switch"
+              ]
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S21"
+            },
+            "evidence_guardrail_applied": true,
+            "evidence_guardrail_reasons": [
+              "invalid_target_evidence_refs:refuel_probe_switch"
+            ],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "failure_code": "evidence_fail",
+            "failure_codes": [
+              "evidence_fail",
+              "vision_conflict_unresolved"
+            ],
+            "failure_stage": "evidence_guardrail",
+            "fallback_explanations": [
+              "请先操作 refuel_probe_switch。"
+            ],
+            "fallback_message": "请先操作 refuel_probe_switch。",
+            "fallback_overlay_reason": "deterministic_step:S21",
+            "fallback_overlay_used": true,
+            "fallback_response_mapping": {
+              "allowed_evidence_ref_count": 129,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S21"
+              },
+              "next": {
+                "step_id": "S21"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_action_plan": {
+              "overlay_step_id": null,
+              "source": "model",
+              "step_id": "S21",
+              "targets": [
+                "refuel_probe_switch"
+              ],
+              "text_only": false
+            },
+            "final_overlay_targets": [
+              "refuel_probe_switch"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_341",
+                  "evidence_refs": [
+                    "GATES.S21.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "refuel_probe_switch"
+                  ],
+                  "frame_id": "1779045232773_000068",
+                  "fused_missing_conditions": [
+                    "vars.ext_refuel_probe_value in [0,5000]"
+                  ],
+                  "fused_step_id": "S21",
+                  "generation_mode": "model",
+                  "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "completion_conflict_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 97,
+                  "target": "refuel_probe_switch",
+                  "type": "overlay",
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779045232773_000068"
+                    ],
+                    "fresh_fact_ids": [
+                      "fcs_page_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_final_go_result_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "tac_page_visible",
+                      "supt_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "bit_root_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "fcs_page_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_final_go_result_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": "vision_conflict_unresolved",
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S21"
+              },
+              "explanations": [
+                "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+              ],
+              "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+              "next": {
+                "step_id": "S21"
+              }
+            },
+            "frame_id": "1779045232773_000068",
+            "fused_missing_conditions": [
+              "vars.ext_refuel_probe_value in [0,5000]"
+            ],
+            "fused_step_id": "S21",
+            "generation_mode": "model",
+            "generation_prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+            "generation_prompt_tokens_est": 1150,
+            "generation_prompt_trimmed": true,
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.92,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "sticky_state",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.fcs_page_visible",
+                    "VISION_FACTS.fcsmc_final_go_result_visible",
+                    "VISION_FACTS.fcsmc_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.ins_ok_text_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S21",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "pitot_heater_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S26",
+                  "supporting_evidence_refs": [
+                    "GATES.S26.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "parking_brake_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S28",
+                  "supporting_evidence_refs": [
+                    "GATES.S28.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button",
+                    "ifei_down_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": [
+                    "GATES.S29.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "refuel_probe_switch"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S21",
+                "supporting_evidence_refs": []
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "frame_count": 20,
+                  "latest_seq": 12642
+                },
+                "vision_fresh_count": 7,
+                "vision_seen_count": 7,
+                "vision_status": "available"
+              },
+              "final_action_plan": {
+                "overlay_step_id": null,
+                "source": "model",
+                "step_id": "S21",
+                "targets": [
+                  "refuel_probe_switch"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "refuel_probe_switch"
+              ],
+              "message_category": "completion_conflict_repair",
+              "model_decision": {
+                "evidence_refs": [],
+                "generation_mode": "model",
+                "overlay_targets": [],
+                "status": "ok",
+                "step_id": "S20"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "deterministic_step:S21"
+              },
+              "schema_version": "v1",
+              "validator_result": {
+                "fallback_overlay_reason": "deterministic_step:S21",
+                "fallback_overlay_used": true,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "extractor_used": true,
+                "frame_ids": [
+                  "1779045232773_000068"
+                ],
+                "reason": "missing_pre_trigger_frame",
+                "status": "called",
+                "sync_delta_ms": 97,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "available",
+                "vision_status": "partial"
+              }
+            },
+            "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "explanations": [
+                "需要更多信息/请确认: refuel_probe_switch",
+                "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+              ],
+              "next": {
+                "step_id": "S20"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "explanations": [
+                "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+              ],
+              "next": {
+                "step_id": "S20"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "gates_summary",
+                    "target": "refuel_probe_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "refuel_probe_switch"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 3731,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "completion_conflict_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S20"
+            },
+            "model_raw_explanations": [
+              "需要更多信息/请确认: refuel_probe_switch",
+              "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "explanations": [
+                "需要更多信息/请确认: refuel_probe_switch",
+                "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+              ],
+              "next": {
+                "step_id": "S20"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S20"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779045232773_000068"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779045232773_000068",
+            "next": {
+              "step_id": "S21"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 924,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "RAG_SNIPPETS.fa18c_error_coding_guide_6",
+                "VISION_FACTS.tac_page_visible@1779045232773_000068",
+                "VISION_FACTS.supt_page_visible@1779045232773_000068"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 3,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "refuel_probe_switch",
+              "prompt_chars": 4598,
+              "prompt_tokens_est": 1150,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 1,
+              "rag_snippet_ids": [
+                "fa18c_error_coding_guide_6"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [
+                "S12",
+                "S13",
+                "S18",
+                "S19",
+                "S20"
+              ],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_rag_snippets",
+                "compact_template"
+              ],
+              "vision_fact_seen_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "vision_fact_status": "available"
+            },
+            "prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+            "prompt_tokens_est": 1150,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+            "request_prompt_tokens_est": 1150,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S20"
+              },
+              "next": {
+                "step_id": "S20"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "state_key": "420509dfb4c1ea964c5127be124cb107e03a74e6b5265583ec584936c3d22b72",
+            "sync_delta_ms": 97,
+            "vision": {
+              "frame_id": "1779045232773_000068",
+              "frame_ids": [
+                "1779045232773_000068"
+              ],
+              "frame_stale": false,
+              "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+              "observation_seq": 12642,
+              "observation_t_wall_ms": 1779045232711,
+              "observation_t_wall_s": 1779045232.7113395,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779045232773,
+                  "channel": "composite_panel",
+                  "frame_id": "1779045232773_000068",
+                  "frame_seq": 68,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045232773_000068_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045232773_000068.png",
+                  "sync_delta_ms": 97,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 97,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779045232773,
+                "channel": "composite_panel",
+                "frame_id": "1779045232773_000068",
+                "frame_seq": 68,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045232773_000068_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045232773_000068.png",
+                "sync_delta_ms": 97,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779045232676,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S08"
+            ],
+            "vision_fact_extractor_used": true,
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779045232773_000068"
+              ],
+              "fresh_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "supt_page_visible",
+                "fcs_page_x_marks_visible",
+                "bit_root_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible"
+              ],
+              "seen_fact_ids": [
+                "fcs_page_visible",
+                "fcsmc_page_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "tac_page_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "supt_page_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "fcs_page_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "fcs_page_x_marks_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "bit_root_page_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "fcsmc_page_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "fcsmc_in_test_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 600000,
+                "expires_at_wall_ms": 1779045832676,
+                "fact_id": "fcsmc_final_go_result_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "result_kind": "final_go",
+                "source_frame_id": "1779045232773_000068",
+                "state": "seen",
+                "sticky": true
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "hsi_page_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "hsi_map_layer_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779045234676,
+                "fact_id": "ins_ok_text_visible",
+                "observed_at_wall_ms": 1779045232676,
+                "source_frame_id": "1779045232773_000068",
+                "state": "seen",
+                "sticky": false
+              }
+            ],
+            "vision_fallback_reason": "vision_conflict_unresolved",
+            "vision_frame_ids": [
+              "1779045232773_000068"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "missing_pre_trigger_frame",
+            "vlm_call_status": "called"
+          },
+          "response_id": "e1cfed7c-0905-45d5-9a0e-e915fd4e6974",
+          "status": "ok",
+          "timestamp": "2026-05-17T19:14:03.321186+00:00",
+          "version": "v1"
+        },
+        "related_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+        "vision_refs": [
+          "1779045232773_000068"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "refuel_probe_switch"
+          },
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S21",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S21",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "refuel_probe_switch"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 12642
+          },
+          "vision_fresh_count": 7,
+          "vision_seen_count": 7,
+          "vision_status": "available"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_error_coding_guide_6",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.4 Parameter / Setting Error (PA)",
+            "score": 18.169210482199993,
+            "section": "2.4 Parameter / Setting Error (PA)",
+            "snippet_id": "fa18c_error_coding_guide_6"
+          },
+          {
+            "chunk_id": "fa18c_nasatlx_vr_0",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "score": 17.54182199533863,
+            "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "snippet_id": "fa18c_nasatlx_vr_0"
+          },
+          {
+            "chunk_id": "fa18c_scoring_sheet_template_2",
+            "doc_id": "fa18c_scoring_sheet_template",
+            "page_or_heading": "2. Step-Level Coding",
+            "score": 15.035058283635504,
+            "section": "2. Step-Level Coding",
+            "snippet_id": "fa18c_scoring_sheet_template_2"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.70514828499053,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_82",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 83,
+            "score": 13.45923683847562,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_82"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.ext_refuel_probe_value in [0,5000]"
+            ],
+            "overlay_step_id": "S21",
+            "role": "candidate_not_authoritative",
+            "step_id": "S21"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 12642,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12642,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 12642,
+            "latest_t_wall": 1779045232.7113395,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.681
+          },
+          "vision_evidence": {
+            "confidence": "high",
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "late_display_anchors": [
+              "fcs_page_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "bit_root_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_intermediate_result_visible",
+              "supt_page_visible",
+              "tac_page_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "source_status": "available",
+            "visual_candidate_steps": [
+              "S12",
+              "S13",
+              "S18",
+              "S19",
+              "S20"
+            ]
+          }
+        },
+        "vision": {
+          "frame_id": "1779045232773_000068",
+          "frame_ids": [
+            "1779045232773_000068"
+          ],
+          "frame_stale": false,
+          "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+          "observation_seq": 12642,
+          "observation_t_wall_ms": 1779045232711,
+          "observation_t_wall_s": 1779045232.7113395,
+          "status": "partial",
+          "sync_delta_ms": 97,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779045232676,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779045232773_000068"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "fact_id": "tac_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "supt_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_x_marks_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "bit_root_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_in_test_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_map_layer_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_ok_text_visible",
+            "frame_ids": null,
+            "status": null
+          }
+        ]
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "frame_count": 20,
+            "latest_seq": 12642
+          },
+          "vision_fresh_count": 7,
+          "vision_seen_count": 7,
+          "vision_status": "available"
+        },
+        "frame_id": "1779045232773_000068",
+        "fused_missing_conditions": [
+          "vars.ext_refuel_probe_value in [0,5000]"
+        ],
+        "fused_step_id": "S21",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_error_coding_guide_6"
+        ],
+        "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+        "prompt_tokens_est": 1150,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "source_chunk_refs": [
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_6",
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+          "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_82"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 97,
+        "vision_fact_seen_ids": [
+          "fcs_page_visible",
+          "fcsmc_page_visible",
+          "fcsmc_final_go_result_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779045232773_000068"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779045232773_000068"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+      "request_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+      "timestamp": "2026-05-17T19:13:59.588788+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_341",
+          "evidence_refs": [
+            "GATES.S21.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "frame_id": "1779045232773_000068",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [0,5000]"
+          ],
+          "fused_step_id": "S21",
+          "generation_mode": "model",
+          "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 97,
+          "target": "refuel_probe_switch",
+          "type": "overlay",
+          "vision_fact_extractor_used": true,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779045232773_000068"
+            ],
+            "fresh_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "supt_page_visible",
+              "fcs_page_x_marks_visible",
+              "bit_root_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible"
+            ],
+            "seen_fact_ids": [
+              "fcs_page_visible",
+              "fcsmc_page_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+      ],
+      "in_reply_to": "c2849a41-0f9b-4440-b926-52a9695cd871",
+      "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+      "metadata": {
+        "completion_conflict_original_explanations": [
+          "需要更多信息/请确认: refuel_probe_switch",
+          "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+        ],
+        "completion_conflict_original_message": "需要更多信息/请确认: refuel_probe_switch",
+        "completion_conflict_original_next": {
+          "step_id": "S20"
+        },
+        "completion_conflict_rewritten": true,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "516a332f-56bf-4510-a566-65abe9786228",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S20",
+          "missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate"
+          ],
+          "step_ui_targets": [
+            "refuel_probe_switch"
+          ]
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S21"
+        },
+        "evidence_guardrail_applied": true,
+        "evidence_guardrail_reasons": [
+          "invalid_target_evidence_refs:refuel_probe_switch"
+        ],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "failure_code": "evidence_fail",
+        "failure_codes": [
+          "evidence_fail",
+          "vision_conflict_unresolved"
+        ],
+        "failure_stage": "evidence_guardrail",
+        "fallback_explanations": [
+          "请先操作 refuel_probe_switch。"
+        ],
+        "fallback_message": "请先操作 refuel_probe_switch。",
+        "fallback_overlay_reason": "deterministic_step:S21",
+        "fallback_overlay_used": true,
+        "fallback_response_mapping": {
+          "allowed_evidence_ref_count": 129,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S21"
+          },
+          "next": {
+            "step_id": "S21"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_action_plan": {
+          "overlay_step_id": null,
+          "source": "model",
+          "step_id": "S21",
+          "targets": [
+            "refuel_probe_switch"
+          ],
+          "text_only": false
+        },
+        "final_overlay_targets": [
+          "refuel_probe_switch"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_341",
+              "evidence_refs": [
+                "GATES.S21.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "refuel_probe_switch"
+              ],
+              "frame_id": "1779045232773_000068",
+              "fused_missing_conditions": [
+                "vars.ext_refuel_probe_value in [0,5000]"
+              ],
+              "fused_step_id": "S21",
+              "generation_mode": "model",
+              "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 97,
+              "target": "refuel_probe_switch",
+              "type": "overlay",
+              "vision_fact_extractor_used": true,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779045232773_000068"
+                ],
+                "fresh_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "supt_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "bit_root_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible"
+                ],
+                "seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": "vision_conflict_unresolved",
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S21"
+          },
+          "explanations": [
+            "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。"
+          ],
+          "message": "当前 S21 尚未完成，请先满足：vars.ext_refuel_probe_value in [0,5000]。",
+          "next": {
+            "step_id": "S21"
+          }
+        },
+        "frame_id": "1779045232773_000068",
+        "fused_missing_conditions": [
+          "vars.ext_refuel_probe_value in [0,5000]"
+        ],
+        "fused_step_id": "S21",
+        "generation_mode": "model",
+        "generation_prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+        "generation_prompt_tokens_est": 1150,
+        "generation_prompt_trimmed": true,
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.92,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "sticky_state",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.fcs_page_visible",
+                "VISION_FACTS.fcsmc_final_go_result_visible",
+                "VISION_FACTS.fcsmc_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.ins_ok_text_visible"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S21",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "pitot_heater_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S26",
+              "supporting_evidence_refs": [
+                "GATES.S26.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "parking_brake_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S28",
+              "supporting_evidence_refs": [
+                "GATES.S28.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S29",
+              "supporting_evidence_refs": [
+                "GATES.S29.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "refuel_probe_switch"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S21",
+            "supporting_evidence_refs": []
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "frame_count": 20,
+              "latest_seq": 12642
+            },
+            "vision_fresh_count": 7,
+            "vision_seen_count": 7,
+            "vision_status": "available"
+          },
+          "final_action_plan": {
+            "overlay_step_id": null,
+            "source": "model",
+            "step_id": "S21",
+            "targets": [
+              "refuel_probe_switch"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "refuel_probe_switch"
+          ],
+          "message_category": "completion_conflict_repair",
+          "model_decision": {
+            "evidence_refs": [],
+            "generation_mode": "model",
+            "overlay_targets": [],
+            "status": "ok",
+            "step_id": "S20"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "deterministic_step:S21"
+          },
+          "schema_version": "v1",
+          "validator_result": {
+            "fallback_overlay_reason": "deterministic_step:S21",
+            "fallback_overlay_used": true,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "extractor_used": true,
+            "frame_ids": [
+              "1779045232773_000068"
+            ],
+            "reason": "missing_pre_trigger_frame",
+            "status": "called",
+            "sync_delta_ms": 97,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "available",
+            "vision_status": "partial"
+          }
+        },
+        "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "explanations": [
+            "需要更多信息/请确认: refuel_probe_switch",
+            "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+          ],
+          "next": {
+            "step_id": "S20"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "explanations": [
+            "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+          ],
+          "next": {
+            "step_id": "S20"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "gates_summary",
+                "target": "refuel_probe_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "refuel_probe_switch"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 3731,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "completion_conflict_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S20"
+        },
+        "model_raw_explanations": [
+          "需要更多信息/请确认: refuel_probe_switch",
+          "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "explanations": [
+            "需要更多信息/请确认: refuel_probe_switch",
+            "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+          ],
+          "next": {
+            "step_id": "S20"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S20"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779045232773_000068"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779045232773_000068",
+        "next": {
+          "step_id": "S21"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 924,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "RAG_SNIPPETS.fa18c_error_coding_guide_6",
+            "VISION_FACTS.tac_page_visible@1779045232773_000068",
+            "VISION_FACTS.supt_page_visible@1779045232773_000068"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 3,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "refuel_probe_switch",
+          "prompt_chars": 4598,
+          "prompt_tokens_est": 1150,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 1,
+          "rag_snippet_ids": [
+            "fa18c_error_coding_guide_6"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [
+            "S12",
+            "S13",
+            "S18",
+            "S19",
+            "S20"
+          ],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_rag_snippets",
+            "compact_template"
+          ],
+          "vision_fact_seen_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "vision_fact_status": "available"
+        },
+        "prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+        "prompt_tokens_est": 1150,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "e6c734f70200e5d0e213473f6ed70176f29328b58055d60fc44ca76385bf708a",
+        "request_prompt_tokens_est": 1150,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S20"
+          },
+          "next": {
+            "step_id": "S20"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "state_key": "420509dfb4c1ea964c5127be124cb107e03a74e6b5265583ec584936c3d22b72",
+        "sync_delta_ms": 97,
+        "vision": {
+          "frame_id": "1779045232773_000068",
+          "frame_ids": [
+            "1779045232773_000068"
+          ],
+          "frame_stale": false,
+          "observation_ref": "4f6aede7-c06f-43f6-9056-7d857322574a",
+          "observation_seq": 12642,
+          "observation_t_wall_ms": 1779045232711,
+          "observation_t_wall_s": 1779045232.7113395,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779045232773,
+              "channel": "composite_panel",
+              "frame_id": "1779045232773_000068",
+              "frame_seq": 68,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045232773_000068_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045232773_000068.png",
+              "sync_delta_ms": 97,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 97,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779045232773,
+            "channel": "composite_panel",
+            "frame_id": "1779045232773_000068",
+            "frame_seq": 68,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779045232773_000068_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779045232773_000068.png",
+            "sync_delta_ms": 97,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779045232676,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S08"
+        ],
+        "vision_fact_extractor_used": true,
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779045232773_000068"
+          ],
+          "fresh_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "supt_page_visible",
+            "fcs_page_x_marks_visible",
+            "bit_root_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible"
+          ],
+          "seen_fact_ids": [
+            "fcs_page_visible",
+            "fcsmc_page_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=fcs_page_visible,fcsmc_page_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible; not_seen=tac_page_visible,supt_page_visible,fcs_page_x_marks_visible,bit_root_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "tac_page_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "supt_page_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "fcs_page_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "fcs_page_x_marks_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "bit_root_page_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "fcsmc_page_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "fcsmc_in_test_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 600000,
+            "expires_at_wall_ms": 1779045832676,
+            "fact_id": "fcsmc_final_go_result_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "result_kind": "final_go",
+            "source_frame_id": "1779045232773_000068",
+            "state": "seen",
+            "sticky": true
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "hsi_page_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "hsi_map_layer_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779045234676,
+            "fact_id": "ins_ok_text_visible",
+            "observed_at_wall_ms": 1779045232676,
+            "source_frame_id": "1779045232773_000068",
+            "state": "seen",
+            "sticky": false
+          }
+        ],
+        "vision_fallback_reason": "vision_conflict_unresolved",
+        "vision_frame_ids": [
+          "1779045232773_000068"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "missing_pre_trigger_frame",
+        "vlm_call_status": "called"
+      },
+      "response_id": "e1cfed7c-0905-45d5-9a0e-e915fd4e6974",
+      "status": "ok",
+      "timestamp": "2026-05-17T19:14:03.321186+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S21",
+    "expected_overlay_target_ids": [
+      "refuel_probe_switch"
+    ],
+    "final_response_source": "deterministic_step:S21",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "called"
+  },
+  "extraction_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.92,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "sticky_state",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.fcs_page_visible",
+          "VISION_FACTS.fcsmc_final_go_result_visible",
+          "VISION_FACTS.fcsmc_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.ins_ok_text_visible"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S21",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "pitot_heater_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S26",
+        "supporting_evidence_refs": [
+          "GATES.S26.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "parking_brake_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S28",
+        "supporting_evidence_refs": [
+          "GATES.S28.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "GATES.S29.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "overlay_step_id": null,
+      "source": "model",
+      "step_id": "S21",
+      "targets": [
+        "refuel_probe_switch"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [],
+      "generation_mode": "model",
+      "overlay_targets": [],
+      "status": "ok",
+      "step_id": "S20"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "deterministic_step:S21"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.92,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "sticky_state",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.fcs_page_visible",
+            "VISION_FACTS.fcsmc_final_go_result_visible",
+            "VISION_FACTS.fcsmc_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.ins_ok_text_visible"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S21",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "pitot_heater_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S26",
+          "supporting_evidence_refs": [
+            "GATES.S26.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "parking_brake_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S28",
+          "supporting_evidence_refs": [
+            "GATES.S28.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S29",
+          "supporting_evidence_refs": [
+            "GATES.S29.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S21",
+        "supporting_evidence_refs": []
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "frame_count": 20,
+          "latest_seq": 12642
+        },
+        "vision_fresh_count": 7,
+        "vision_seen_count": 7,
+        "vision_status": "available"
+      },
+      "final_action_plan": {
+        "overlay_step_id": null,
+        "source": "model",
+        "step_id": "S21",
+        "targets": [
+          "refuel_probe_switch"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "refuel_probe_switch"
+      ],
+      "message_category": "completion_conflict_repair",
+      "model_decision": {
+        "evidence_refs": [],
+        "generation_mode": "model",
+        "overlay_targets": [],
+        "status": "ok",
+        "step_id": "S20"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "deterministic_step:S21"
+      },
+      "schema_version": "v1",
+      "validator_result": {
+        "fallback_overlay_reason": "deterministic_step:S21",
+        "fallback_overlay_used": true,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "extractor_used": true,
+        "frame_ids": [
+          "1779045232773_000068"
+        ],
+        "reason": "missing_pre_trigger_frame",
+        "status": "called",
+        "sync_delta_ms": 97,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "available",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "deterministic_step:S21",
+      "fallback_overlay_used": true,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S20"
+      },
+      "explanations": [
+        "需要更多信息/请确认: refuel_probe_switch",
+        "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+      ],
+      "next": {
+        "step_id": "S20"
+      },
+      "overlay": {
+        "evidence": [],
+        "targets": []
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S20"
+      },
+      "explanations": [
+        "需要更多信息/请确认: refuel_probe_switch",
+        "当前步骤 S20 未完成，加油探头未完全伸出。请操作 refuel_probe_switch 伸出加油探头。"
+      ],
+      "next": {
+        "step_id": "S20"
+      },
+      "overlay": {
+        "evidence": [],
+        "targets": []
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "c2849a41-0f9b-4440-b926-52a9695cd871",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 13303,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260517_190017.jsonl"
+  }
+}


### PR DESCRIPTION
## Summary
- add the replay-eval fixture files referenced by the issue #312 coverage matrix
- fixes GitHub ci-guard failure where CI checkout lacked ignored local artifacts

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_replay_eval.py::test_replay_eval_report_includes_issue_312_fixture_regression_sources
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_replay_eval.py