### PR TITLE
Fix S08 visual recovery and S09 pull gating

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -497,6 +497,11 @@ def _s09_state_action_plan(
     compact = scratchpad_text.replace(" ", "")
     payload = compact[3:] if compact.startswith("1--") else compact
     recent = set(_strings(recent_action_targets))
+    entry_mode_confirmed = (
+        vars_map.get("ufc_comm1_pull_pressed") is True
+        or "ufc_comm1_channel_selector_pull" in recent
+        or compact.startswith("1--")
+    )
 
     def _target(name: str, guidance: str) -> _StateActionPlan | None:
         if name not in allowed:
@@ -527,6 +532,8 @@ def _s09_state_action_plan(
             reasons=(reason,),
         )
 
+    if not entry_mode_confirmed:
+        return _target("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector before entering 134.000.")
     if payload.endswith("134.000"):
         return _target("ufc_ent_button", "The UFC scratchpad shows 134.000; press ENT to commit the COMM1 preset.")
     if payload.endswith("13.400") or payload.endswith("1.340") or payload.endswith(".134") or payload.endswith("1.34"):
@@ -542,16 +549,9 @@ def _s09_state_action_plan(
         if max_overlay_targets < len(_S09_NUMERIC_SEQUENCE_TARGETS):
             return _target("ufc_key_1", "COMM1 preset 1 is open with the old 305.000 value; press 1 next.")
         return _numeric_sequence(sequence_guidance)
-    if vars_map.get("ufc_comm1_pull_pressed") is True or "ufc_comm1_channel_selector_pull" in recent:
-        if max_overlay_targets < len(_S09_NUMERIC_SEQUENCE_TARGETS):
-            return _target("ufc_key_1", "COMM1 preset entry is open; start typing 134.000 with key 1.")
-        return _numeric_sequence(sequence_guidance)
     if max_overlay_targets < len(_S09_NUMERIC_SEQUENCE_TARGETS):
-        return _target("ufc_comm1_channel_selector_pull", "Pull the UFC COMM1 channel selector before entering 134.000.")
-    return _numeric_sequence(
-        "Pull the UFC COMM1 channel selector if needed, then enter frequency 134.000 with keys 1-3-4-0-0-0 and press ENT.",
-        reason="s09_numeric_sequence_targets_selector_maybe_needed",
-    )
+        return _target("ufc_key_1", "COMM1 preset entry is open; start typing 134.000 with key 1.")
+    return _numeric_sequence(sequence_guidance)
 
 
 def _changed_var(evidence_packet: Any, var_name: str) -> Mapping[str, Any] | None:

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2670,8 +2670,12 @@ def _s08_visual_recovery_needed(context: Mapping[str, Any]) -> bool:
         item for item in summary.get("not_seen_fact_ids", [])
         if isinstance(item, str) and item
     } if isinstance(summary.get("not_seen_fact_ids"), (list, tuple, set)) else set()
-    return (
+    left_page_recovery_visible = (
         "tac_page_visible" in seen_or_fresh
+        or "supt_page_visible" in seen_or_fresh
+    )
+    return (
+        left_page_recovery_visible
         and "bit_root_page_visible" in seen_or_fresh
         and "fcs_page_visible" in not_seen
     )
@@ -6181,16 +6185,7 @@ class LiveDcsTutorLoop:
                     "AMPCD, and HUD controls; DDI warm-up can lag briefly, so wait for the displays before navigating."
                 )
             )
-        if "s09_numeric_sequence_targets_selector_maybe_needed" in plan.reasons:
-            plan_guidance = (
-                "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
-                if self.lang == "zh"
-                else (
-                    "Pull the UFC COMM1 selector if needed, then enter COMM1 frequency 134.000: "
-                    "press 1-3-4-0-0-0, then ENT."
-                )
-            )
-        elif "s09_numeric_sequence_targets" in plan.reasons:
+        if "s09_numeric_sequence_targets" in plan.reasons:
             plan_guidance = (
                 "请在 UFC 输入 COMM1 频率 134.000：按 1-3-4-0-0-0，然后按 ENT。"
                 if self.lang == "zh"
@@ -6763,12 +6758,24 @@ class LiveDcsTutorLoop:
             if advanced is not None and isinstance(advanced.inferred_step_id, str)
             else self._next_step_id_after(rejected_step_id)
         )
