### PR TITLE
Fix S08/S09 multitarget planner states

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -423,10 +423,22 @@ def _s08_state_action_plan(
     allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
     if not allowed:
         return None
-    if max_overlay_targets < len(_S08_DISPLAY_POWER_TARGETS):
-        return None
     if not all(vars_map.get(var_name) is False for var_name in _S08_DISPLAY_POWER_VARS):
         return None
+    if max_overlay_targets < len(_S08_DISPLAY_POWER_TARGETS):
+        target = next((item for item in _S08_DISPLAY_POWER_TARGETS if item in allowed), None)
+        if target is None:
+            return None
+        return _StateActionPlan(
+            targets=(target,),
+            guidance=(
+                "All displays are still off. Start by powering the display brightness controls; "
+                "DDI warm-up can lag, so wait for the displays before page navigation."
+            ),
+            text_only=False,
+            source="state_action_planner",
+            reasons=("s08_all_displays_off_single_power_target",),
+        )
     if not all(target in allowed for target in _S08_DISPLAY_POWER_TARGETS):
         return _StateActionPlan(
             targets=_S08_DISPLAY_POWER_TARGETS,
@@ -497,7 +509,7 @@ def _s09_state_action_plan(
             reasons=(f"s09_state_target:{name}",),
         )
 
-    def _numeric_sequence(guidance: str) -> _StateActionPlan | None:
+    def _numeric_sequence(guidance: str, reason: str = "s09_numeric_sequence_targets") -> _StateActionPlan | None:
         missing = tuple(target for target in _S09_NUMERIC_SEQUENCE_TARGETS if target not in allowed)
         if missing:
             return _StateActionPlan(
@@ -512,7 +524,7 @@ def _s09_state_action_plan(
             guidance=guidance,
             text_only=False,
             source="state_action_planner",
-            reasons=("s09_numeric_sequence_targets",),
+            reasons=(reason,),
         )
 
     if payload.endswith("134.000"):
@@ -537,7 +549,8 @@ def _s09_state_action_plan(
     if max_overlay_targets < len(_S09_NUMERIC_SEQUENCE_TARGETS):
         return _target("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector before entering 134.000.")
     return _numeric_sequence(
-        "Pull the UFC COMM1 channel selector if needed, then enter frequency 134.000 with keys 1-3-4-0-0-0 and press ENT."
+        "Pull the UFC COMM1 channel selector if needed, then enter frequency 134.000 with keys 1-3-4-0-0-0 and press ENT.",
+        reason="s09_numeric_sequence_targets_selector_maybe_needed",
     )
 
 

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -402,6 +402,54 @@ def _latest_vars(latest_vars: Mapping[str, Any] | None) -> Mapping[str, Any]:
     return latest_vars if isinstance(latest_vars, Mapping) else {}
 
 
+_S08_DISPLAY_POWER_TARGETS = (
+    "left_mdi_brightness_selector",
+    "right_mdi_brightness_selector",
+    "ampcd_off_brightness_knob",
+    "hud_symbology_brightness_knob",
+)
+
+_S08_DISPLAY_POWER_VARS = ("left_ddi_on", "right_ddi_on", "mpcd_on", "hud_on")
+
+_S09_NUMERIC_SEQUENCE_TARGETS = ("ufc_key_1", "ufc_key_3", "ufc_key_4", "ufc_key_0")
+
+
+def _s08_state_action_plan(
+    vars_map: Mapping[str, Any],
+    *,
+    spec: StepHarnessSpec | None,
+    max_overlay_targets: int,
+) -> _StateActionPlan | None:
+    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
+    if not allowed:
+        return None
+    if max_overlay_targets < len(_S08_DISPLAY_POWER_TARGETS):
+        return None
+    if not all(vars_map.get(var_name) is False for var_name in _S08_DISPLAY_POWER_VARS):
+        return None
+    if not all(target in allowed for target in _S08_DISPLAY_POWER_TARGETS):
+        return _StateActionPlan(
+            targets=_S08_DISPLAY_POWER_TARGETS,
+            guidance=(
+                "All displays are still off. Power the left DDI, right DDI, AMPCD, and HUD brightness controls; "
+                "DDI warm-up can lag, so wait for the displays before page navigation."
+            ),
+            text_only=True,
+            source="state_action_planner",
+            reasons=("s08_all_displays_off_power_targets_unavailable",),
+        )
+    return _StateActionPlan(
+        targets=_S08_DISPLAY_POWER_TARGETS,
+        guidance=(
+            "All displays are still off. Power the left DDI, right DDI, AMPCD, and HUD brightness controls; "
+            "DDI warm-up can lag, so wait for the displays before page navigation."
+        ),
+        text_only=False,
+        source="state_action_planner",
+        reasons=("s08_all_displays_off_power_targets",),
+    )
+
+
 def _normalize_ufc_scratchpad_text(vars_map: Mapping[str, Any]) -> str:
     parts: list[str] = []
     for key in (
@@ -427,6 +475,7 @@ def _s09_state_action_plan(
     *,
     spec: StepHarnessSpec | None,
     recent_action_targets: Sequence[str] | None,
+    max_overlay_targets: int,
 ) -> _StateActionPlan | None:
     allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
     if not allowed or _s09_comm1_frequency_complete(vars_map):
@@ -448,6 +497,24 @@ def _s09_state_action_plan(
             reasons=(f"s09_state_target:{name}",),
         )
 
+    def _numeric_sequence(guidance: str) -> _StateActionPlan | None:
+        missing = tuple(target for target in _S09_NUMERIC_SEQUENCE_TARGETS if target not in allowed)
+        if missing:
+            return _StateActionPlan(
+                targets=_S09_NUMERIC_SEQUENCE_TARGETS,
+                guidance=guidance,
+                text_only=True,
+                source="state_action_planner",
+                reasons=tuple(f"s09_numeric_sequence_target_unavailable:{target}" for target in missing),
+            )
+        return _StateActionPlan(
+            targets=_S09_NUMERIC_SEQUENCE_TARGETS,
+            guidance=guidance,
+            text_only=False,
+            source="state_action_planner",
+            reasons=("s09_numeric_sequence_targets",),
+        )
+
     if payload.endswith("134.000"):
         return _target("ufc_ent_button", "The UFC scratchpad shows 134.000; press ENT to commit the COMM1 preset.")
     if payload.endswith("13.400") or payload.endswith("1.340") or payload.endswith(".134") or payload.endswith("1.34"):
@@ -456,11 +523,22 @@ def _s09_state_action_plan(
         return _target("ufc_key_4", "COMM1 preset entry shows 13; press 4 next.")
     if payload.endswith(".1"):
         return _target("ufc_key_3", "COMM1 preset entry shows 1; press 3 next.")
+    sequence_guidance = (
+        "Enter COMM1 frequency 134.000 with UFC keys 1-3-4-0-0-0, then press ENT."
+    )
     if payload.endswith("305.000") or payload.endswith("305000"):
-        return _target("ufc_key_1", "COMM1 preset 1 is open with the old 305.000 value; press 1 next.")
+        if max_overlay_targets < len(_S09_NUMERIC_SEQUENCE_TARGETS):
+            return _target("ufc_key_1", "COMM1 preset 1 is open with the old 305.000 value; press 1 next.")
+        return _numeric_sequence(sequence_guidance)
     if vars_map.get("ufc_comm1_pull_pressed") is True or "ufc_comm1_channel_selector_pull" in recent:
-        return _target("ufc_key_1", "COMM1 preset entry is open; start typing 134.000 with key 1.")
-    return _target("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector before entering 134.000.")
+        if max_overlay_targets < len(_S09_NUMERIC_SEQUENCE_TARGETS):
+            return _target("ufc_key_1", "COMM1 preset entry is open; start typing 134.000 with key 1.")
+        return _numeric_sequence(sequence_guidance)
+    if max_overlay_targets < len(_S09_NUMERIC_SEQUENCE_TARGETS):
+        return _target("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector before entering 134.000.")
+    return _numeric_sequence(
+        "Pull the UFC COMM1 channel selector if needed, then enter frequency 134.000 with keys 1-3-4-0-0-0 and press ENT."
+    )
 
 
 def _changed_var(evidence_packet: Any, var_name: str) -> Mapping[str, Any] | None:
@@ -507,13 +585,21 @@ def _state_action_plan(
     vision_seen_fact_ids: Sequence[str] | None = None,
     vision_fresh_fact_ids: Sequence[str] | None = None,
     vision_not_seen_fact_ids: Sequence[str] | None = None,
+    max_overlay_targets: int = 1,
 ) -> _StateActionPlan | None:
     vars_map = _latest_vars(latest_vars)
+    if step_id == "S08":
+        return _s08_state_action_plan(
+            vars_map,
+            spec=spec,
+            max_overlay_targets=max_overlay_targets,
+        )
     if step_id == "S09":
         return _s09_state_action_plan(
             vars_map,
             spec=spec,
             recent_action_targets=recent_action_targets,
+            max_overlay_targets=max_overlay_targets,
         )
 
     motion_state = _probe_motion_state(step_id, vars_map, evidence_packet=evidence_packet)
@@ -638,6 +724,7 @@ def plan_harness_action(
         vision_seen_fact_ids=vision_seen_fact_ids,
         vision_fresh_fact_ids=vision_fresh_fact_ids,
         vision_not_seen_fact_ids=vision_not_seen_fact_ids,
+        max_overlay_targets=max_overlay_targets,
     )
     if state_plan is not None and state_plan.text_only:
         return HarnessActionPlan(

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -6060,7 +6060,16 @@ class LiveDcsTutorLoop:
                     "AMPCD, and HUD controls; DDI warm-up can lag briefly, so wait for the displays before navigating."
                 )
             )
-        if "s09_numeric_sequence_targets" in plan.reasons:
+        if "s09_numeric_sequence_targets_selector_maybe_needed" in plan.reasons:
+            plan_guidance = (
+                "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+                if self.lang == "zh"
+                else (
+                    "Pull the UFC COMM1 selector if needed, then enter COMM1 frequency 134.000: "
+                    "press 1-3-4-0-0-0, then ENT."
+                )
+            )
+        elif "s09_numeric_sequence_targets" in plan.reasons:
             plan_guidance = (
                 "请在 UFC 输入 COMM1 频率 134.000：按 1-3-4-0-0-0，然后按 ENT。"
                 if self.lang == "zh"

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -6050,6 +6050,22 @@ class LiveDcsTutorLoop:
             s08_power_guidance = _s08_power_guidance_for_target(plan.targets[0], self.lang)
             if isinstance(s08_power_guidance, str) and s08_power_guidance:
                 plan_guidance = s08_power_guidance
+        if "s08_all_displays_off_power_targets" in plan.reasons:
+            plan_guidance = (
+                "当前四个显示相关电源/亮度都还没有打开。请依次打开左 DDI、右 DDI、AMPCD 和 HUD 的亮度/电源控件；"
+                "DDI 点亮可能有短暂延迟，确认亮起后再继续导航。"
+                if self.lang == "zh"
+                else (
+                    "All four display power/brightness controls are still off. Power the left DDI, right DDI, "
+                    "AMPCD, and HUD controls; DDI warm-up can lag briefly, so wait for the displays before navigating."
+                )
+            )
+        if "s09_numeric_sequence_targets" in plan.reasons:
+            plan_guidance = (
+                "请在 UFC 输入 COMM1 频率 134.000：按 1-3-4-0-0-0，然后按 ENT。"
+                if self.lang == "zh"
+                else "Enter COMM1 frequency 134.000 on the UFC: press 1-3-4-0-0-0, then ENT."
+            )
         if s18_visual_hint_used and (not isinstance(plan_guidance, str) or not plan_guidance):
             plan_guidance = s18_visual_hint_reason
         emergency_presentation_fallback = response.status == "error" or response.metadata.get("provider") == "fallback"

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -590,6 +590,51 @@ def test_plan_harness_action_clears_unavailable_s18_state_target() -> None:
     assert "target_not_in_runtime_allowlist:right_mdi_pb5" in plan.reasons
 
 
+def test_plan_harness_action_uses_s08_all_displays_off_power_targets() -> None:
+    specs = {
+        "S08": _spec(
+            "S08",
+            (
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S08"].allowed_overlay_targets)
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S08",
+        model_step_id="S08",
+        proposed_overlay_targets=["left_mdi_brightness_selector"],
+        candidate_step_ids=["S08"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=4,
+        latest_vars={
+            "left_ddi_on": False,
+            "right_ddi_on": False,
+            "mpcd_on": False,
+            "hud_on": False,
+        },
+    )
+
+    assert plan.targets == (
+        "left_mdi_brightness_selector",
+        "right_mdi_brightness_selector",
+        "ampcd_off_brightness_knob",
+        "hud_symbology_brightness_knob",
+    )
+    assert "left_mdi_pb18" not in plan.targets
+    assert "left_mdi_pb15" not in plan.targets
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "warm" in (plan.guidance or "").lower()
+
+
 def test_plan_harness_action_uses_s09_scratchpad_state_without_live_hint() -> None:
     specs = {
         "S09": _spec(
@@ -606,16 +651,6 @@ def test_plan_harness_action_uses_s09_scratchpad_state_without_live_hint() -> No
     }
     allowed_targets = list(specs["S09"].allowed_overlay_targets)
     cases = [
-        ({}, "ufc_comm1_channel_selector_pull"),
-        (
-            {
-                "ufc_comm1_pull_pressed": True,
-                "ufc_scratchpad_string_1_display": "1-",
-                "ufc_scratchpad_string_2_display": "-",
-                "ufc_scratchpad_number_display": "305.000",
-            },
-            "ufc_key_1",
-        ),
         (
             {
                 "ufc_scratchpad_string_1_display": "1-",
@@ -668,6 +703,52 @@ def test_plan_harness_action_uses_s09_scratchpad_state_without_live_hint() -> No
         assert plan.final_action_plan_source == "state_action_planner"
 
 
+def test_plan_harness_action_uses_s09_numeric_sequence_for_initial_entry() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S09"].allowed_overlay_targets)
+    cases = [
+        {},
+        {
+            "ufc_comm1_pull_pressed": True,
+            "ufc_scratchpad_string_1_display": "1-",
+            "ufc_scratchpad_string_2_display": "-",
+            "ufc_scratchpad_number_display": "305.000",
+        },
+    ]
+
+    for vars_map in cases:
+        plan = plan_harness_action(
+            step_specs=specs,
+            inferred_step_id="S09",
+            model_step_id="S09",
+            proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+            candidate_step_ids=["S09"],
+            runtime_overlay_targets=allowed_targets,
+            request_overlay_targets=allowed_targets,
+            max_overlay_targets=4,
+            latest_vars={"comm1_freq_134_000": False, **vars_map},
+            recent_action_targets=[],
+        )
+
+        assert plan.targets == ("ufc_key_1", "ufc_key_3", "ufc_key_4", "ufc_key_0")
+        assert plan.final_action_plan_source == "state_action_planner"
+        assert "134.000" in (plan.guidance or "")
+        assert "1-3-4-0-0-0" in (plan.guidance or "")
+        assert "ENT" in (plan.guidance or "")
+
+
 def test_plan_harness_action_uses_recent_action_for_s09_open_scratchpad() -> None:
     specs = {
         "S09": _spec(
@@ -692,12 +773,12 @@ def test_plan_harness_action_uses_recent_action_for_s09_open_scratchpad() -> Non
         candidate_step_ids=["S09"],
         runtime_overlay_targets=allowed_targets,
         request_overlay_targets=allowed_targets,
-        max_overlay_targets=1,
+        max_overlay_targets=4,
         latest_vars={"comm1_freq_134_000": False},
         recent_action_targets=["ufc_comm1_channel_selector_pull"],
     )
 
-    assert plan.targets == ("ufc_key_1",)
+    assert plan.targets == ("ufc_key_1", "ufc_key_3", "ufc_key_4", "ufc_key_0")
     assert plan.final_action_plan_source == "state_action_planner"
 
 

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -635,6 +635,42 @@ def test_plan_harness_action_uses_s08_all_displays_off_power_targets() -> None:
     assert "warm" in (plan.guidance or "").lower()
 
 
+def test_plan_harness_action_keeps_s08_all_displays_off_single_target_when_max_below_four() -> None:
+    specs = {
+        "S08": _spec(
+            "S08",
+            (
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S08"].allowed_overlay_targets)
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S08",
+        model_step_id="S08",
+        proposed_overlay_targets=["left_mdi_brightness_selector", "right_mdi_brightness_selector"],
+        candidate_step_ids=["S08"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=2,
+        latest_vars={
+            "left_ddi_on": False,
+            "right_ddi_on": False,
+            "mpcd_on": False,
+            "hud_on": False,
+        },
+    )
+
+    assert plan.targets == ("left_mdi_brightness_selector",)
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "state_action_target_mismatch:right_mdi_brightness_selector" in plan.reasons
+
+
 def test_plan_harness_action_uses_s09_scratchpad_state_without_live_hint() -> None:
     specs = {
         "S09": _spec(

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -6185,6 +6185,192 @@ def test_harness_validation_action_plan_records_s26_repair_metadata() -> None:
         loop.close()
 
 
+def test_harness_validation_action_plan_uses_s08_all_displays_off_targets() -> None:
+    response = TutorResponse(
+        message="Turn on the left DDI.",
+        explanations=["Turn on the left DDI."],
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "left_mdi_brightness_selector",
+                "element_id": "pnt_51",
+            }
+        ],
+        metadata={
+            "next": {"step_id": "S08"},
+            "diagnosis": {"step_id": "S08", "error_category": "OM"},
+            "help_response": {
+                "diagnosis": {"step_id": "S08", "error_category": "OM"},
+                "next": {"step_id": "S08"},
+                "overlay": {
+                    "targets": ["left_mdi_brightness_selector"],
+                    "evidence": [
+                        {
+                            "target": "left_mdi_brightness_selector",
+                            "type": "gate",
+                            "ref": "GATES.S08.completion",
+                            "quote": "blocked",
+                        }
+                    ],
+                },
+                "explanations": ["Turn on the left DDI."],
+            },
+        },
+    )
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "overlay_target_allowlist": [],
+            "gates": [
+                {"gate_id": "S08.completion", "status": "blocked", "reason": "Displays must be powered."},
+                {"gate_id": "S08.precondition", "status": "allowed"},
+            ],
+            "vars": {
+                "left_ddi_on": False,
+                "right_ddi_on": False,
+                "mpcd_on": False,
+                "hud_on": False,
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S08",
+                "overlay_step_id": "S08",
+                "missing_conditions": [
+                    "vars.left_ddi_on==true",
+                    "vars.right_ddi_on==true",
+                    "vars.mpcd_on==true",
+                    "vars.hud_on==true",
+                ],
+                "step_evidence_requirements": ["var", "gate"],
+            },
+            "rag_topk": [],
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(Path("/dev/null")),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+        max_overlay_targets=4,
+    )
+    try:
+        request.context["overlay_target_allowlist"] = list(loop.overlay_allowlist)
+
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "state_action_planner"
+        assert [action["target"] for action in response.actions] == [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+        ]
+        assert "DDI" in response.message
+        assert "页面" not in response.message
+        assert response.metadata["final_action_plan_source"] == "state_action_planner"
+    finally:
+        loop.close()
+
+
+def test_harness_validation_action_plan_uses_s09_initial_numeric_sequence_targets() -> None:
+    response = TutorResponse(
+        message="Pull COMM1.",
+        explanations=["Pull COMM1."],
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "ufc_comm1_channel_selector_pull",
+                "element_id": "pnt_301",
+            }
+        ],
+        metadata={
+            "next": {"step_id": "S09"},
+            "diagnosis": {"step_id": "S09", "error_category": "OM"},
+            "help_response": {
+                "diagnosis": {"step_id": "S09", "error_category": "OM"},
+                "next": {"step_id": "S09"},
+                "overlay": {
+                    "targets": ["ufc_comm1_channel_selector_pull"],
+                    "evidence": [
+                        {
+                            "target": "ufc_comm1_channel_selector_pull",
+                            "type": "gate",
+                            "ref": "GATES.S09.completion",
+                            "quote": "blocked",
+                        }
+                    ],
+                },
+                "explanations": ["Pull COMM1."],
+            },
+        },
+    )
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "overlay_target_allowlist": [],
+            "gates": [
+                {"gate_id": "S09.completion", "status": "blocked", "reason": "COMM1 frequency is not 134.000."},
+                {"gate_id": "S09.precondition", "status": "allowed"},
+            ],
+            "vars": {
+                "comm1_freq_134_000": False,
+                "ufc_comm1_pull_pressed": True,
+                "ufc_scratchpad_string_1_display": "1-",
+                "ufc_scratchpad_string_2_display": "-",
+                "ufc_scratchpad_number_display": "305.000",
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_evidence_requirements": ["var", "gate"],
+            },
+            "rag_topk": [],
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(Path("/dev/null")),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+        max_overlay_targets=4,
+    )
+    try:
+        request.context["overlay_target_allowlist"] = list(loop.overlay_allowlist)
+
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "state_action_planner"
+        assert [action["target"] for action in response.actions] == [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+        ]
+        assert "134.000" in response.message
+        assert "1-3-4-0-0-0" in response.message
+        assert "ENT" in response.message
+        assert response.metadata["help_response"]["overlay"]["targets"] == [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+        ]
+    finally:
+        loop.close()
+
+
 def test_harness_validation_action_plan_waits_without_highlight_for_s20_probe_moving() -> None:
     response = TutorResponse(
         message="Extend the refuel probe.",

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -6185,6 +6185,42 @@ def test_harness_validation_action_plan_records_s26_repair_metadata() -> None:
         loop.close()
 
 
+def _annotate_test_final_metadata(
+    loop: LiveDcsTutorLoop,
+    response: TutorResponse,
+    request: TutorRequest,
+) -> None:
+    loop._annotate_response_audit_metadata(response)
+    _build_harness_trace_metadata(
+        request=request,
+        response=response,
+        vision_selection=HelpCycleVisionSelection(
+            status="vision_not_required",
+            observation_ref=None,
+            observation_seq=None,
+            observation_t_wall_s=None,
+            observation_t_wall_ms=None,
+            trigger_wall_ms=None,
+            sync_window_ms=None,
+            vision_used=False,
+            frame_id=None,
+            sync_status=None,
+            sync_delta_ms=None,
+            frame_stale=False,
+            frame_ids=[],
+            selected_frames=[],
+            pre_trigger_frame=None,
+            trigger_frame=None,
+            sync_miss_reason=None,
+        ),
+        vision_fact_context={
+            "status": "vision_not_required",
+            "vision_fact_summary": {"status": "vision_not_required"},
+            "vision_facts": [],
+        },
+    )
+
+
 def test_harness_validation_action_plan_uses_s08_all_displays_off_targets() -> None:
     response = TutorResponse(
         message="Turn on the left DDI.",
@@ -6273,6 +6309,14 @@ def test_harness_validation_action_plan_uses_s08_all_displays_off_targets() -> N
         assert "DDI" in response.message
         assert "页面" not in response.message
         assert response.metadata["final_action_plan_source"] == "state_action_planner"
+        _annotate_test_final_metadata(loop, response, request)
+        assert response.metadata["final_overlay_targets"] == [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+        ]
+        assert response.metadata["final_public_response"]["actions"][0]["target"] == "left_mdi_brightness_selector"
     finally:
         loop.close()
 
@@ -6367,6 +6411,105 @@ def test_harness_validation_action_plan_uses_s09_initial_numeric_sequence_target
             "ufc_key_4",
             "ufc_key_0",
         ]
+        _annotate_test_final_metadata(loop, response, request)
+        assert response.metadata["final_overlay_targets"] == [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+        ]
+        assert response.metadata["final_public_response"]["message"] == response.message
+        assert response.metadata["final_public_response"]["actions"][0]["target"] == "ufc_key_1"
+    finally:
+        loop.close()
+
+
+def test_harness_validation_action_plan_s09_empty_scratchpad_mentions_selector_if_needed() -> None:
+    response = TutorResponse(
+        message="Pull COMM1.",
+        explanations=["Pull COMM1."],
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "ufc_comm1_channel_selector_pull",
+                "element_id": "pnt_301",
+            }
+        ],
+        metadata={
+            "next": {"step_id": "S09"},
+            "diagnosis": {"step_id": "S09", "error_category": "OM"},
+            "help_response": {
+                "diagnosis": {"step_id": "S09", "error_category": "OM"},
+                "next": {"step_id": "S09"},
+                "overlay": {
+                    "targets": ["ufc_comm1_channel_selector_pull"],
+                    "evidence": [
+                        {
+                            "target": "ufc_comm1_channel_selector_pull",
+                            "type": "gate",
+                            "ref": "GATES.S09.completion",
+                            "quote": "blocked",
+                        }
+                    ],
+                },
+                "explanations": ["Pull COMM1."],
+            },
+        },
+    )
+    request = TutorRequest(
+        actor="learner",
+        intent="help",
+        message="help",
+        context={
+            "overlay_target_allowlist": [],
+            "gates": [
+                {"gate_id": "S09.completion", "status": "blocked", "reason": "COMM1 frequency is not 134.000."},
+                {"gate_id": "S09.precondition", "status": "allowed"},
+            ],
+            "vars": {"comm1_freq_134_000": False},
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_evidence_requirements": ["var", "gate"],
+            },
+            "rag_topk": [],
+        },
+    )
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(Path("/dev/null")),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=5.0,
+        lang="zh",
+        max_overlay_targets=4,
+    )
+    try:
+        request.context["overlay_target_allowlist"] = list(loop.overlay_allowlist)
+
+        used, reason = loop._apply_harness_validation_action_plan(response, request)
+
+        assert used is True
+        assert reason == "state_action_planner"
+        assert [action["target"] for action in response.actions] == [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+        ]
+        assert "COMM1 selector" in response.message
+        assert "134.000" in response.message
+        assert "1-3-4-0-0-0" in response.message
+        _annotate_test_final_metadata(loop, response, request)
+        assert response.metadata["final_overlay_targets"] == [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+        ]
+        assert response.metadata["final_public_response"]["message"] == response.message
     finally:
         loop.close()
 


### PR DESCRIPTION
## Summary
- Add an S08 all-displays-off state planner that highlights the four display power/brightness controls together when max_overlay_targets >= 4.
- Update S09 initial/old COMM1 entry planning to highlight the numeric 1/3/4/0 sequence together when max_overlay_targets >= 4, while preserving single-target behavior for max_overlay_targets=1.
- Localize live guidance so final message and overlay targets describe the same action.

## Tests
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_live_dcs.py
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Fixes follow-up comment on #314.