### PR TITLE
Remember final help progress for VLM gating

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -6598,6 +6598,39 @@ class LiveDcsTutorLoop:
                     return step_id
         return None
 
+    def _remember_final_response_progress(self, response: TutorResponse, request: TutorRequest) -> bool:
+        final_plan = response.metadata.get("harness_action_plan")
+        if not isinstance(final_plan, Mapping):
+            return False
+        final_step_id = final_plan.get("step_id")
+        if not isinstance(final_step_id, str) or not final_step_id:
+            return False
+        final_idx = self._step_order_index.get(final_step_id)
+        if final_idx is None:
+            return False
+        last_step_id = self._last_inferred_step_id
+        last_idx = self._step_order_index.get(last_step_id) if isinstance(last_step_id, str) else None
+        if last_idx is not None and final_idx < last_idx:
+            return False
+
+        context = request.context if isinstance(request.context, Mapping) else {}
+        hint = context.get("deterministic_step_hint")
+        hint_step_id = hint.get("inferred_step_id") if isinstance(hint, Mapping) else None
+        if hint_step_id == final_step_id and isinstance(hint, Mapping):
+            raw_missing = hint.get("missing_conditions")
+            missing_conditions = tuple(
+                item for item in raw_missing if isinstance(item, str) and item
+            ) if isinstance(raw_missing, (list, tuple)) else ()
+        else:
+            missing_conditions = tuple(self._missing_conditions_for_final_step(final_step_id, context))
+
+        if final_step_id != self._last_inferred_step_id:
+            self._step_interacted_targets = set()
+        self._last_inferred_step_id = final_step_id
+        self._sticky_inference_step_id = final_step_id
+        self._sticky_inference_missing_conditions = missing_conditions
+        return True
+
     def _missing_conditions_for_final_step(
         self,
         step_id: str,
@@ -8177,6 +8210,7 @@ class LiveDcsTutorLoop:
             else:
                 self._help_cache = None
 
+        self._remember_final_response_progress(response, request)
         hint = request.context.get("deterministic_step_hint")
         if isinstance(hint, Mapping):
             observability_status = hint.get("observability_status")

--- a/tests/test_issue_298_vlm_progress.py
+++ b/tests/test_issue_298_vlm_progress.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from adapters.step_inference import StepInferenceResult
+from core.types import TutorRequest, TutorResponse
+from live_dcs import LiveDcsTutorLoop, ReplayBiosReceiver
+
+
+class _NoopModel:
+    def explain_error(self, obs, request):  # pragma: no cover
+        raise AssertionError("model is not used by these progress-state tests")
+
+
+class _NoopExecutor:
+    def execute_actions(self, actions):  # pragma: no cover
+        return {"executed": [], "failed": [], "dry_run": []}
+
+
+def _write_replay(path: Path, frames: list[dict[str, Any]]) -> None:
+    path.write_text("\n".join(json.dumps(frame) for frame in frames), encoding="utf-8")
+
+
+def _bios_frame(seq: int, t_wall: float) -> dict[str, Any]:
+    return {
+        "schema_version": "v2",
+        "seq": seq,
+        "t_wall": t_wall,
+        "aircraft": "FA-18C_hornet",
+        "bios": {"BATTERY_SW": 2, "L_GEN_SW": 1, "R_GEN_SW": 1},
+        "delta": {},
+    }
+
+
+def _loop(tmp_path: Path, session_id: str) -> LiveDcsTutorLoop:
+    replay_path = tmp_path / f"{session_id}.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0)])
+    return LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=_NoopModel(),
+        action_executor=_NoopExecutor(),
+        session_id=session_id,
+    )
+
+
+def _request(step_id: str, missing_conditions: list[str]) -> TutorRequest:
+    return TutorRequest(
+        request_id=f"cycle-{step_id.lower()}",
+        actor="learner",
+        intent="help",
+        message="help",
+        observation_ref=f"obs-{step_id.lower()}",
+        context={
+            "vars": {},
+            "gates": {},
+            "recent_actions": {"recent_buttons": []},
+            "deterministic_step_hint": {
+                "inferred_step_id": step_id,
+                "missing_conditions": list(missing_conditions),
+            },
+            "vision_facts": [],
+        },
+        metadata={},
+    )
+
+
+def _trusted_response(step_id: str) -> TutorResponse:
+    return TutorResponse(
+        status="ok",
+        in_reply_to=f"cycle-{step_id.lower()}",
+        message=f"Proceed with {step_id}.",
+        actions=[],
+        metadata={
+            "harness_action_plan": {
+                "step_id": step_id,
+                "overlay_step_id": step_id,
+                "targets": [],
+                "text_only": True,
+                "source": "final_evidence_consistency_validator",
+            }
+        },
+    )
+
+
+def test_issue_298_keeps_s08_active_when_page_navigation_unconfirmed(tmp_path: Path) -> None:
+    loop = _loop(tmp_path, "issue-298-s08-page-unconfirmed")
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+
+        active = loop._active_step_ids_for_vision_facts(
+            StepInferenceResult("S08", ("vision_facts.fcs_page_visible==seen",)),
+        )
+    finally:
+        loop.close()
+
+    assert active == ["S08"]
+
+
+def test_issue_298_remembers_final_response_progress_for_next_vision_gate(tmp_path: Path) -> None:
+    loop = _loop(tmp_path, "issue-298-final-progress")
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+
+        updated = loop._remember_final_response_progress(
+            _trusted_response("S09"),
+            _request("S08", ["vision_facts.fcs_page_visible==seen"]),
+        )
+        active = loop._active_step_ids_for_vision_facts(
+            StepInferenceResult("S08", ("vision_facts.fcs_page_visible==seen",)),
+        )
+    finally:
+        loop.close()
+
+    assert updated is True
+    assert loop._last_inferred_step_id == "S09"
+    assert loop._sticky_inference_step_id == "S09"
+    assert active == ["S09"]
+
+
+def test_issue_298_does_not_remember_untrusted_next_as_progress(tmp_path: Path) -> None:
+    loop = _loop(tmp_path, "issue-298-untrusted-next")
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+        response = TutorResponse(
+            status="ok",
+            in_reply_to="cycle-untrusted-next",
+            message="Model says a later step.",
+            actions=[],
+            metadata={
+                "next": {"step_id": "S20"},
+                "final_action_plan": {
+                    "step_id": "S20",
+                    "targets": [],
+                    "text_only": True,
+                    "source": "model",
+                },
+            },
+        )
+
+        updated = loop._remember_final_response_progress(
+            response,
+            _request("S08", ["vision_facts.fcs_page_visible==seen"]),
+        )
+        active = loop._active_step_ids_for_vision_facts(
+            StepInferenceResult("S08", ("vision_facts.fcs_page_visible==seen",)),
+        )
+    finally:
+        loop.close()
+
+    assert updated is False
+    assert loop._last_inferred_step_id == "S08"
+    assert loop._sticky_inference_step_id == "S08"
+    assert active == ["S08"]
+
+
+def test_issue_298_remembers_visual_final_progress_as_visual_hold(tmp_path: Path) -> None:
+    loop = _loop(tmp_path, "issue-298-visual-final-progress")
+    try:
+        loop._last_inferred_step_id = "S18"
+        loop._sticky_inference_step_id = "S18"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcsmc_page_visible==seen",)
+
+        updated = loop._remember_final_response_progress(
+            _trusted_response("S19"),
+            _request("S19", ["vision_facts.fcsmc_final_go_result_visible==seen"]),
+        )
+        active = loop._active_step_ids_for_vision_facts(StepInferenceResult("S17", ()))
+    finally:
+        loop.close()
+
+    assert updated is True
+    assert loop._sticky_inference_step_id == "S19"
+    assert loop._sticky_inference_missing_conditions == ("vision_facts.fcsmc_final_go_result_visible==seen",)
+    assert active == ["S19"]


### PR DESCRIPTION
## Summary
- remember the trusted final harness action plan step after a help cycle so the next VLM gate does not keep using stale S08 fused progress
- only trust harness_action_plan for progress memory; synthesized final_action_plan / raw next or diagnosis cannot advance live progress
- add issue #298 regressions for stale S08 after final S09, untrusted next/final_action_plan, S08 still-active page navigation, and S19 visual hold preservation

Fixes #298

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_issue_298_vlm_progress.py tests/test_live_dcs.py -k "issue_298 or stale_visual_preliminary or non_visual_progress_floor or ignores_stale_s19_visual_facts_for_s20 or ignores_stale_s19_visual_facts_for_s21 or unresolved_visual_sticky_hold"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_issue_298_vlm_progress.py tests/test_live_dcs.py tests/test_evidence_packet.py tests/test_help_cycle_audit.py tests/test_live_replay_fixture.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=/tmp/iefmmq-298-final-pytest-full

## Notes
- Based on latest main including #315; this branch contains only #298 changes.