+        s08_visual_hint = _s08_visual_hint_from_vision_summary(context) if s08_visual_recovery else None
+        s08_visual_target = s08_visual_hint[0] if s08_visual_hint is not None else "left_mdi_pb18"
+        s08_visual_evidence_ref = (
+            s08_visual_hint[2]
+            if s08_visual_hint is not None
+            else _visual_fact_ref_from_context(context, "tac_page_visible")
+        )
+
         if s08_visual_recovery:
             next_step_id = "S08"
         if not isinstance(next_step_id, str) or not next_step_id:
             next_step_id = rejected_step_id
 
-        if s08_visual_recovery and self.lang == "zh":
+        if s08_visual_recovery and s08_visual_target == "left_mdi_pb15" and self.lang == "zh":
+            rewritten = "当前仍在 S08：左 DDI 已到 SUPT 页面，但 FCS 页面尚未出现。请按左 DDI PB15 进入 FCS。"
+        elif s08_visual_recovery and s08_visual_target == "left_mdi_pb15":
+            rewritten = "You are still on S08: the left DDI is on SUPT, but the FCS page is not visible. Press Left DDI PB15 to enter FCS."
+        elif s08_visual_recovery and self.lang == "zh":
             rewritten = "当前仍在 S08：左 DDI 还在 TAC 页面，FCS 页面尚未出现。请先按左 DDI PB18 进入 SUPT，再进入 FCS。"
         elif s08_visual_recovery:
             rewritten = "You are still on S08: the left DDI is on TAC and the FCS page is not visible. Press Left DDI PB18 to reach SUPT, then enter FCS."
@@ -6801,24 +6808,18 @@ class LiveDcsTutorLoop:
         ]
 
         if s08_visual_recovery:
-            visual_hint = _s08_visual_hint_from_vision_summary(context)
-            target = visual_hint[0] if visual_hint is not None else "left_mdi_pb18"
-            evidence_ref = visual_hint[2] if visual_hint is not None else _visual_fact_ref_from_context(
-                context,
-                "tac_page_visible",
-            )
             fallback_help_obj = {
                 "diagnosis": {"step_id": "S08", "error_category": "OM"},
                 "next": {"step_id": "S08"},
-                "overlay": {"targets": [target], "evidence": []},
+                "overlay": {"targets": [s08_visual_target], "evidence": []},
                 "explanations": [rewritten],
             }
-            if isinstance(evidence_ref, str) and evidence_ref:
+            if isinstance(s08_visual_evidence_ref, str) and s08_visual_evidence_ref:
                 fallback_help_obj["overlay"]["evidence"] = [
                     {
-                        "target": target,
+                        "target": s08_visual_target,
                         "type": "visual",
-                        "ref": evidence_ref,
+                        "ref": s08_visual_evidence_ref,
                         "quote": "VLM confirms S08 page recovery is still required.",
                         "grounding_confidence": 0.95,
                     }
@@ -7124,16 +7125,35 @@ class LiveDcsTutorLoop:
             }
         elif inferred_step_id == "S09" and "vars.comm1_freq_134_000==true" in missing_set:
             reason = "s09_comm1_frequency_guidance"
+            recent_actions = context.get("recent_actions")
+            recent_buttons = (
+                [
+                    item for item in recent_actions.get("recent_buttons", [])
+                    if isinstance(item, str) and item
+                ]
+                if isinstance(recent_actions, Mapping)
+                else []
+            )
+            scratchpad_text = _normalize_ufc_scratchpad_text(vars_map)
+            compact_scratchpad = scratchpad_text.replace(" ", "")
+            s09_entry_mode_confirmed = (
+                vars_map.get("ufc_comm1_pull_pressed") is True
+                or "ufc_comm1_channel_selector_pull" in set(recent_buttons)
+                or compact_scratchpad.startswith("1--")
+            )
             if self.lang == "zh":
