### PR TITLE
Fix S19 sticky VLM gate advancement

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2519,6 +2519,21 @@ def _missing_conditions_satisfied_by_vars(
     return checked
 
 
+def _s19_final_go_hold_satisfied_by_facts(
+    missing_conditions: Sequence[str],
+    vision_facts: Mapping[str, Any],
+) -> bool:
+    conditions = [item for item in missing_conditions if isinstance(item, str) and item]
+    if conditions != ["vision_facts.fcsmc_final_go_result_visible==seen"]:
+        return False
+    fact = vision_facts.get("fcsmc_final_go_result_visible")
+    return (
+        isinstance(fact, Mapping)
+        and fact.get("state") in {"seen", "fresh"}
+        and fact.get("sticky") is True
+    )
+
+
 def _vision_summary_seen_or_fresh(
     summary: Mapping[str, Any] | None,
     fact_id: str,
@@ -4539,6 +4554,23 @@ class LiveDcsTutorLoop:
                 self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
                 return advanced
         if (
+            current_step_id == "S19"
+            and _s19_final_go_hold_satisfied_by_facts(
+                inference.missing_conditions,
+                self._vision_fact_snapshot,
+            )
+        ):
+            advanced = self._infer_after_completed_step(
+                "S19",
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
+        if (
             current_step_id in {"S09", "S10"}
             and _missing_conditions_satisfied_by_vars(inference.missing_conditions, vars_selected)
         ):
@@ -4563,6 +4595,23 @@ class LiveDcsTutorLoop:
         ):
             advanced = self._infer_after_completed_step(
                 sticky_step_id,
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
+        if (
+            sticky_step_id == "S19"
+            and _s19_final_go_hold_satisfied_by_facts(
+                self._sticky_inference_missing_conditions,
+                self._vision_fact_snapshot,
+            )
+        ):
+            advanced = self._infer_after_completed_step(
+                "S19",
                 vars_selected,
                 recent_ui_targets=recent_ui_targets,
                 vision_facts=None,
@@ -4702,6 +4751,16 @@ class LiveDcsTutorLoop:
         )
         sticky_step_id = self._sticky_inference_step_id
         sticky_idx = self._step_order_index.get(sticky_step_id) if isinstance(sticky_step_id, str) else None
+        s19_final_go_hold_satisfied = _s19_final_go_hold_satisfied_by_facts(
+            preliminary_inference.missing_conditions,
+            self._vision_fact_snapshot,
+        ) or (
+            sticky_step_id == "S19"
+            and _s19_final_go_hold_satisfied_by_facts(
+                self._sticky_inference_missing_conditions,
+                self._vision_fact_snapshot,
+            )
+        )
 
         if (
             current_step_id == "S08"
@@ -4709,6 +4768,8 @@ class LiveDcsTutorLoop:
             and self._s08_page_navigation_recently_completed()
         ):
             current_step_id = self._next_step_id_after("S08")
+        if current_step_id == "S19" and s19_final_go_hold_satisfied:
+            current_step_id = self._next_step_id_after(current_step_id) or current_step_id
 
         current_idx = self._step_order_index.get(current_step_id) if isinstance(current_step_id, str) else None
         last_idx = self._step_order_index.get(last_step_id) if isinstance(last_step_id, str) else None
@@ -4725,12 +4786,17 @@ class LiveDcsTutorLoop:
                 current_step_id = last_step_id
             current_idx = self._step_order_index.get(current_step_id) if isinstance(current_step_id, str) else None
 
+        if current_step_id == "S19" and s19_final_go_hold_satisfied:
+            current_step_id = self._next_step_id_after(current_step_id) or current_step_id
+            current_idx = self._step_order_index.get(current_step_id) if isinstance(current_step_id, str) else None
+
         out: list[str] = []
         if isinstance(current_step_id, str) and current_step_id:
             out.append(current_step_id)
 
         if (
             sticky_missing_has_visual_hold
+            and not s19_final_go_hold_satisfied
             and isinstance(sticky_step_id, str)
             and sticky_step_id in self.vision_priority_step_set
             and current_idx is not None

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -8287,6 +8287,135 @@ def test_live_loop_ignores_stale_s19_visual_facts_for_s20(tmp_path: Path) -> Non
     assert stats["vision_cycles"] == 0
 
 
+def test_live_loop_advances_satisfied_s19_visual_hold_before_vlm_gate(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s20_satisfied_s19_visual_hold.jsonl"
+    frame = _bios_frame(1, 10.0, apu_switch=1)
+    frame["bios"]["EXT_REFUEL_PROBE_SW"] = 0
+    frame["delta"]["EXT_REFUEL_PROBE_SW"] = 0
+    _write_replay(replay_path, [frame])
+
+    class StaticVisionPort:
+        def __init__(self) -> None:
+            self._polled = False
+
+        def start(self, session_id: str) -> None:
+            assert session_id == "sess-s19-hold-satisfied"
+
+        def stop(self) -> None:
+            return
+
+        def poll(self):
+            if self._polled:
+                return []
+            self._polled = True
+            return [
+                VisionObservation(
+                    frame_id="10000_000654",
+                    capture_wall_ms=10000,
+                    frame_seq=654,
+                    channel="composite_panel",
+                    layout_id="fa18c_composite_panel_v2",
+                    image_uri=str(tmp_path / "10000_000654.png"),
+                )
+            ]
+
+    class FailingIfCalledVisionFactExtractor:
+        def extract(self, vision, *, session_id: str | None, trigger_wall_ms: int):  # pragma: no cover
+            del vision, session_id, trigger_wall_ms
+            raise AssertionError("VLM extractor should not be called after S19 visual hold is satisfied")
+
+        def close(self) -> None:
+            return
+
+    class RequestHintModel:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def explain_error(self, observation: Observation, request=None) -> TutorResponse:
+            self.calls.append({"observation": observation, "request": request})
+            hint = request.context["deterministic_step_hint"]
+            step_id = hint["inferred_step_id"]
+            target = hint.get("action_hint", {}).get("target") or hint["step_ui_targets"][0]
+            return TutorResponse(
+                status="ok",
+                in_reply_to=request.request_id,
+                message=f"Operate {target}.",
+                actions=[],
+                explanations=[f"Operate {target}."],
+                metadata={
+                    "provider": "mock_qwen",
+                    "help_response": {
+                        "diagnosis": {"step_id": step_id, "error_category": "OM"},
+                        "next": {"step_id": step_id},
+                        "overlay": {
+                            "targets": [target],
+                            "evidence": [
+                                {
+                                    "target": target,
+                                    "type": "gate",
+                                    "ref": f"GATES.{step_id}.completion",
+                                    "quote": "Current gate remains incomplete.",
+                                    "grounding_confidence": 0.95,
+                                }
+                            ],
+                        },
+                        "explanations": [f"Operate {target}."],
+                    },
+                },
+            )
+
+    source = ReplayBiosReceiver(replay_path, speed=0.0)
+    model = RequestHintModel()
+    loop = LiveDcsTutorLoop(
+        source=source,
+        model=model,
+        action_executor=RecordingExecutor(),
+        session_id="sess-s19-hold-satisfied",
+        vision_port=StaticVisionPort(),
+        vision_session_id="sess-s19-hold-satisfied",
+        vision_mode="replay",
+        vision_fact_extractor=FailingIfCalledVisionFactExtractor(),
+    )
+    loop._infer_preliminary_step_for_vision_facts = lambda obs: StepInferenceResult(
+        "S19",
+        ("vision_facts.fcsmc_final_go_result_visible==seen",),
+    )
+    loop._last_inferred_step_id = "S19"
+    loop._sticky_inference_step_id = "S19"
+    loop._sticky_inference_missing_conditions = ("vision_facts.fcsmc_final_go_result_visible==seen",)
+    loop._vision_fact_snapshot = {
+        "fcsmc_final_go_result_visible": {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "state": "seen",
+            "source_frame_id": "old-s19-frame",
+            "sticky": True,
+            "expires_after_ms": 600000,
+            "observed_at_wall_ms": 9000,
+            "expires_at_wall_ms": 609000,
+        }
+    }
+    try:
+        obs = source.get_observation()
+        assert obs is not None
+        loop._ingest_observation(obs)
+        response, _report = loop.run_help_cycle(trigger_t_wall=10.0)
+        stats = loop.stats.to_dict()
+    finally:
+        loop.close()
+
+    assert response is not None
+    request = model.calls[0]["request"]
+    assert request.metadata["vision_fact_status"] == "vision_not_required"
+    assert request.metadata["vision_fact_active_step_ids"] == ["S20"]
+    assert request.context["vision_facts"] == []
+    assert request.context["deterministic_step_hint"]["inferred_step_id"] == "S20"
+    assert response.metadata["final_action_plan"]["step_id"] == "S20"
+    assert response.actions[0]["target"] == "refuel_probe_switch"
+    assert response.metadata["vlm_call_status"] == "not_required"
+    assert response.metadata["harness_trace"]["vlm_call"]["extractor_called"] is False
+    assert stats["vision_cycles"] == 0
+
+
 def test_live_loop_keeps_unresolved_visual_sticky_hold_for_regressed_preliminary_step(tmp_path: Path) -> None:
     replay_path = tmp_path / "bios_visual_sticky_regression.jsonl"
     _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
@@ -8308,6 +8437,41 @@ def test_live_loop_keeps_unresolved_visual_sticky_hold_for_regressed_preliminary
 
     assert regressed == ["S17", "S19"]
     assert advanced == ["S20"]
+
+
+def test_live_loop_advances_satisfied_s19_sticky_hold_for_regressed_preliminary_step(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s19_sticky_satisfied_regression.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=1)])
+
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-sticky-visual-satisfied-regression",
+    )
+    try:
+        loop._last_inferred_step_id = "S19"
+        loop._sticky_inference_step_id = "S19"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcsmc_final_go_result_visible==seen",)
+        loop._vision_fact_snapshot = {
+            "fcsmc_final_go_result_visible": {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "state": "seen",
+                "source_frame_id": "old-s19-frame",
+                "sticky": True,
+                "observed_at_wall_ms": 9000,
+                "expires_at_wall_ms": 609000,
+            }
+        }
+
+        active = loop._active_step_ids_for_vision_facts(
+            StepInferenceResult("S17", ()),
+            now_wall_ms=10000,
+        )
+    finally:
+        loop.close()
+
+    assert active == ["S20"]
 
 
 def test_live_loop_suppresses_stale_visual_preliminary_behind_progress(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- advance satisfied S19 sticky final-GO holds to S20 before VLM extraction is considered
- keep S20 vision context as vision_not_required without injecting VLM facts
- add regressions for the 338a4b8a-style S19-to-S20 leak and regressed preliminary-step active ids

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k "satisfied_s19 or unresolved_visual_sticky_hold or stale_s19_visual_facts_for_s20"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k "satisfied_s19 or unresolved_visual_sticky_hold or s19_visual or stale_s19 or visual_hold or vision_facts_for_s20 or s20"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_evidence_packet.py -k "sticky_visual_state or telemetry_only or sticky_state"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full