### PR TITLE
Fix refuel probe session latch handling

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -486,12 +486,12 @@ def _probe_motion_state(
     is_retracting = first_value is not None and last_value is not None and last_value < first_value
 
     if step_id == "S20":
-        if switch_value == 0 and probe_value is not None and 0 < probe_value < 60000 and is_extending:
+        if probe_value is not None and 0 < probe_value < 60000 and is_extending:
             return "s20_extending"
     if step_id == "S21":
         near_retract_threshold = probe_value is not None and 5000 < probe_value <= 7000
-        if switch_value == 1 and probe_value is not None and probe_value > 5000 and (
-            is_retracting or near_retract_threshold
+        if probe_value is not None and probe_value > 5000 and (
+            is_retracting or (switch_value == 1 and near_retract_threshold)
         ):
             return "s21_retracting"
     return None

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2480,6 +2480,20 @@ def _left_engine_start_complete(vars_selected: Mapping[str, Any]) -> bool:
     )
 
 
+def _refuel_probe_extended(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("probe_extended") is True:
+        return True
+    probe_value = _coerce_float(vars_selected.get("ext_refuel_probe_value"))
+    return probe_value is not None and probe_value >= 60000
+
+
+def _refuel_probe_retracted(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("probe_retracted") is True:
+        return True
+    probe_value = _coerce_float(vars_selected.get("ext_refuel_probe_value"))
+    return probe_value is not None and probe_value <= 5000
+
+
 def _missing_conditions_satisfied_by_vars(
     missing_conditions: Sequence[str],
     vars_selected: Mapping[str, Any],
@@ -2701,16 +2715,16 @@ def _refuel_probe_motion_state(context: Mapping[str, Any], step_id: str | None) 
     is_retracting = first_value is not None and last_value is not None and last_value < first_value
 
     if step_id == "S20":
-        if vars_map.get("probe_extended") is True or (probe_value is not None and probe_value >= 60000):
+        if _refuel_probe_extended(vars_map):
             return "s20_extended"
-        if switch_value == 0 and probe_value is not None and 0 < probe_value < 60000 and is_extending:
+        if probe_value is not None and 0 < probe_value < 60000 and is_extending:
             return "s20_extending"
     elif step_id == "S21":
-        if vars_map.get("probe_retracted") is True or (probe_value is not None and probe_value <= 5000):
+        if _refuel_probe_retracted(vars_map):
             return "s21_retracted"
         near_retract_threshold = probe_value is not None and 5000 < probe_value <= 7000
-        if switch_value == 1 and probe_value is not None and probe_value > 5000 and (
-            is_retracting or near_retract_threshold
+        if probe_value is not None and probe_value > 5000 and (
+            is_retracting or (switch_value == 1 and near_retract_threshold)
         ):
             return "s21_retracting"
     return None
@@ -3648,6 +3662,8 @@ class LiveDcsTutorLoop:
         }
         self._sticky_inference_step_id: str | None = None
         self._sticky_inference_missing_conditions: tuple[str, ...] = ()
+        self._refuel_probe_s20_latched_complete = False
+        self._refuel_probe_s21_latched_complete = False
         self._pending_help_trigger_t_wall: float | None = None
         self._stats = LiveLoopStats()
 
@@ -3675,6 +3691,8 @@ class LiveDcsTutorLoop:
         self._last_inferred_step_id = None
         self._sticky_inference_step_id = None
         self._sticky_inference_missing_conditions = ()
+        self._refuel_probe_s20_latched_complete = False
+        self._refuel_probe_s21_latched_complete = False
 
     def _remember_step_interactions(self, targets: Sequence[str] | None) -> None:
         if not isinstance(self._last_inferred_step_id, str) or not self._last_inferred_step_id:
@@ -3682,6 +3700,29 @@ class LiveDcsTutorLoop:
         for target in targets or ():
             if isinstance(target, str) and target:
                 self._step_interacted_targets.add(target)
+
+    def _step_reached_for_refuel_probe_latch(self, step_id: str | None) -> bool:
+        idx = self._step_order_index.get(step_id) if isinstance(step_id, str) else None
+        s20_idx = self._step_order_index.get("S20")
+        return idx is not None and s20_idx is not None and idx >= s20_idx
+
+    def _update_refuel_probe_completion_latches(
+        self,
+        vars_selected: Mapping[str, Any],
+        *,
+        current_step_id: str | None = None,
+    ) -> None:
+        if not (
+            self._step_reached_for_refuel_probe_latch(current_step_id)
+            or self._step_reached_for_refuel_probe_latch(self._sticky_inference_step_id)
+        ):
+            return
+        if self._refuel_probe_s21_latched_complete and not _refuel_probe_retracted(vars_selected):
+            self._refuel_probe_s21_latched_complete = False
+        if _refuel_probe_extended(vars_selected):
+            self._refuel_probe_s20_latched_complete = True
+        if self._refuel_probe_s20_latched_complete and _refuel_probe_retracted(vars_selected):
+            self._refuel_probe_s21_latched_complete = True
 
     def _ensure_knowledge(self) -> KnowledgePort:
         if self.knowledge is None:
@@ -3846,6 +3887,8 @@ class LiveDcsTutorLoop:
             self._accumulated_vars.update(enriched_vars)
             if self._should_reset_sticky_inference(self._accumulated_vars):
                 self._clear_live_progress_state()
+            else:
+                self._update_refuel_probe_completion_latches(self._accumulated_vars)
 
         payload = raw_obs.payload if isinstance(raw_obs.payload, Mapping) else {}
         delta = payload.get("delta")
@@ -4400,6 +4443,33 @@ class LiveDcsTutorLoop:
         sticky_idx = self._step_order_index.get(sticky_step_id) if isinstance(sticky_step_id, str) else None
         if current_idx is None:
             return inference
+        self._update_refuel_probe_completion_latches(vars_selected, current_step_id=current_step_id)
+        if (
+            self._refuel_probe_s21_latched_complete
+            and _refuel_probe_retracted(vars_selected)
+            and current_step_id in {"S20", "S21"}
+        ):
+            advanced = self._infer_after_completed_step(
+                "S21",
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
+        if self._refuel_probe_s20_latched_complete and current_step_id == "S20":
+            advanced = self._infer_after_completed_step(
+                "S20",
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
         if (
             current_step_id in {"S09", "S10"}
             and _missing_conditions_satisfied_by_vars(inference.missing_conditions, vars_selected)

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -744,7 +744,7 @@ def test_plan_harness_action_returns_text_only_when_probe_is_already_moving() ->
     cases = [
         (
             "S20",
-            {"probe_switch_value": 0, "ext_refuel_probe_value": 12000},
+            {"probe_switch_value": 2, "ext_refuel_probe_value": 12000},
             [
                 {"seq": 1, "t_wall": 1.0, "vars": {"ext_refuel_probe_value": 8000}},
                 {"seq": 2, "t_wall": 2.0, "vars": {"ext_refuel_probe_value": 12000}},

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -6821,6 +6821,197 @@ def test_live_loop_stabilizes_inference_without_power_reset(tmp_path: Path) -> N
     assert reset.inferred_step_id == "S01"
 
 
+def test_live_inference_latches_refuel_probe_cycle_after_observed_s20_completion(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_refuel_probe_latch.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-refuel-probe-latch",
+    )
+    try:
+        extended = loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S21",
+                missing_conditions=("vars.ext_refuel_probe_value in [0,5000]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": True,
+                "probe_retracted": False,
+                "ext_refuel_probe_value": 65535,
+                "launch_bar_switch_value": 0,
+            },
+        )
+        retracted = loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S20",
+                missing_conditions=("vars.ext_refuel_probe_value in [60000,65535]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": False,
+                "probe_retracted": True,
+                "ext_refuel_probe_value": 0,
+                "launch_bar_switch_value": 0,
+            },
+        )
+    finally:
+        loop.close()
+
+    assert extended.inferred_step_id == "S21"
+    assert retracted.inferred_step_id == "S22"
+    assert retracted.inferred_step_id != "S20"
+
+
+def test_live_inference_does_not_skip_s20_from_initial_retracted_probe(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_refuel_probe_initial_retracted.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-refuel-probe-initial",
+    )
+    try:
+        result = loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S20",
+                missing_conditions=("vars.ext_refuel_probe_value in [60000,65535]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": False,
+                "probe_retracted": True,
+                "ext_refuel_probe_value": 0,
+                "launch_bar_switch_value": 0,
+            },
+        )
+    finally:
+        loop.close()
+
+    assert result.inferred_step_id == "S20"
+    assert result.missing_conditions == ("vars.ext_refuel_probe_value in [60000,65535]",)
+
+
+def test_live_inference_ignores_probe_motion_seen_before_s20(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_refuel_probe_early_motion.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-refuel-probe-early",
+    )
+    try:
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S19",
+                missing_conditions=("vision_facts.fcsmc_final_go_result_visible==seen",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": True,
+                "probe_retracted": False,
+                "ext_refuel_probe_value": 65535,
+            },
+        )
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S19",
+                missing_conditions=("vision_facts.fcsmc_final_go_result_visible==seen",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": False,
+                "probe_retracted": True,
+                "ext_refuel_probe_value": 0,
+            },
+        )
+        result = loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S20",
+                missing_conditions=("vars.ext_refuel_probe_value in [60000,65535]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": False,
+                "probe_retracted": True,
+                "ext_refuel_probe_value": 0,
+            },
+        )
+    finally:
+        loop.close()
+
+    assert result.inferred_step_id == "S20"
+    assert loop._refuel_probe_s20_latched_complete is False
+    assert loop._refuel_probe_s21_latched_complete is False
+
+
+def test_live_inference_requires_probe_to_remain_retracted_for_s21_latch(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_refuel_probe_reextended.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-refuel-probe-reextended",
+    )
+    try:
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S21",
+                missing_conditions=("vars.ext_refuel_probe_value in [0,5000]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": True,
+                "probe_retracted": False,
+                "ext_refuel_probe_value": 65535,
+            },
+        )
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S20",
+                missing_conditions=("vars.ext_refuel_probe_value in [60000,65535]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": False,
+                "probe_retracted": True,
+                "ext_refuel_probe_value": 0,
+            },
+        )
+        reextended = loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S20",
+                missing_conditions=("vars.ext_refuel_probe_value in [60000,65535]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "probe_extended": True,
+                "probe_retracted": False,
+                "ext_refuel_probe_value": 65535,
+            },
+        )
+    finally:
+        loop.close()
+
+    assert reextended.inferred_step_id == "S21"
+    assert loop._refuel_probe_s20_latched_complete is True
+    assert loop._refuel_probe_s21_latched_complete is False
+
+
 def test_live_dcs_cli_parses_raw_bios_source_args() -> None:
     parser = build_arg_parser()
     args = parser.parse_args(
@@ -11822,6 +12013,8 @@ def test_ingest_observation_clears_live_progress_state_on_power_loss(tmp_path: P
         loop._sticky_inference_missing_conditions = ("vars.pitot_heat_on==true",)
         loop._last_inferred_step_id = "S19"
         loop._step_interacted_targets = {"launch_bar_switch"}
+        loop._refuel_probe_s20_latched_complete = True
+        loop._refuel_probe_s21_latched_complete = True
 
         loop._ingest_observation(
             Observation(
@@ -11844,6 +12037,8 @@ def test_ingest_observation_clears_live_progress_state_on_power_loss(tmp_path: P
     assert loop._sticky_inference_missing_conditions == ()
     assert loop._last_inferred_step_id is None
     assert loop._step_interacted_targets == set()
+    assert loop._refuel_probe_s20_latched_complete is False
+    assert loop._refuel_probe_s21_latched_complete is False
 
 
 def test_low_confidence_bootstrap_suppresses_early_battery_overlay(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- recognize S20 refuel probe extension from telemetry trend without relying on the old switch value
- add live S20/S21 completion latches scoped to the S20+ procedure region so completed probe cycles do not regress to S20
- require the probe to still be retracted before using the S21 latch, and cover early/initial/re-extended edge cases

## Tests
- python -m pytest -q tests/test_harness_validation.py::test_plan_harness_action_returns_text_only_when_probe_is_already_moving tests/test_live_dcs.py::test_live_inference_latches_refuel_probe_cycle_after_observed_s20_completion tests/test_live_dcs.py::test_live_inference_does_not_skip_s20_from_initial_retracted_probe tests/test_live_dcs.py::test_live_inference_ignores_probe_motion_seen_before_s20 tests/test_live_dcs.py::test_live_inference_requires_probe_to_remain_retracted_for_s21_latch tests/test_live_dcs.py::test_ingest_observation_clears_live_progress_state_on_power_loss
- python -m pytest -q tests/test_harness_validation.py tests/test_evidence_packet.py tests/test_live_dcs.py
- python -m pytest -q -s --basetemp=.tmp/pytest-full

Fixes #306