-                rewritten = (
-                    "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz：先拉出 UFC 的 COMM1 "
-                    "频道选择钮，输入 1-3-4-0-0-0，然后按 ENT 确认。"
-                )
+                if s09_entry_mode_confirmed:
+                    rewritten = (
+                        "当前处于 S09。请把 COMM1 预置 1 设置为 134.000 MHz："
+                        "输入 1-3-4-0-0-0，然后按 ENT 确认。"
+                    )
+                else:
+                    rewritten = "当前处于 S09。请先拉出 UFC 的 COMM1 频道选择钮，打开预置 1 输入模式；目标频率是 134.000 MHz。"
             else:
-                rewritten = (
-                    "You are on S09. Set COMM1 preset 1 to 134.000 MHz: pull the UFC COMM1 "
-                    "channel selector, enter 1-3-4-0-0-0, then press ENT."
-                )
+                if s09_entry_mode_confirmed:
+                    rewritten = "You are on S09. Set COMM1 preset 1 to 134.000 MHz: enter 1-3-4-0-0-0, then press ENT."
+                else:
+                    rewritten = "You are on S09. First pull the UFC COMM1 channel selector to open preset 1 entry mode; the target frequency is 134.000 MHz."
         elif inferred_step_id == "S10" and _left_engine_start_complete(vars_map):
             reason = "s10_left_engine_start_complete"
             recent_actions = context.get("recent_actions")

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -754,35 +754,72 @@ def test_plan_harness_action_uses_s09_numeric_sequence_for_initial_entry() -> No
         )
     }
     allowed_targets = list(specs["S09"].allowed_overlay_targets)
-    cases = [
-        {},
-        {
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S09",
+        model_step_id="S09",
+        proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        candidate_step_ids=["S09"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=4,
+        latest_vars={
+            "comm1_freq_134_000": False,
             "ufc_comm1_pull_pressed": True,
             "ufc_scratchpad_string_1_display": "1-",
             "ufc_scratchpad_string_2_display": "-",
             "ufc_scratchpad_number_display": "305.000",
         },
-    ]
+        recent_action_targets=[],
+    )
 
-    for vars_map in cases:
-        plan = plan_harness_action(
-            step_specs=specs,
-            inferred_step_id="S09",
-            model_step_id="S09",
-            proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
-            candidate_step_ids=["S09"],
-            runtime_overlay_targets=allowed_targets,
-            request_overlay_targets=allowed_targets,
-            max_overlay_targets=4,
-            latest_vars={"comm1_freq_134_000": False, **vars_map},
-            recent_action_targets=[],
+    assert plan.targets == ("ufc_key_1", "ufc_key_3", "ufc_key_4", "ufc_key_0")
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "134.000" in (plan.guidance or "")
+    assert "1-3-4-0-0-0" in (plan.guidance or "")
+    assert "ENT" in (plan.guidance or "")
+
+
+def test_plan_harness_action_requires_s09_comm1_pull_before_numeric_sequence() -> None:
+    specs = {
+        "S09": _spec(
+            "S09",
+            (
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ),
         )
+    }
+    allowed_targets = list(specs["S09"].allowed_overlay_targets)
 
-        assert plan.targets == ("ufc_key_1", "ufc_key_3", "ufc_key_4", "ufc_key_0")
-        assert plan.final_action_plan_source == "state_action_planner"
-        assert "134.000" in (plan.guidance or "")
-        assert "1-3-4-0-0-0" in (plan.guidance or "")
-        assert "ENT" in (plan.guidance or "")
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S09",
+        model_step_id="S09",
+        proposed_overlay_targets=["ufc_comm1_channel_selector_pull"],
+        candidate_step_ids=["S09"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=4,
+        latest_vars={
+            "comm1_freq_134_000": False,
+            "comm1_freq_value": 30500,
+            "ufc_comm1_pull_pressed": False,
+            "ufc_scratchpad_number_display": "305.000",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+        },
+        recent_action_targets=[],
+    )
+
+    assert plan.targets == ("ufc_comm1_channel_selector_pull",)
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "134.000" in (plan.guidance or "")
+    assert "1-3-4-0-0-0" not in (plan.guidance or "")
 
 
 def test_plan_harness_action_uses_recent_action_for_s09_open_scratchpad() -> None:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -5378,7 +5378,8 @@ def test_procedural_guidance_rewrite_mentions_s09_frequency_134(tmp_path: Path) 
         assert rewritten is True
         assert reason == "s09_comm1_frequency_guidance"
         assert "134.000" in response.message
-        assert "1-3-4-0-0-0" in response.message
+        assert "COMM1" in response.message
+        assert "1-3-4-0-0-0" not in response.message
     finally:
         loop.close()
 
@@ -5997,7 +5998,8 @@ def test_procedural_guidance_rewrite_mentions_s09_frequency_134(tmp_path: Path) 
         assert rewritten is True
         assert reason == "s09_comm1_frequency_guidance"
         assert "134.000" in response.message
-        assert "1-3-4-0-0-0" in response.message
+        assert "COMM1" in response.message
+        assert "1-3-4-0-0-0" not in response.message
     finally:
         loop.close()
 
@@ -6493,22 +6495,12 @@ def test_harness_validation_action_plan_s09_empty_scratchpad_mentions_selector_i
 
         assert used is True
         assert reason == "state_action_planner"
-        assert [action["target"] for action in response.actions] == [
-            "ufc_key_1",
-            "ufc_key_3",
-            "ufc_key_4",
-            "ufc_key_0",
-        ]
-        assert "COMM1 selector" in response.message
+        assert [action["target"] for action in response.actions] == ["ufc_comm1_channel_selector_pull"]
+        assert "COMM1" in response.message
         assert "134.000" in response.message
-        assert "1-3-4-0-0-0" in response.message
+        assert "1-3-4-0-0-0" not in response.message
         _annotate_test_final_metadata(loop, response, request)
-        assert response.metadata["final_overlay_targets"] == [
-            "ufc_key_1",
-            "ufc_key_3",
-            "ufc_key_4",
-            "ufc_key_0",
-        ]
+        assert response.metadata["final_overlay_targets"] == ["ufc_comm1_channel_selector_pull"]
         assert response.metadata["final_public_response"]["message"] == response.message
     finally:
         loop.close()
@@ -11061,6 +11053,41 @@ def test_live_help_fixture_314_keeps_s08_tac_bit_root_visual_recovery() -> None:
     public_text = _public_response_text(repaired)
     assert "S09" not in public_text
     assert "COMM1" not in public_text
+
+
+def test_live_help_fixture_314_keeps_s08_supt_bit_root_visual_recovery() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response, vision_status="available")
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S08"
+    assert repaired.metadata["next"]["step_id"] == "S08"
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "left_mdi_pb15"
+    assert repaired.metadata["final_overlay_targets"] == ["left_mdi_pb15"]
+    public_text = _public_response_text(repaired)
+    assert "S09" not in public_text
+    assert "COMM1" not in public_text
+    assert "PB15" in public_text or "left_mdi_pb15" in public_text
+
+
+def test_live_help_fixture_314_s09_requires_comm1_pull_before_numeric_sequence() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/ce8512ef-901a-4f08-a339-af10893b744f.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["final_overlay_targets"] == ["ufc_comm1_channel_selector_pull"]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "ufc_comm1_channel_selector_pull"
+    assert "134.000" in _public_response_text(repaired)
+    assert "1-3-4-0-0-0" not in _public_response_text(repaired)
+    assert not {"ufc_key_1", "ufc_key_3", "ufc_key_4", "ufc_key_0"} & set(
+        repaired.metadata["final_overlay_targets"]
+    )
 
 
 def test_live_help_fixture_314_s18_pb5_repair_rewrites_public_message() -> None:


### PR DESCRIPTION
## Summary
- keep S08 active for SUPT/BIT-root visual recovery and target left_mdi_pb15 instead of advancing to S09
- require confirmed COMM1 entry mode before S09 numeric sequence targets; otherwise target COMM1 selector first
- add live fixture/core regression coverage for the latest issue #314 comment

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_live_dcs.py -k 's09 or 314 or final_evidence_validator or final_evidence_consistency or visual_recovery'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py

Related to #314