### PR TITLE
Generalize four-down transition latches

### DIFF
--- a/artifacts/live_fixtures/20c79783-092e-4128-ad47-5fa7d3774ed7.fixture.json
+++ b/artifacts/live_fixtures/20c79783-092e-4128-ad47-5fa7d3774ed7.fixture.json
@@ -1,0 +1,3336 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 1,
+        "contradiction_count": 0,
+        "first_seq": 9509,
+        "frame_count": 20,
+        "latest_seq": 9528
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+      "source_observation_seq": 9528,
+      "source_observation_t_wall": 1779191995.1893234,
+      "telemetry_window_first_seq": 9509,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 9528,
+      "telemetry_window_latest_t_wall": 1779191995.1893234,
+      "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+    },
+    "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 2,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:56245",
+          "raw_delta_count": 2,
+          "seq": 9528
+        },
+        "observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_RIGHT",
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 2,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 2,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_RIGHT",
+                "ui_targets": [],
+                "value": 39039
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41408
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 9528,
+          "t_wall": 1779191995.1893234,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 316,
+            "temp_r": 296,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T11:59:55.189323+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 1,
+      "contradiction_count": 0,
+      "first_seq": 9509,
+      "frame_count": 20,
+      "latest_seq": 9528
+    },
+    "vision": {
+      "frame_ids": [
+        "1779191995263_000204"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779191995263_000204",
+        "frame_ids": [
+          "1779191995263_000204"
+        ],
+        "frame_stale": false,
+        "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+        "observation_seq": 9528,
+        "observation_t_wall_ms": 1779191995189,
+        "observation_t_wall_s": 1779191995.1893234,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779191995263,
+            "channel": "composite_panel",
+            "frame_id": "1779191995263_000204",
+            "frame_seq": 204,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191995263_000204_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191995263_000204.png",
+            "sync_delta_ms": 101,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 101,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779191995263,
+          "channel": "composite_panel",
+          "frame_id": "1779191995263_000204",
+          "frame_seq": 204,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191995263_000204_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191995263_000204.png",
+          "sync_delta_ms": 101,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779191995162,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779191995263_000204"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "kind": "tutor_request",
+        "lineno": 10076,
+        "metadata": {
+          "frame_id": "1779191995263_000204",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "fused_step_id": "S20",
+          "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 101,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "four_down_completion_latches": {
+              "s20_latched_complete": true,
+              "s21_latched_complete": true,
+              "s22_latched_complete": false,
+              "s23_latched_complete": false,
+              "s24_latched_complete": false,
+              "s25_latched_complete": false
+            },
+            "refuel_probe_completion_latches": {
+              "s20_latched_complete": true,
+              "s21_latched_complete": true
+            },
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "refuel_probe_switch"
+              },
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S20",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S20",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "refuel_probe_switch"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "first_seq": 9509,
+                "frame_count": 20,
+                "latest_seq": 9528
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+              "source_observation_seq": 9528,
+              "source_observation_t_wall": 1779191995.1893234,
+              "telemetry_window_first_seq": 9509,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 9528,
+              "telemetry_window_latest_t_wall": 1779191995.1893234,
+              "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.70514828499053,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "fa18c_nasatlx_vr_0",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "score": 13.19501049960089,
+                "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "snippet_id": "fa18c_nasatlx_vr_0"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 93,
+                "score": 11.014724065569608,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_59",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 60,
+                "score": 10.90028486486424,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_59"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_8",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "score": 10.677970127175083,
+                "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "snippet_id": "Appendix - Training Task Syllabus_8"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.ext_refuel_probe_value in [60000,65535]"
+                ],
+                "overlay_step_id": "S20",
+                "role": "candidate_not_authoritative",
+                "step_id": "S20"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 9528,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": 757,
+                    "last_value": 0,
+                    "latest_transition_age_s": 0.639,
+                    "transition_count": 2,
+                    "var": "ext_refuel_probe_value"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 9509,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 9528,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 9528,
+                "latest_t_wall": 1779191995.1893234,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.712
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779191995263_000204",
+              "frame_ids": [
+                "1779191995263_000204"
+              ],
+              "frame_stale": false,
+              "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+              "observation_seq": 9528,
+              "observation_t_wall_ms": 1779191995189,
+              "observation_t_wall_s": 1779191995.1893234,
+              "status": "partial",
+              "sync_delta_ms": 101,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779191995162,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191995263_000204"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "first_seq": 9509,
+                "frame_count": 20,
+                "latest_seq": 9528
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+              "source_observation_seq": 9528,
+              "source_observation_t_wall": 1779191995.1893234,
+              "telemetry_window_first_seq": 9509,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 9528,
+              "telemetry_window_latest_t_wall": 1779191995.1893234,
+              "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "frame_id": "1779191995263_000204",
+            "fused_missing_conditions": [
+              "vars.ext_refuel_probe_value in [60000,65535]"
+            ],
+            "fused_step_id": "S20",
+            "grounding_cache_hit": true,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_coldstart_quiz_1",
+              "fa18c_nasatlx_vr_0",
+              "DCS FA-18C Early Access Guide EN_92",
+              "DCS FA-18C Early Access Guide EN_59",
+              "Appendix - Training Task Syllabus_8"
+            ],
+            "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+            "prompt_tokens_est": 5471,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "source_chunk_refs": [
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_59",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 101,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191995263_000204"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779191995263_000204"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+          "request_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "timestamp": "2026-05-19T11:59:55.717522+00:00",
+          "version": "v1"
+        },
+        "related_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "vision_refs": [
+          "1779191995263_000204"
+        ]
+      },
+      {
+        "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "kind": "overlay_requested",
+        "lineno": 10077,
+        "metadata": {
+          "final_overlay_targets": [
+            "launch_bar_switch"
+          ],
+          "frame_id": "1779191995263_000204",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "fused_step_id": "S20",
+          "generation_mode": "model",
+          "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 101,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "adb62994-19c2-4e94-ba29-c3b3b45a489c",
+          "final_overlay_targets": [
+            "launch_bar_switch"
+          ],
+          "frame_id": "1779191995263_000204",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "fused_step_id": "S20",
+          "generation_mode": "model",
+          "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 101,
+          "target": "pnt_341",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "kind": "overlay_requested",
+        "lineno": 10078,
+        "metadata": {
+          "final_overlay_targets": [
+            "launch_bar_switch"
+          ],
+          "frame_id": "1779191995263_000204",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "fused_step_id": "S20",
+          "generation_mode": "model",
+          "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 101,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "d4e3af41-a376-419d-bc19-8c945346b289",
+          "final_overlay_targets": [
+            "launch_bar_switch"
+          ],
+          "frame_id": "1779191995263_000204",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "fused_step_id": "S20",
+          "generation_mode": "model",
+          "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 101,
+          "target": "pnt_233",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "kind": "tutor_response",
+        "lineno": 10079,
+        "metadata": {
+          "final_overlay_targets": [
+            "launch_bar_switch"
+          ],
+          "frame_id": "1779191995263_000204",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "fused_step_id": "S20",
+          "generation_mode": "model",
+          "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 101,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_233",
+              "evidence_refs": [
+                "GATES.S20.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "launch_bar_switch"
+              ],
+              "frame_id": "1779191995263_000204",
+              "fused_missing_conditions": [
+                "vars.ext_refuel_probe_value in [60000,65535]"
+              ],
+              "fused_step_id": "S20",
+              "generation_mode": "model",
+              "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 101,
+              "target": "launch_bar_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191995263_000204"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "S20 的最新证据已经满足。现在进入 S22。"
+          ],
+          "in_reply_to": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "message": "S20 的最新证据已经满足。现在进入 S22。",
+          "metadata": {
+            "action_hint_overlay_override_kind": "action_hint",
+            "action_hint_overlay_override_original_actions": [
+              {
+                "element_id": "pnt_233",
+                "evidence_refs": [
+                  "GATES.S20.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "launch_bar_switch",
+                "type": "overlay"
+              }
+            ],
+            "action_hint_overlay_override_original_targets": [
+              "launch_bar_switch"
+            ],
+            "allowed_evidence_ref_count": 116,
+            "completion_conflict_original_actions": [
+              {
+                "element_id": "pnt_341",
+                "evidence_refs": [
+                  "GATES.S20.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "refuel_probe_switch",
+                "type": "overlay"
+              }
+            ],
+            "completion_conflict_original_explanations": [
+              "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+            ],
+            "completion_conflict_original_message": "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。",
+            "completion_conflict_original_next": {
+              "step_id": "S22"
+            },
+            "completion_conflict_overlay_cleared": true,
+            "completion_conflict_rewritten": true,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "a162b36a-6f67-4ca7-a32c-3d7fed52afa6",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "S20 的最新证据已经满足。现在进入 S22。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S22"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+              "source_observation_seq": 9528,
+              "source_observation_t_wall": 1779191995.1893234,
+              "telemetry_window_first_seq": 9509,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 9528,
+              "telemetry_window_latest_t_wall": 1779191995.1893234,
+              "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "overlay_step_id": "S22",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S22",
+              "targets": [
+                "launch_bar_switch"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 116,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S22"
+              },
+              "next": {
+                "step_id": "S22"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S22",
+            "final_evidence_consistency_reasons": [
+              "refuel_probe_latched_completion:S21"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "launch_bar_switch"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_233",
+                  "evidence_refs": [
+                    "GATES.S20.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "launch_bar_switch"
+                  ],
+                  "frame_id": "1779191995263_000204",
+                  "fused_missing_conditions": [
+                    "vars.ext_refuel_probe_value in [60000,65535]"
+                  ],
+                  "fused_step_id": "S20",
+                  "generation_mode": "model",
+                  "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "completion_conflict_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 101,
+                  "target": "launch_bar_switch",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779191995263_000204"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S22"
+              },
+              "explanations": [
+                "S20 的最新证据已经满足。现在进入 S22。"
+              ],
+              "message": "S20 的最新证据已经满足。现在进入 S22。",
+              "next": {
+                "step_id": "S22"
+              }
+            },
+            "frame_id": "1779191995263_000204",
+            "fused_missing_conditions": [
+              "vars.ext_refuel_probe_value in [60000,65535]"
+            ],
+            "fused_step_id": "S20",
+            "generation_mode": "model",
+            "generation_prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+            "generation_prompt_tokens_est": 5471,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S22",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S22",
+              "targets": [
+                "launch_bar_switch"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.7,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "telemetry_window",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "TELEMETRY_WINDOW.changed_vars.ext_refuel_probe_value"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "pitot_heater_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S26",
+                  "supporting_evidence_refs": [
+                    "GATES.S26.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "parking_brake_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S28",
+                  "supporting_evidence_refs": [
+                    "GATES.S28.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button",
+                    "ifei_down_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": [
+                    "GATES.S29.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.7,
+                "proposed_next_action_target_ids": [
+                  "launch_bar_switch"
+                ],
+                "role": "candidate",
+                "source": "telemetry_window",
+                "step_id": "S22",
+                "supporting_evidence_refs": [
+                  "TELEMETRY_WINDOW.changed_vars.ext_refuel_probe_value"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 1,
+                  "contradiction_count": 0,
+                  "first_seq": 9509,
+                  "frame_count": 20,
+                  "latest_seq": 9528
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+                "source_observation_seq": 9528,
+                "source_observation_t_wall": 1779191995.1893234,
+                "telemetry_window_first_seq": 9509,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 9528,
+                "telemetry_window_latest_t_wall": 1779191995.1893234,
+                "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "overlay_step_id": "S22",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S22",
+                "targets": [
+                  "launch_bar_switch"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "launch_bar_switch"
+              ],
+              "message_category": "completion_conflict_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S20.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "refuel_probe_switch"
+                ],
+                "status": "ok",
+                "step_id": "S22"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S20"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+                "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "refuel_probe_latched_completion:S21"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S20"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779191995263_000204"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 101,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "refuel_probe_latched_completion:S21"
+            ],
+            "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S22"
+              },
+              "explanations": [
+                "S20 的最新证据已经满足。现在进入 S22。"
+              ],
+              "next": {
+                "step_id": "S22"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S20.completion",
+                    "target": "launch_bar_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "launch_bar_switch"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S22"
+              },
+              "explanations": [
+                "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+              ],
+              "next": {
+                "step_id": "S22"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S20.completion",
+                    "target": "refuel_probe_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "refuel_probe_switch"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4555,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "completion_conflict_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S22"
+            },
+            "model_raw_explanations": [
+              "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S22"
+              },
+              "explanations": [
+                "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+              ],
+              "next": {
+                "step_id": "S22"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S20.completion",
+                    "target": "refuel_probe_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "refuel_probe_switch"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S22"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779191995263_000204"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779191995263_000204",
+            "next": {
+              "step_id": "S22"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5488,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.ext_refuel_probe_value",
+                "GATES.S20.completion",
+                "GATES.S20.precondition",
+                "GATES.S22.completion",
+                "GATES.S25.completion",
+                "GATES.S26.completion",
+                "GATES.S28.completion",
+                "GATES.S29.completion",
+                "GATES.S31.completion",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+                "RAG_SNIPPETS.fa18c_nasatlx_vr_0",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_92",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_59",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_8"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 23,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "refuel_probe_switch",
+              "prompt_chars": 21884,
+              "prompt_tokens_est": 5471,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_coldstart_quiz_1",
+                "fa18c_nasatlx_vr_0",
+                "DCS FA-18C Early Access Guide EN_92",
+                "DCS FA-18C Early Access Guide EN_59",
+                "Appendix - Training Task Syllabus_8"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+            "prompt_tokens_est": 5471,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.ext_refuel_probe_value in [60000,65535]"
+            ],
+            "rejected_model_step_id": "S20",
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+            "request_prompt_tokens_est": 5471,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 116,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S22"
+              },
+              "next": {
+                "step_id": "S22"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+              "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+            },
+            "state_key": "f4522ad9ff0c8be3fec77384f3809c9c6f54019430142528b9f353cefe722371",
+            "sync_delta_ms": 101,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779191995263_000204",
+              "frame_ids": [
+                "1779191995263_000204"
+              ],
+              "frame_stale": false,
+              "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+              "observation_seq": 9528,
+              "observation_t_wall_ms": 1779191995189,
+              "observation_t_wall_s": 1779191995.1893234,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779191995263,
+                  "channel": "composite_panel",
+                  "frame_id": "1779191995263_000204",
+                  "frame_seq": 204,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191995263_000204_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191995263_000204.png",
+                  "sync_delta_ms": 101,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 101,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779191995263,
+                "channel": "composite_panel",
+                "frame_id": "1779191995263_000204",
+                "frame_seq": 204,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191995263_000204_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191995263_000204.png",
+                "sync_delta_ms": 101,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779191995162,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S20"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191995263_000204"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779191995263_000204"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "c7d13dd3-d318-4367-8969-b620aa70a879",
+          "status": "ok",
+          "timestamp": "2026-05-19T12:00:00.273925+00:00",
+          "version": "v1"
+        },
+        "related_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "vision_refs": [
+          "1779191995263_000204"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "four_down_completion_latches": {
+          "s20_latched_complete": true,
+          "s21_latched_complete": true,
+          "s22_latched_complete": false,
+          "s23_latched_complete": false,
+          "s24_latched_complete": false,
+          "s25_latched_complete": false
+        },
+        "refuel_probe_completion_latches": {
+          "s20_latched_complete": true,
+          "s21_latched_complete": true
+        },
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "refuel_probe_switch"
+          },
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S20",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S20",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "refuel_probe_switch"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "first_seq": 9509,
+            "frame_count": 20,
+            "latest_seq": 9528
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+          "source_observation_seq": 9528,
+          "source_observation_t_wall": 1779191995.1893234,
+          "telemetry_window_first_seq": 9509,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 9528,
+          "telemetry_window_latest_t_wall": 1779191995.1893234,
+          "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.70514828499053,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "fa18c_nasatlx_vr_0",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "score": 13.19501049960089,
+            "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "snippet_id": "fa18c_nasatlx_vr_0"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 93,
+            "score": 11.014724065569608,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_59",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 60,
+            "score": 10.90028486486424,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_59"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_8",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "score": 10.677970127175083,
+            "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "snippet_id": "Appendix - Training Task Syllabus_8"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.ext_refuel_probe_value in [60000,65535]"
+            ],
+            "overlay_step_id": "S20",
+            "role": "candidate_not_authoritative",
+            "step_id": "S20"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 9528,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": 757,
+                "last_value": 0,
+                "latest_transition_age_s": 0.639,
+                "transition_count": 2,
+                "var": "ext_refuel_probe_value"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 9509,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 9528,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 9528,
+            "latest_t_wall": 1779191995.1893234,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.712
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779191995263_000204",
+          "frame_ids": [
+            "1779191995263_000204"
+          ],
+          "frame_stale": false,
+          "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+          "observation_seq": 9528,
+          "observation_t_wall_ms": 1779191995189,
+          "observation_t_wall_s": 1779191995.1893234,
+          "status": "partial",
+          "sync_delta_ms": 101,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779191995162,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191995263_000204"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "first_seq": 9509,
+            "frame_count": 20,
+            "latest_seq": 9528
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+          "source_observation_seq": 9528,
+          "source_observation_t_wall": 1779191995.1893234,
+          "telemetry_window_first_seq": 9509,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 9528,
+          "telemetry_window_latest_t_wall": 1779191995.1893234,
+          "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "frame_id": "1779191995263_000204",
+        "fused_missing_conditions": [
+          "vars.ext_refuel_probe_value in [60000,65535]"
+        ],
+        "fused_step_id": "S20",
+        "grounding_cache_hit": true,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_coldstart_quiz_1",
+          "fa18c_nasatlx_vr_0",
+          "DCS FA-18C Early Access Guide EN_92",
+          "DCS FA-18C Early Access Guide EN_59",
+          "Appendix - Training Task Syllabus_8"
+        ],
+        "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+        "prompt_tokens_est": 5471,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "source_chunk_refs": [
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_59",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 101,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191995263_000204"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779191995263_000204"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+      "request_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+      "timestamp": "2026-05-19T11:59:55.717522+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_233",
+          "evidence_refs": [
+            "GATES.S20.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "launch_bar_switch"
+          ],
+          "frame_id": "1779191995263_000204",
+          "fused_missing_conditions": [
+            "vars.ext_refuel_probe_value in [60000,65535]"
+          ],
+          "fused_step_id": "S20",
+          "generation_mode": "model",
+          "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 101,
+          "target": "launch_bar_switch",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "S20 的最新证据已经满足。现在进入 S22。"
+      ],
+      "in_reply_to": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+      "message": "S20 的最新证据已经满足。现在进入 S22。",
+      "metadata": {
+        "action_hint_overlay_override_kind": "action_hint",
+        "action_hint_overlay_override_original_actions": [
+          {
+            "element_id": "pnt_233",
+            "evidence_refs": [
+              "GATES.S20.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "launch_bar_switch",
+            "type": "overlay"
+          }
+        ],
+        "action_hint_overlay_override_original_targets": [
+          "launch_bar_switch"
+        ],
+        "allowed_evidence_ref_count": 116,
+        "completion_conflict_original_actions": [
+          {
+            "element_id": "pnt_341",
+            "evidence_refs": [
+              "GATES.S20.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "refuel_probe_switch",
+            "type": "overlay"
+          }
+        ],
+        "completion_conflict_original_explanations": [
+          "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+        ],
+        "completion_conflict_original_message": "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。",
+        "completion_conflict_original_next": {
+          "step_id": "S22"
+        },
+        "completion_conflict_overlay_cleared": true,
+        "completion_conflict_rewritten": true,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "a162b36a-6f67-4ca7-a32c-3d7fed52afa6",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "S20 的最新证据已经满足。现在进入 S22。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S22"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+          "source_observation_seq": 9528,
+          "source_observation_t_wall": 1779191995.1893234,
+          "telemetry_window_first_seq": 9509,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 9528,
+          "telemetry_window_latest_t_wall": 1779191995.1893234,
+          "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "overlay_step_id": "S22",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S22",
+          "targets": [
+            "launch_bar_switch"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 116,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S22"
+          },
+          "next": {
+            "step_id": "S22"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S22",
+        "final_evidence_consistency_reasons": [
+          "refuel_probe_latched_completion:S21"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "launch_bar_switch"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_233",
+              "evidence_refs": [
+                "GATES.S20.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "launch_bar_switch"
+              ],
+              "frame_id": "1779191995263_000204",
+              "fused_missing_conditions": [
+                "vars.ext_refuel_probe_value in [60000,65535]"
+              ],
+              "fused_step_id": "S20",
+              "generation_mode": "model",
+              "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 101,
+              "target": "launch_bar_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191995263_000204"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S22"
+          },
+          "explanations": [
+            "S20 的最新证据已经满足。现在进入 S22。"
+          ],
+          "message": "S20 的最新证据已经满足。现在进入 S22。",
+          "next": {
+            "step_id": "S22"
+          }
+        },
+        "frame_id": "1779191995263_000204",
+        "fused_missing_conditions": [
+          "vars.ext_refuel_probe_value in [60000,65535]"
+        ],
+        "fused_step_id": "S20",
+        "generation_mode": "model",
+        "generation_prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+        "generation_prompt_tokens_est": 5471,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S22",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S22",
+          "targets": [
+            "launch_bar_switch"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.7,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "telemetry_window",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "TELEMETRY_WINDOW.changed_vars.ext_refuel_probe_value"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "pitot_heater_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S26",
+              "supporting_evidence_refs": [
+                "GATES.S26.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "parking_brake_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S28",
+              "supporting_evidence_refs": [
+                "GATES.S28.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S29",
+              "supporting_evidence_refs": [
+                "GATES.S29.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.7,
+            "proposed_next_action_target_ids": [
+              "launch_bar_switch"
+            ],
+            "role": "candidate",
+            "source": "telemetry_window",
+            "step_id": "S22",
+            "supporting_evidence_refs": [
+              "TELEMETRY_WINDOW.changed_vars.ext_refuel_probe_value"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 1,
+              "contradiction_count": 0,
+              "first_seq": 9509,
+              "frame_count": 20,
+              "latest_seq": 9528
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+            "source_observation_seq": 9528,
+            "source_observation_t_wall": 1779191995.1893234,
+            "telemetry_window_first_seq": 9509,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 9528,
+            "telemetry_window_latest_t_wall": 1779191995.1893234,
+            "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "overlay_step_id": "S22",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S22",
+            "targets": [
+              "launch_bar_switch"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "launch_bar_switch"
+          ],
+          "message_category": "completion_conflict_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S20.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "refuel_probe_switch"
+            ],
+            "status": "ok",
+            "step_id": "S22"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S20"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+            "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "refuel_probe_latched_completion:S21"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S20"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779191995263_000204"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 101,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "refuel_probe_latched_completion:S21"
+        ],
+        "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S22"
+          },
+          "explanations": [
+            "S20 的最新证据已经满足。现在进入 S22。"
+          ],
+          "next": {
+            "step_id": "S22"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S20.completion",
+                "target": "launch_bar_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "launch_bar_switch"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S22"
+          },
+          "explanations": [
+            "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+          ],
+          "next": {
+            "step_id": "S22"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S20.completion",
+                "target": "refuel_probe_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "refuel_probe_switch"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4555,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "completion_conflict_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S22"
+        },
+        "model_raw_explanations": [
+          "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S22"
+          },
+          "explanations": [
+            "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+          ],
+          "next": {
+            "step_id": "S22"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S20.completion",
+                "target": "refuel_probe_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "refuel_probe_switch"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S22"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779191995263_000204"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779191995263_000204",
+        "next": {
+          "step_id": "S22"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5488,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.ext_refuel_probe_value",
+            "GATES.S20.completion",
+            "GATES.S20.precondition",
+            "GATES.S22.completion",
+            "GATES.S25.completion",
+            "GATES.S26.completion",
+            "GATES.S28.completion",
+            "GATES.S29.completion",
+            "GATES.S31.completion",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+            "RAG_SNIPPETS.fa18c_nasatlx_vr_0",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_92",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_59",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_8"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 23,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "refuel_probe_switch",
+          "prompt_chars": 21884,
+          "prompt_tokens_est": 5471,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_coldstart_quiz_1",
+            "fa18c_nasatlx_vr_0",
+            "DCS FA-18C Early Access Guide EN_92",
+            "DCS FA-18C Early Access Guide EN_59",
+            "Appendix - Training Task Syllabus_8"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+        "prompt_tokens_est": 5471,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.ext_refuel_probe_value in [60000,65535]"
+        ],
+        "rejected_model_step_id": "S20",
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "813be66d4fd882f3b470c9166cf902ca86245f5e92eb99978cca87d5880bf311",
+        "request_prompt_tokens_est": 5471,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 116,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S22"
+          },
+          "next": {
+            "step_id": "S22"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+          "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+        },
+        "state_key": "f4522ad9ff0c8be3fec77384f3809c9c6f54019430142528b9f353cefe722371",
+        "sync_delta_ms": 101,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779191995263_000204",
+          "frame_ids": [
+            "1779191995263_000204"
+          ],
+          "frame_stale": false,
+          "observation_ref": "b77b2830-7cdb-4b94-a687-d29902856580",
+          "observation_seq": 9528,
+          "observation_t_wall_ms": 1779191995189,
+          "observation_t_wall_s": 1779191995.1893234,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779191995263,
+              "channel": "composite_panel",
+              "frame_id": "1779191995263_000204",
+              "frame_seq": 204,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191995263_000204_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191995263_000204.png",
+              "sync_delta_ms": 101,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 101,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779191995263,
+            "channel": "composite_panel",
+            "frame_id": "1779191995263_000204",
+            "frame_seq": 204,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191995263_000204_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191995263_000204.png",
+            "sync_delta_ms": 101,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779191995162,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S20"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191995263_000204"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779191995263_000204"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "c7d13dd3-d318-4367-8969-b620aa70a879",
+      "status": "ok",
+      "timestamp": "2026-05-19T12:00:00.273925+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S22",
+    "expected_overlay_target_ids": [
+      "launch_bar_switch"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.7,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "telemetry_window",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "TELEMETRY_WINDOW.changed_vars.ext_refuel_probe_value"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "pitot_heater_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S26",
+        "supporting_evidence_refs": [
+          "GATES.S26.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "parking_brake_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S28",
+        "supporting_evidence_refs": [
+          "GATES.S28.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "GATES.S29.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+      "overlay_step_id": "S22",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S22",
+      "targets": [
+        "launch_bar_switch"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S20.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "refuel_probe_switch"
+      ],
+      "status": "ok",
+      "step_id": "S22"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.7,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "telemetry_window",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "TELEMETRY_WINDOW.changed_vars.ext_refuel_probe_value"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "pitot_heater_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S26",
+          "supporting_evidence_refs": [
+            "GATES.S26.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "parking_brake_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S28",
+          "supporting_evidence_refs": [
+            "GATES.S28.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S29",
+          "supporting_evidence_refs": [
+            "GATES.S29.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.7,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "telemetry_window",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "TELEMETRY_WINDOW.changed_vars.ext_refuel_probe_value"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 1,
+          "contradiction_count": 0,
+          "first_seq": 9509,
+          "frame_count": 20,
+          "latest_seq": 9528
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "final_decision_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "model_request_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "source_observation_id": "b77b2830-7cdb-4b94-a687-d29902856580",
+        "source_observation_seq": 9528,
+        "source_observation_t_wall": 1779191995.1893234,
+        "telemetry_window_first_seq": 9509,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 9528,
+        "telemetry_window_latest_t_wall": 1779191995.1893234,
+        "validator_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "overlay_step_id": "S22",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S22",
+        "targets": [
+          "launch_bar_switch"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "launch_bar_switch"
+      ],
+      "message_category": "completion_conflict_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S20.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "refuel_probe_switch"
+        ],
+        "status": "ok",
+        "step_id": "S22"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S20"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "final_decision": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "model_request": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70",
+        "validator": "91dd82f9e5b64138dd97519221782c30cb1a1e563610c7ba07fbca4bac367b70"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "refuel_probe_latched_completion:S21"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S20"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779191995263_000204"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 101,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "refuel_probe_latched_completion:S21"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S20"
+    }
+  },
+  "help_cycle_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S22"
+      },
+      "explanations": [
+        "S20 的最新证据已经满足。现在进入 S22。"
+      ],
+      "next": {
+        "step_id": "S22"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S20.completion",
+            "target": "launch_bar_switch",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "launch_bar_switch"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S22"
+      },
+      "explanations": [
+        "当前处于 S22 阶段，但前置步骤 S20 未完成。[REDACTED_ENDPOINT] 显示受油管必须完全伸出。请操作 refuel_probe_switch，右键将其拨到 EXTEND 位置以伸出受油管。"
+      ],
+      "next": {
+        "step_id": "S22"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S20.completion",
+            "target": "refuel_probe_switch",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "refuel_probe_switch"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "20c79783-092e-4128-ad47-5fa7d3774ed7",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 12408,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_115004.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/6232bd96-95f8-4905-9ae9-8f27e4515c3d.fixture.json
+++ b/artifacts/live_fixtures/6232bd96-95f8-4905-9ae9-8f27e4515c3d.fixture.json
@@ -1,0 +1,3276 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 10103,
+        "frame_count": 20,
+        "latest_seq": 10122
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+      "source_observation_seq": 10122,
+      "source_observation_t_wall": 1779192036.8884494,
+      "telemetry_window_first_seq": 10103,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 10122,
+      "telemetry_window_latest_t_wall": 1779192036.8884494,
+      "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+    },
+    "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:56245",
+          "raw_delta_count": 1,
+          "seq": 10122
+        },
+        "observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41391
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 10122,
+          "t_wall": 1779192036.8884494,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 316,
+            "temp_r": 296,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T12:00:36.888449+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 10103,
+      "frame_count": 20,
+      "latest_seq": 10122
+    },
+    "vision": {
+      "frame_ids": [
+        "1779192036935_000208"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779192036935_000208",
+        "frame_ids": [
+          "1779192036935_000208"
+        ],
+        "frame_stale": false,
+        "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+        "observation_seq": 10122,
+        "observation_t_wall_ms": 1779192036888,
+        "observation_t_wall_s": 1779192036.8884494,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779192036935,
+            "channel": "composite_panel",
+            "frame_id": "1779192036935_000208",
+            "frame_seq": 208,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192036935_000208_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192036935_000208.png",
+            "sync_delta_ms": 83,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 83,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779192036935,
+          "channel": "composite_panel",
+          "frame_id": "1779192036935_000208",
+          "frame_seq": 208,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192036935_000208_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192036935_000208.png",
+          "sync_delta_ms": 83,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779192036852,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779192036935_000208"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "kind": "tutor_request",
+        "lineno": 10687,
+        "metadata": {
+          "frame_id": "1779192036935_000208",
+          "fused_missing_conditions": [
+            "vars.launch_bar_switch_value in [0,0]"
+          ],
+          "fused_step_id": "S23",
+          "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 83,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "four_down_completion_latches": {
+              "s20_latched_complete": true,
+              "s21_latched_complete": true,
+              "s22_latched_complete": true,
+              "s23_latched_complete": true,
+              "s24_latched_complete": false,
+              "s25_latched_complete": false
+            },
+            "refuel_probe_completion_latches": {
+              "s20_latched_complete": true,
+              "s21_latched_complete": true
+            },
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "launch_bar_switch"
+              },
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S23",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S23",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "launch_bar_switch"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 10103,
+                "frame_count": 20,
+                "latest_seq": 10122
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+              "source_observation_seq": 10122,
+              "source_observation_t_wall": 1779192036.8884494,
+              "telemetry_window_first_seq": 10103,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 10122,
+              "telemetry_window_latest_t_wall": 1779192036.8884494,
+              "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_nasatlx_vr_0",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "score": 21.88863349107637,
+                "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "snippet_id": "fa18c_nasatlx_vr_0"
+              },
+              {
+                "chunk_id": "fa18c_scoring_sheet_template_2",
+                "doc_id": "fa18c_scoring_sheet_template",
+                "page_or_heading": "2. Step-Level Coding",
+                "score": 20.598915920041165,
+                "section": "2. Step-Level Coding",
+                "snippet_id": "fa18c_scoring_sheet_template_2"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_57",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 58,
+                "score": 19.184623101767777,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_57"
+              },
+              {
+                "chunk_id": "fa18c_nasatlx_vr_1",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "1. Mental Demand",
+                "score": 17.669751353263905,
+                "section": "1. Mental Demand",
+                "snippet_id": "fa18c_nasatlx_vr_1"
+              },
+              {
+                "chunk_id": "fa18c_nasatlx_vr_5",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "5. Effort",
+                "score": 17.54274657438537,
+                "section": "5. Effort",
+                "snippet_id": "fa18c_nasatlx_vr_5"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.launch_bar_switch_value in [0,0]"
+                ],
+                "overlay_step_id": "S23",
+                "role": "candidate_not_authoritative",
+                "step_id": "S23"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 10122,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 10103,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10122,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 10122,
+                "latest_t_wall": 1779192036.8884494,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.54
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779192036935_000208",
+              "frame_ids": [
+                "1779192036935_000208"
+              ],
+              "frame_stale": false,
+              "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+              "observation_seq": 10122,
+              "observation_t_wall_ms": 1779192036888,
+              "observation_t_wall_s": 1779192036.8884494,
+              "status": "partial",
+              "sync_delta_ms": 83,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779192036852,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779192036935_000208"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 10103,
+                "frame_count": 20,
+                "latest_seq": 10122
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+              "source_observation_seq": 10122,
+              "source_observation_t_wall": 1779192036.8884494,
+              "telemetry_window_first_seq": 10103,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 10122,
+              "telemetry_window_latest_t_wall": 1779192036.8884494,
+              "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "frame_id": "1779192036935_000208",
+            "fused_missing_conditions": [
+              "vars.launch_bar_switch_value in [0,0]"
+            ],
+            "fused_step_id": "S23",
+            "grounding_cache_hit": true,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_nasatlx_vr_0",
+              "fa18c_scoring_sheet_template_2",
+              "DCS FA-18C Early Access Guide EN_57",
+              "fa18c_nasatlx_vr_1",
+              "fa18c_nasatlx_vr_5"
+            ],
+            "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+            "prompt_tokens_est": 5428,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "source_chunk_refs": [
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+              "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_57",
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_1",
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_5"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 83,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779192036935_000208"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779192036935_000208"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+          "request_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "timestamp": "2026-05-19T12:00:37.395156+00:00",
+          "version": "v1"
+        },
+        "related_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "vision_refs": [
+          "1779192036935_000208"
+        ]
+      },
+      {
+        "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "kind": "overlay_requested",
+        "lineno": 10688,
+        "metadata": {
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192036935_000208",
+          "fused_missing_conditions": [
+            "vars.launch_bar_switch_value in [0,0]"
+          ],
+          "fused_step_id": "S23",
+          "generation_mode": "model",
+          "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 83,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "82ebd2a3-6179-4310-9074-90503312982b",
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192036935_000208",
+          "fused_missing_conditions": [
+            "vars.launch_bar_switch_value in [0,0]"
+          ],
+          "fused_step_id": "S23",
+          "generation_mode": "model",
+          "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 83,
+          "target": "pnt_233",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "kind": "overlay_requested",
+        "lineno": 10689,
+        "metadata": {
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192036935_000208",
+          "fused_missing_conditions": [
+            "vars.launch_bar_switch_value in [0,0]"
+          ],
+          "fused_step_id": "S23",
+          "generation_mode": "model",
+          "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 83,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "94b6bff4-65fa-41f9-be39-3e9d40786c3d",
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192036935_000208",
+          "fused_missing_conditions": [
+            "vars.launch_bar_switch_value in [0,0]"
+          ],
+          "fused_step_id": "S23",
+          "generation_mode": "model",
+          "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 83,
+          "target": "pnt_293",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "kind": "tutor_response",
+        "lineno": 10690,
+        "metadata": {
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192036935_000208",
+          "fused_missing_conditions": [
+            "vars.launch_bar_switch_value in [0,0]"
+          ],
+          "fused_step_id": "S23",
+          "generation_mode": "model",
+          "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 83,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_293",
+              "evidence_refs": [
+                "GATES.S25.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "arresting_hook_handle"
+              ],
+              "frame_id": "1779192036935_000208",
+              "fused_missing_conditions": [
+                "vars.launch_bar_switch_value in [0,0]"
+              ],
+              "fused_step_id": "S23",
+              "generation_mode": "model",
+              "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 83,
+              "target": "arresting_hook_handle",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779192036935_000208"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "S23 的最新证据已经满足。现在进入 S25。"
+          ],
+          "in_reply_to": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "message": "S23 的最新证据已经满足。现在进入 S25。",
+          "metadata": {
+            "action_hint_overlay_override_kind": "action_hint",
+            "action_hint_overlay_override_original_actions": [
+              {
+                "element_id": "pnt_293",
+                "evidence_refs": [
+                  "GATES.S25.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "arresting_hook_handle",
+                "type": "overlay"
+              }
+            ],
+            "action_hint_overlay_override_original_targets": [
+              "arresting_hook_handle"
+            ],
+            "allowed_evidence_ref_count": 116,
+            "completion_conflict_original_actions": [
+              {
+                "element_id": "pnt_233",
+                "evidence_refs": [
+                  "GATES.S22.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "launch_bar_switch",
+                "type": "overlay"
+              }
+            ],
+            "completion_conflict_original_explanations": [
+              "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+            ],
+            "completion_conflict_original_message": "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。",
+            "completion_conflict_original_next": {
+              "step_id": "S22"
+            },
+            "completion_conflict_overlay_cleared": true,
+            "completion_conflict_rewritten": true,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "e4689ace-aef7-4501-97c9-2e2f7b686957",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "S23 的最新证据已经满足。现在进入 S25。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S25"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+              "source_observation_seq": 10122,
+              "source_observation_t_wall": 1779192036.8884494,
+              "telemetry_window_first_seq": 10103,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 10122,
+              "telemetry_window_latest_t_wall": 1779192036.8884494,
+              "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "overlay_step_id": "S25",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S25",
+              "targets": [
+                "arresting_hook_handle"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 116,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "next": {
+                "step_id": "S25"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S25",
+            "final_evidence_consistency_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+              "completion_gate_already_satisfied:S23"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "arresting_hook_handle"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_293",
+                  "evidence_refs": [
+                    "GATES.S25.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "arresting_hook_handle"
+                  ],
+                  "frame_id": "1779192036935_000208",
+                  "fused_missing_conditions": [
+                    "vars.launch_bar_switch_value in [0,0]"
+                  ],
+                  "fused_step_id": "S23",
+                  "generation_mode": "model",
+                  "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "completion_conflict_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 83,
+                  "target": "arresting_hook_handle",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779192036935_000208"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "explanations": [
+                "S23 的最新证据已经满足。现在进入 S25。"
+              ],
+              "message": "S23 的最新证据已经满足。现在进入 S25。",
+              "next": {
+                "step_id": "S25"
+              }
+            },
+            "frame_id": "1779192036935_000208",
+            "fused_missing_conditions": [
+              "vars.launch_bar_switch_value in [0,0]"
+            ],
+            "fused_step_id": "S23",
+            "generation_mode": "model",
+            "generation_prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+            "generation_prompt_tokens_est": 5428,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S25",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S25",
+              "targets": [
+                "arresting_hook_handle"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S23",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "pitot_heater_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S26",
+                  "supporting_evidence_refs": [
+                    "GATES.S26.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "parking_brake_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S28",
+                  "supporting_evidence_refs": [
+                    "GATES.S28.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button",
+                    "ifei_down_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": [
+                    "GATES.S29.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.66,
+                "proposed_next_action_target_ids": [
+                  "arresting_hook_handle"
+                ],
+                "role": "candidate",
+                "source": "gate_blocker",
+                "step_id": "S25",
+                "supporting_evidence_refs": [
+                  "GATES.S25.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 10103,
+                  "frame_count": 20,
+                  "latest_seq": 10122
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+                "source_observation_seq": 10122,
+                "source_observation_t_wall": 1779192036.8884494,
+                "telemetry_window_first_seq": 10103,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 10122,
+                "telemetry_window_latest_t_wall": 1779192036.8884494,
+                "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "overlay_step_id": "S25",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S25",
+                "targets": [
+                  "arresting_hook_handle"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "arresting_hook_handle"
+              ],
+              "message_category": "completion_conflict_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S22.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "launch_bar_switch"
+                ],
+                "status": "ok",
+                "step_id": "S22"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S23"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+                "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+                  "completion_gate_already_satisfied:S23"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S23"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779192036935_000208"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 83,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+              "completion_gate_already_satisfied:S23"
+            ],
+            "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "explanations": [
+                "S23 的最新证据已经满足。现在进入 S25。"
+              ],
+              "next": {
+                "step_id": "S25"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S25.completion",
+                    "target": "arresting_hook_handle",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "arresting_hook_handle"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S22"
+              },
+              "explanations": [
+                "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+              ],
+              "next": {
+                "step_id": "S22"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S22.completion",
+                    "target": "launch_bar_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "launch_bar_switch"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4228,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "completion_conflict_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S22"
+            },
+            "model_raw_explanations": [
+              "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S22"
+              },
+              "explanations": [
+                "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+              ],
+              "next": {
+                "step_id": "S22"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S22.completion",
+                    "target": "launch_bar_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "launch_bar_switch"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S22"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779192036935_000208"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779192036935_000208",
+            "next": {
+              "step_id": "S25"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5611,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.launch_bar_switch_value",
+                "GATES.S20.completion",
+                "GATES.S22.completion",
+                "GATES.S23.completion",
+                "GATES.S23.precondition",
+                "GATES.S25.completion",
+                "GATES.S26.completion",
+                "GATES.S28.completion",
+                "GATES.S29.completion",
+                "RAG_SNIPPETS.fa18c_nasatlx_vr_0",
+                "RAG_SNIPPETS.fa18c_scoring_sheet_template_2",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_57",
+                "RAG_SNIPPETS.fa18c_nasatlx_vr_1",
+                "RAG_SNIPPETS.fa18c_nasatlx_vr_5"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "launch_bar_switch",
+              "prompt_chars": 21712,
+              "prompt_tokens_est": 5428,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_nasatlx_vr_0",
+                "fa18c_scoring_sheet_template_2",
+                "DCS FA-18C Early Access Guide EN_57",
+                "fa18c_nasatlx_vr_1",
+                "fa18c_nasatlx_vr_5"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+            "prompt_tokens_est": 5428,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.launch_bar_switch_value in [0,0]"
+            ],
+            "rejected_model_step_id": "S23",
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+            "request_prompt_tokens_est": 5428,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 116,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S22"
+              },
+              "next": {
+                "step_id": "S22"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+              "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+            },
+            "state_key": "59137f2929c4f9057aab73498578650de03ce590803b7980dcee522032ca1452",
+            "sync_delta_ms": 83,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779192036935_000208",
+              "frame_ids": [
+                "1779192036935_000208"
+              ],
+              "frame_stale": false,
+              "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+              "observation_seq": 10122,
+              "observation_t_wall_ms": 1779192036888,
+              "observation_t_wall_s": 1779192036.8884494,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779192036935,
+                  "channel": "composite_panel",
+                  "frame_id": "1779192036935_000208",
+                  "frame_seq": 208,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192036935_000208_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192036935_000208.png",
+                  "sync_delta_ms": 83,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 83,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779192036935,
+                "channel": "composite_panel",
+                "frame_id": "1779192036935_000208",
+                "frame_seq": 208,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192036935_000208_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192036935_000208.png",
+                "sync_delta_ms": 83,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779192036852,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S23"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779192036935_000208"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779192036935_000208"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "1e4fe419-18a5-4f86-95a4-d5403044e19e",
+          "status": "ok",
+          "timestamp": "2026-05-19T12:00:41.625564+00:00",
+          "version": "v1"
+        },
+        "related_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "vision_refs": [
+          "1779192036935_000208"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "four_down_completion_latches": {
+          "s20_latched_complete": true,
+          "s21_latched_complete": true,
+          "s22_latched_complete": true,
+          "s23_latched_complete": true,
+          "s24_latched_complete": false,
+          "s25_latched_complete": false
+        },
+        "refuel_probe_completion_latches": {
+          "s20_latched_complete": true,
+          "s21_latched_complete": true
+        },
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "launch_bar_switch"
+          },
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S23",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S23",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "launch_bar_switch"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 10103,
+            "frame_count": 20,
+            "latest_seq": 10122
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+          "source_observation_seq": 10122,
+          "source_observation_t_wall": 1779192036.8884494,
+          "telemetry_window_first_seq": 10103,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 10122,
+          "telemetry_window_latest_t_wall": 1779192036.8884494,
+          "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_nasatlx_vr_0",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "score": 21.88863349107637,
+            "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "snippet_id": "fa18c_nasatlx_vr_0"
+          },
+          {
+            "chunk_id": "fa18c_scoring_sheet_template_2",
+            "doc_id": "fa18c_scoring_sheet_template",
+            "page_or_heading": "2. Step-Level Coding",
+            "score": 20.598915920041165,
+            "section": "2. Step-Level Coding",
+            "snippet_id": "fa18c_scoring_sheet_template_2"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_57",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 58,
+            "score": 19.184623101767777,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_57"
+          },
+          {
+            "chunk_id": "fa18c_nasatlx_vr_1",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "1. Mental Demand",
+            "score": 17.669751353263905,
+            "section": "1. Mental Demand",
+            "snippet_id": "fa18c_nasatlx_vr_1"
+          },
+          {
+            "chunk_id": "fa18c_nasatlx_vr_5",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "5. Effort",
+            "score": 17.54274657438537,
+            "section": "5. Effort",
+            "snippet_id": "fa18c_nasatlx_vr_5"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.launch_bar_switch_value in [0,0]"
+            ],
+            "overlay_step_id": "S23",
+            "role": "candidate_not_authoritative",
+            "step_id": "S23"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 10122,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 10103,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10122,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 10122,
+            "latest_t_wall": 1779192036.8884494,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.54
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779192036935_000208",
+          "frame_ids": [
+            "1779192036935_000208"
+          ],
+          "frame_stale": false,
+          "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+          "observation_seq": 10122,
+          "observation_t_wall_ms": 1779192036888,
+          "observation_t_wall_s": 1779192036.8884494,
+          "status": "partial",
+          "sync_delta_ms": 83,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779192036852,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779192036935_000208"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 10103,
+            "frame_count": 20,
+            "latest_seq": 10122
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+          "source_observation_seq": 10122,
+          "source_observation_t_wall": 1779192036.8884494,
+          "telemetry_window_first_seq": 10103,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 10122,
+          "telemetry_window_latest_t_wall": 1779192036.8884494,
+          "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "frame_id": "1779192036935_000208",
+        "fused_missing_conditions": [
+          "vars.launch_bar_switch_value in [0,0]"
+        ],
+        "fused_step_id": "S23",
+        "grounding_cache_hit": true,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_nasatlx_vr_0",
+          "fa18c_scoring_sheet_template_2",
+          "DCS FA-18C Early Access Guide EN_57",
+          "fa18c_nasatlx_vr_1",
+          "fa18c_nasatlx_vr_5"
+        ],
+        "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+        "prompt_tokens_est": 5428,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "source_chunk_refs": [
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+          "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_57",
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_1",
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_5"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 83,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779192036935_000208"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779192036935_000208"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+      "request_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+      "timestamp": "2026-05-19T12:00:37.395156+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_293",
+          "evidence_refs": [
+            "GATES.S25.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192036935_000208",
+          "fused_missing_conditions": [
+            "vars.launch_bar_switch_value in [0,0]"
+          ],
+          "fused_step_id": "S23",
+          "generation_mode": "model",
+          "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 83,
+          "target": "arresting_hook_handle",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "S23 的最新证据已经满足。现在进入 S25。"
+      ],
+      "in_reply_to": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+      "message": "S23 的最新证据已经满足。现在进入 S25。",
+      "metadata": {
+        "action_hint_overlay_override_kind": "action_hint",
+        "action_hint_overlay_override_original_actions": [
+          {
+            "element_id": "pnt_293",
+            "evidence_refs": [
+              "GATES.S25.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "arresting_hook_handle",
+            "type": "overlay"
+          }
+        ],
+        "action_hint_overlay_override_original_targets": [
+          "arresting_hook_handle"
+        ],
+        "allowed_evidence_ref_count": 116,
+        "completion_conflict_original_actions": [
+          {
+            "element_id": "pnt_233",
+            "evidence_refs": [
+              "GATES.S22.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "launch_bar_switch",
+            "type": "overlay"
+          }
+        ],
+        "completion_conflict_original_explanations": [
+          "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+        ],
+        "completion_conflict_original_message": "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。",
+        "completion_conflict_original_next": {
+          "step_id": "S22"
+        },
+        "completion_conflict_overlay_cleared": true,
+        "completion_conflict_rewritten": true,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "e4689ace-aef7-4501-97c9-2e2f7b686957",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "S23 的最新证据已经满足。现在进入 S25。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S25"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+          "source_observation_seq": 10122,
+          "source_observation_t_wall": 1779192036.8884494,
+          "telemetry_window_first_seq": 10103,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 10122,
+          "telemetry_window_latest_t_wall": 1779192036.8884494,
+          "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "overlay_step_id": "S25",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S25",
+          "targets": [
+            "arresting_hook_handle"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 116,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "next": {
+            "step_id": "S25"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S25",
+        "final_evidence_consistency_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+          "completion_gate_already_satisfied:S23"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "arresting_hook_handle"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_293",
+              "evidence_refs": [
+                "GATES.S25.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "arresting_hook_handle"
+              ],
+              "frame_id": "1779192036935_000208",
+              "fused_missing_conditions": [
+                "vars.launch_bar_switch_value in [0,0]"
+              ],
+              "fused_step_id": "S23",
+              "generation_mode": "model",
+              "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 83,
+              "target": "arresting_hook_handle",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779192036935_000208"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "explanations": [
+            "S23 的最新证据已经满足。现在进入 S25。"
+          ],
+          "message": "S23 的最新证据已经满足。现在进入 S25。",
+          "next": {
+            "step_id": "S25"
+          }
+        },
+        "frame_id": "1779192036935_000208",
+        "fused_missing_conditions": [
+          "vars.launch_bar_switch_value in [0,0]"
+        ],
+        "fused_step_id": "S23",
+        "generation_mode": "model",
+        "generation_prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+        "generation_prompt_tokens_est": 5428,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S25",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S25",
+          "targets": [
+            "arresting_hook_handle"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S23",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "pitot_heater_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S26",
+              "supporting_evidence_refs": [
+                "GATES.S26.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "parking_brake_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S28",
+              "supporting_evidence_refs": [
+                "GATES.S28.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S29",
+              "supporting_evidence_refs": [
+                "GATES.S29.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.66,
+            "proposed_next_action_target_ids": [
+              "arresting_hook_handle"
+            ],
+            "role": "candidate",
+            "source": "gate_blocker",
+            "step_id": "S25",
+            "supporting_evidence_refs": [
+              "GATES.S25.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 10103,
+              "frame_count": 20,
+              "latest_seq": 10122
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+            "source_observation_seq": 10122,
+            "source_observation_t_wall": 1779192036.8884494,
+            "telemetry_window_first_seq": 10103,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 10122,
+            "telemetry_window_latest_t_wall": 1779192036.8884494,
+            "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "overlay_step_id": "S25",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S25",
+            "targets": [
+              "arresting_hook_handle"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "message_category": "completion_conflict_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S22.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "launch_bar_switch"
+            ],
+            "status": "ok",
+            "step_id": "S22"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S23"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+            "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+              "completion_gate_already_satisfied:S23"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S23"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779192036935_000208"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 83,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+          "completion_gate_already_satisfied:S23"
+        ],
+        "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "explanations": [
+            "S23 的最新证据已经满足。现在进入 S25。"
+          ],
+          "next": {
+            "step_id": "S25"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S25.completion",
+                "target": "arresting_hook_handle",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "arresting_hook_handle"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S22"
+          },
+          "explanations": [
+            "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+          ],
+          "next": {
+            "step_id": "S22"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S22.completion",
+                "target": "launch_bar_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "launch_bar_switch"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4228,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "completion_conflict_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S22"
+        },
+        "model_raw_explanations": [
+          "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S22"
+          },
+          "explanations": [
+            "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+          ],
+          "next": {
+            "step_id": "S22"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S22.completion",
+                "target": "launch_bar_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "launch_bar_switch"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S22"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779192036935_000208"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779192036935_000208",
+        "next": {
+          "step_id": "S25"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5611,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.launch_bar_switch_value",
+            "GATES.S20.completion",
+            "GATES.S22.completion",
+            "GATES.S23.completion",
+            "GATES.S23.precondition",
+            "GATES.S25.completion",
+            "GATES.S26.completion",
+            "GATES.S28.completion",
+            "GATES.S29.completion",
+            "RAG_SNIPPETS.fa18c_nasatlx_vr_0",
+            "RAG_SNIPPETS.fa18c_scoring_sheet_template_2",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_57",
+            "RAG_SNIPPETS.fa18c_nasatlx_vr_1",
+            "RAG_SNIPPETS.fa18c_nasatlx_vr_5"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "launch_bar_switch",
+          "prompt_chars": 21712,
+          "prompt_tokens_est": 5428,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_nasatlx_vr_0",
+            "fa18c_scoring_sheet_template_2",
+            "DCS FA-18C Early Access Guide EN_57",
+            "fa18c_nasatlx_vr_1",
+            "fa18c_nasatlx_vr_5"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+        "prompt_tokens_est": 5428,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.launch_bar_switch_value in [0,0]"
+        ],
+        "rejected_model_step_id": "S23",
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "b78c09bd155a4070b4afaf51dad2ae24c82b5e8c11d293bf75e6df39d315285b",
+        "request_prompt_tokens_est": 5428,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 116,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S22"
+          },
+          "next": {
+            "step_id": "S22"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+          "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+        },
+        "state_key": "59137f2929c4f9057aab73498578650de03ce590803b7980dcee522032ca1452",
+        "sync_delta_ms": 83,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779192036935_000208",
+          "frame_ids": [
+            "1779192036935_000208"
+          ],
+          "frame_stale": false,
+          "observation_ref": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+          "observation_seq": 10122,
+          "observation_t_wall_ms": 1779192036888,
+          "observation_t_wall_s": 1779192036.8884494,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779192036935,
+              "channel": "composite_panel",
+              "frame_id": "1779192036935_000208",
+              "frame_seq": 208,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192036935_000208_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192036935_000208.png",
+              "sync_delta_ms": 83,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 83,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779192036935,
+            "channel": "composite_panel",
+            "frame_id": "1779192036935_000208",
+            "frame_seq": 208,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192036935_000208_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192036935_000208.png",
+            "sync_delta_ms": 83,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779192036852,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S23"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779192036935_000208"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779192036935_000208"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "1e4fe419-18a5-4f86-95a4-d5403044e19e",
+      "status": "ok",
+      "timestamp": "2026-05-19T12:00:41.625564+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S24",
+    "expected_overlay_target_ids": [
+      "arresting_hook_handle"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S23",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "pitot_heater_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S26",
+        "supporting_evidence_refs": [
+          "GATES.S26.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "parking_brake_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S28",
+        "supporting_evidence_refs": [
+          "GATES.S28.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "GATES.S29.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+      "overlay_step_id": "S25",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S25",
+      "targets": [
+        "arresting_hook_handle"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S22.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "launch_bar_switch"
+      ],
+      "status": "ok",
+      "step_id": "S22"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S23",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "pitot_heater_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S26",
+          "supporting_evidence_refs": [
+            "GATES.S26.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "parking_brake_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S28",
+          "supporting_evidence_refs": [
+            "GATES.S28.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S29",
+          "supporting_evidence_refs": [
+            "GATES.S29.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 10103,
+          "frame_count": 20,
+          "latest_seq": 10122
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "final_decision_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "model_request_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "source_observation_id": "1c2414e2-eeda-4535-9741-3e0ecb9dfc43",
+        "source_observation_seq": 10122,
+        "source_observation_t_wall": 1779192036.8884494,
+        "telemetry_window_first_seq": 10103,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 10122,
+        "telemetry_window_latest_t_wall": 1779192036.8884494,
+        "validator_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "overlay_step_id": "S25",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S25",
+        "targets": [
+          "arresting_hook_handle"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "arresting_hook_handle"
+      ],
+      "message_category": "completion_conflict_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S22.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "launch_bar_switch"
+        ],
+        "status": "ok",
+        "step_id": "S22"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S23"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "final_decision": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "model_request": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d",
+        "validator": "781a326baeb019aca1830462f786edae9847f5da7da9dde2866e70a18128687d"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+          "completion_gate_already_satisfied:S23"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S23"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779192036935_000208"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 83,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "missing_condition_satisfied_by_latest_telemetry:vars.launch_bar_switch_value in [0,0]",
+        "completion_gate_already_satisfied:S23"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S23"
+    }
+  },
+  "help_cycle_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S25"
+      },
+      "explanations": [
+        "S23 的最新证据已经满足。现在进入 S25。"
+      ],
+      "next": {
+        "step_id": "S25"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S25.completion",
+            "target": "arresting_hook_handle",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "arresting_hook_handle"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S22"
+      },
+      "explanations": [
+        "当前步骤 S22 未完成，需将弹射杆开关（Launch Bar Switch）置于伸出位。请右键点击 launch_bar_switch 将其拨到 EXT 位置。"
+      ],
+      "next": {
+        "step_id": "S22"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S22.completion",
+            "target": "launch_bar_switch",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "launch_bar_switch"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "6232bd96-95f8-4905-9ae9-8f27e4515c3d",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 12408,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_115004.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/da08da4a-0909-4acb-a2e6-7027324fa989.fixture.json
+++ b/artifacts/live_fixtures/da08da4a-0909-4acb-a2e6-7027324fa989.fixture.json
@@ -1,0 +1,3094 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 10625,
+        "frame_count": 20,
+        "latest_seq": 10644
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+      "source_observation_seq": 10644,
+      "source_observation_t_wall": 1779192063.7441182,
+      "telemetry_window_first_seq": 10625,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 10644,
+      "telemetry_window_latest_t_wall": 1779192063.7441182,
+      "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+    },
+    "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 3,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:56245",
+          "raw_delta_count": 3,
+          "seq": 10644
+        },
+        "observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE",
+              "IFEI_FUEL_DOWN",
+              "IFEI_FUEL_UP"
+            ],
+            "delta_count": 3,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 3,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41357
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "IFEI_FUEL_DOWN",
+                "ui_targets": [],
+                "value": "10580I"
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "IFEI_FUEL_UP",
+                "ui_targets": [],
+                "value": "10580T"
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 10644,
+          "t_wall": 1779192063.7441182,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 316,
+            "temp_r": 296,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T12:01:03.744118+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 10625,
+      "frame_count": 20,
+      "latest_seq": 10644
+    },
+    "vision": {
+      "frame_ids": [
+        "1779192063799_000210"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779192063799_000210",
+        "frame_ids": [
+          "1779192063799_000210"
+        ],
+        "frame_stale": false,
+        "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+        "observation_seq": 10644,
+        "observation_t_wall_ms": 1779192063744,
+        "observation_t_wall_s": 1779192063.7441182,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779192063799,
+            "channel": "composite_panel",
+            "frame_id": "1779192063799_000210",
+            "frame_seq": 210,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192063799_000210_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192063799_000210.png",
+            "sync_delta_ms": 86,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 86,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779192063799,
+          "channel": "composite_panel",
+          "frame_id": "1779192063799_000210",
+          "frame_seq": 210,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192063799_000210_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192063799_000210.png",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779192063713,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779192063799_000210"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+        "kind": "tutor_request",
+        "lineno": 11218,
+        "metadata": {
+          "frame_id": "1779192063799_000210",
+          "fused_missing_conditions": [
+            "vars.hook_handle_value in [0,0]"
+          ],
+          "fused_step_id": "S25",
+          "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192063799_000210"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "four_down_completion_latches": {
+              "s20_latched_complete": true,
+              "s21_latched_complete": true,
+              "s22_latched_complete": true,
+              "s23_latched_complete": true,
+              "s24_latched_complete": true,
+              "s25_latched_complete": false
+            },
+            "refuel_probe_completion_latches": {
+              "s20_latched_complete": true,
+              "s21_latched_complete": true
+            },
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "arresting_hook_handle"
+              },
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S25",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S25",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "arresting_hook_handle"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 10625,
+                "frame_count": 20,
+                "latest_seq": 10644
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+              "source_observation_seq": 10644,
+              "source_observation_t_wall": 1779192063.7441182,
+              "telemetry_window_first_seq": 10625,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 10644,
+              "telemetry_window_latest_t_wall": 1779192063.7441182,
+              "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_scoring_sheet_template_2",
+                "doc_id": "fa18c_scoring_sheet_template",
+                "page_or_heading": "2. Step-Level Coding",
+                "score": 25.039944761327018,
+                "section": "2. Step-Level Coding",
+                "snippet_id": "fa18c_scoring_sheet_template_2"
+              },
+              {
+                "chunk_id": "fa18c_nasatlx_vr_0",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "score": 21.88863349107637,
+                "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+                "snippet_id": "fa18c_nasatlx_vr_0"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_63",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 64,
+                "score": 20.974642355449337,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_63"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 18.834010694115808,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "fa18c_nasatlx_vr_1",
+                "doc_id": "fa18c_nasatlx_vr",
+                "page_or_heading": "1. Mental Demand",
+                "score": 17.669751353263905,
+                "section": "1. Mental Demand",
+                "snippet_id": "fa18c_nasatlx_vr_1"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.hook_handle_value in [0,0]"
+                ],
+                "overlay_step_id": "S25",
+                "role": "candidate_not_authoritative",
+                "step_id": "S25"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 10644,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 10625,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 10644,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 10644,
+                "latest_t_wall": 1779192063.7441182,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.323
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779192063799_000210",
+              "frame_ids": [
+                "1779192063799_000210"
+              ],
+              "frame_stale": false,
+              "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+              "observation_seq": 10644,
+              "observation_t_wall_ms": 1779192063744,
+              "observation_t_wall_s": 1779192063.7441182,
+              "status": "partial",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779192063713,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779192063799_000210"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 10625,
+                "frame_count": 20,
+                "latest_seq": 10644
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+              "source_observation_seq": 10644,
+              "source_observation_t_wall": 1779192063.7441182,
+              "telemetry_window_first_seq": 10625,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 10644,
+              "telemetry_window_latest_t_wall": 1779192063.7441182,
+              "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "frame_id": "1779192063799_000210",
+            "fused_missing_conditions": [
+              "vars.hook_handle_value in [0,0]"
+            ],
+            "fused_step_id": "S25",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_scoring_sheet_template_2",
+              "fa18c_nasatlx_vr_0",
+              "DCS FA-18C Early Access Guide EN_63",
+              "fa18c_coldstart_quiz_1",
+              "fa18c_nasatlx_vr_1"
+            ],
+            "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+            "prompt_tokens_est": 5547,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "source_chunk_refs": [
+              "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_63",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "fa18c_nasatlx_vr/fa18c_nasatlx_vr_1"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 86,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779192063799_000210"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779192063799_000210"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+          "request_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+          "timestamp": "2026-05-19T12:01:04.250942+00:00",
+          "version": "v1"
+        },
+        "related_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+        "vision_refs": [
+          "1779192063799_000210"
+        ]
+      },
+      {
+        "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+        "kind": "overlay_requested",
+        "lineno": 11219,
+        "metadata": {
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192063799_000210",
+          "fused_missing_conditions": [
+            "vars.hook_handle_value in [0,0]"
+          ],
+          "fused_step_id": "S25",
+          "generation_mode": "model",
+          "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192063799_000210"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "ee35a2a7-e35e-4063-a5d8-b056dd993e56",
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192063799_000210",
+          "fused_missing_conditions": [
+            "vars.hook_handle_value in [0,0]"
+          ],
+          "fused_step_id": "S25",
+          "generation_mode": "model",
+          "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 86,
+          "target": "pnt_293",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192063799_000210"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+        "kind": "tutor_response",
+        "lineno": 11220,
+        "metadata": {
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192063799_000210",
+          "fused_missing_conditions": [
+            "vars.hook_handle_value in [0,0]"
+          ],
+          "fused_step_id": "S25",
+          "generation_mode": "model",
+          "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192063799_000210"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_293",
+              "evidence_refs": [
+                "GATES.S25.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "arresting_hook_handle"
+              ],
+              "frame_id": "1779192063799_000210",
+              "fused_missing_conditions": [
+                "vars.hook_handle_value in [0,0]"
+              ],
+              "fused_step_id": "S25",
+              "generation_mode": "model",
+              "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 86,
+              "target": "arresting_hook_handle",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779192063799_000210"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+          ],
+          "in_reply_to": "da08da4a-0909-4acb-a2e6-7027324fa989",
+          "message": "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。",
+          "metadata": {
+            "allowed_evidence_ref_count": 118,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "a619baed-eed3-4f0c-b13c-788756b4806b",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S25"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+              "source_observation_seq": 10644,
+              "source_observation_t_wall": 1779192063.7441182,
+              "telemetry_window_first_seq": 10625,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 10644,
+              "telemetry_window_latest_t_wall": 1779192063.7441182,
+              "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "overlay_step_id": "S25",
+              "source": "validator_action_hint",
+              "step_id": "S25",
+              "targets": [
+                "arresting_hook_handle"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "validator_action_hint",
+            "final_overlay_targets": [
+              "arresting_hook_handle"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_293",
+                  "evidence_refs": [
+                    "GATES.S25.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "arresting_hook_handle"
+                  ],
+                  "frame_id": "1779192063799_000210",
+                  "fused_missing_conditions": [
+                    "vars.hook_handle_value in [0,0]"
+                  ],
+                  "fused_step_id": "S25",
+                  "generation_mode": "model",
+                  "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 86,
+                  "target": "arresting_hook_handle",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779192063799_000210"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "explanations": [
+                "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+              ],
+              "message": "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。",
+              "next": {
+                "step_id": "S25"
+              }
+            },
+            "frame_id": "1779192063799_000210",
+            "fused_missing_conditions": [
+              "vars.hook_handle_value in [0,0]"
+            ],
+            "fused_step_id": "S25",
+            "generation_mode": "model",
+            "generation_prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+            "generation_prompt_tokens_est": 5547,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S25",
+              "source": "validator_action_hint",
+              "step_id": "S25",
+              "targets": [
+                "arresting_hook_handle"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "pitot_heater_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S26",
+                  "supporting_evidence_refs": [
+                    "GATES.S26.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "parking_brake_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S28",
+                  "supporting_evidence_refs": [
+                    "GATES.S28.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button",
+                    "ifei_down_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": [
+                    "GATES.S29.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_altimeter_bug_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S31",
+                  "supporting_evidence_refs": [
+                    "GATES.S31.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "arresting_hook_handle"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S25",
+                "supporting_evidence_refs": [
+                  "GATES.S25.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 10625,
+                  "frame_count": 20,
+                  "latest_seq": 10644
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+                "source_observation_seq": 10644,
+                "source_observation_t_wall": 1779192063.7441182,
+                "telemetry_window_first_seq": 10625,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 10644,
+                "telemetry_window_latest_t_wall": 1779192063.7441182,
+                "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "overlay_step_id": "S25",
+                "source": "validator_action_hint",
+                "step_id": "S25",
+                "targets": [
+                  "arresting_hook_handle"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "arresting_hook_handle"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S25.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "arresting_hook_handle"
+                ],
+                "status": "ok",
+                "step_id": "S25"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "validator_action_hint"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+                "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [],
+                "rejected": true,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779192063799_000210"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 86,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [],
+            "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "explanations": [
+                "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+              ],
+              "next": {
+                "step_id": "S25"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S25.completion",
+                    "target": "arresting_hook_handle",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "arresting_hook_handle"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "explanations": [
+                "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+              ],
+              "next": {
+                "step_id": "S25"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S25.completion",
+                    "target": "arresting_hook_handle",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "arresting_hook_handle"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4083,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S25"
+            },
+            "model_raw_explanations": [
+              "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "explanations": [
+                "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+              ],
+              "next": {
+                "step_id": "S25"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S25.completion",
+                    "target": "arresting_hook_handle",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "arresting_hook_handle"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S25"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779192063799_000210"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779192063799_000210",
+            "next": {
+              "step_id": "S25"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5576,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.hook_handle_value",
+                "GATES.S20.completion",
+                "GATES.S22.completion",
+                "GATES.S25.completion",
+                "GATES.S25.precondition",
+                "GATES.S26.completion",
+                "GATES.S28.completion",
+                "GATES.S29.completion",
+                "GATES.S31.completion",
+                "RAG_SNIPPETS.fa18c_scoring_sheet_template_2",
+                "RAG_SNIPPETS.fa18c_nasatlx_vr_0",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_63",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+                "RAG_SNIPPETS.fa18c_nasatlx_vr_1"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "arresting_hook_handle",
+              "prompt_chars": 22185,
+              "prompt_tokens_est": 5547,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_scoring_sheet_template_2",
+                "fa18c_nasatlx_vr_0",
+                "DCS FA-18C Early Access Guide EN_63",
+                "fa18c_coldstart_quiz_1",
+                "fa18c_nasatlx_vr_1"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+            "prompt_tokens_est": 5547,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+            "request_prompt_tokens_est": 5547,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 118,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S25"
+              },
+              "next": {
+                "step_id": "S25"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+              "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+            },
+            "state_key": "d7526d828db0d74c57eb1e07f38fa6d7a4bbb13cb73426b366a5edaa0b4eb16a",
+            "sync_delta_ms": 86,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779192063799_000210",
+              "frame_ids": [
+                "1779192063799_000210"
+              ],
+              "frame_stale": false,
+              "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+              "observation_seq": 10644,
+              "observation_t_wall_ms": 1779192063744,
+              "observation_t_wall_s": 1779192063.7441182,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779192063799,
+                  "channel": "composite_panel",
+                  "frame_id": "1779192063799_000210",
+                  "frame_seq": 210,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192063799_000210_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192063799_000210.png",
+                  "sync_delta_ms": 86,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779192063799,
+                "channel": "composite_panel",
+                "frame_id": "1779192063799_000210",
+                "frame_seq": 210,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192063799_000210_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192063799_000210.png",
+                "sync_delta_ms": 86,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779192063713,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S25"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779192063799_000210"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779192063799_000210"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "a792102c-9957-41f4-8311-04028e35bd63",
+          "status": "ok",
+          "timestamp": "2026-05-19T12:01:08.335891+00:00",
+          "version": "v1"
+        },
+        "related_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+        "vision_refs": [
+          "1779192063799_000210"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "four_down_completion_latches": {
+          "s20_latched_complete": true,
+          "s21_latched_complete": true,
+          "s22_latched_complete": true,
+          "s23_latched_complete": true,
+          "s24_latched_complete": true,
+          "s25_latched_complete": false
+        },
+        "refuel_probe_completion_latches": {
+          "s20_latched_complete": true,
+          "s21_latched_complete": true
+        },
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "arresting_hook_handle"
+          },
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S25",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S25",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "arresting_hook_handle"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 10625,
+            "frame_count": 20,
+            "latest_seq": 10644
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+          "source_observation_seq": 10644,
+          "source_observation_t_wall": 1779192063.7441182,
+          "telemetry_window_first_seq": 10625,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 10644,
+          "telemetry_window_latest_t_wall": 1779192063.7441182,
+          "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_scoring_sheet_template_2",
+            "doc_id": "fa18c_scoring_sheet_template",
+            "page_or_heading": "2. Step-Level Coding",
+            "score": 25.039944761327018,
+            "section": "2. Step-Level Coding",
+            "snippet_id": "fa18c_scoring_sheet_template_2"
+          },
+          {
+            "chunk_id": "fa18c_nasatlx_vr_0",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "score": 21.88863349107637,
+            "section": "Task: F/A-18C Cold Start in DCS World (VR)",
+            "snippet_id": "fa18c_nasatlx_vr_0"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_63",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 64,
+            "score": 20.974642355449337,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_63"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 18.834010694115808,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "fa18c_nasatlx_vr_1",
+            "doc_id": "fa18c_nasatlx_vr",
+            "page_or_heading": "1. Mental Demand",
+            "score": 17.669751353263905,
+            "section": "1. Mental Demand",
+            "snippet_id": "fa18c_nasatlx_vr_1"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.hook_handle_value in [0,0]"
+            ],
+            "overlay_step_id": "S25",
+            "role": "candidate_not_authoritative",
+            "step_id": "S25"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 10644,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 10625,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 10644,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 10644,
+            "latest_t_wall": 1779192063.7441182,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.323
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779192063799_000210",
+          "frame_ids": [
+            "1779192063799_000210"
+          ],
+          "frame_stale": false,
+          "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+          "observation_seq": 10644,
+          "observation_t_wall_ms": 1779192063744,
+          "observation_t_wall_s": 1779192063.7441182,
+          "status": "partial",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779192063713,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779192063799_000210"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 10625,
+            "frame_count": 20,
+            "latest_seq": 10644
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+          "source_observation_seq": 10644,
+          "source_observation_t_wall": 1779192063.7441182,
+          "telemetry_window_first_seq": 10625,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 10644,
+          "telemetry_window_latest_t_wall": 1779192063.7441182,
+          "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "frame_id": "1779192063799_000210",
+        "fused_missing_conditions": [
+          "vars.hook_handle_value in [0,0]"
+        ],
+        "fused_step_id": "S25",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_scoring_sheet_template_2",
+          "fa18c_nasatlx_vr_0",
+          "DCS FA-18C Early Access Guide EN_63",
+          "fa18c_coldstart_quiz_1",
+          "fa18c_nasatlx_vr_1"
+        ],
+        "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+        "prompt_tokens_est": 5547,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "source_chunk_refs": [
+          "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2",
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_0",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_63",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "fa18c_nasatlx_vr/fa18c_nasatlx_vr_1"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 86,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779192063799_000210"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779192063799_000210"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+      "request_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+      "timestamp": "2026-05-19T12:01:04.250942+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_293",
+          "evidence_refs": [
+            "GATES.S25.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "frame_id": "1779192063799_000210",
+          "fused_missing_conditions": [
+            "vars.hook_handle_value in [0,0]"
+          ],
+          "fused_step_id": "S25",
+          "generation_mode": "model",
+          "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 86,
+          "target": "arresting_hook_handle",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779192063799_000210"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+      ],
+      "in_reply_to": "da08da4a-0909-4acb-a2e6-7027324fa989",
+      "message": "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。",
+      "metadata": {
+        "allowed_evidence_ref_count": 118,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "a619baed-eed3-4f0c-b13c-788756b4806b",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S25"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+          "source_observation_seq": 10644,
+          "source_observation_t_wall": 1779192063.7441182,
+          "telemetry_window_first_seq": 10625,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 10644,
+          "telemetry_window_latest_t_wall": 1779192063.7441182,
+          "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "overlay_step_id": "S25",
+          "source": "validator_action_hint",
+          "step_id": "S25",
+          "targets": [
+            "arresting_hook_handle"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "validator_action_hint",
+        "final_overlay_targets": [
+          "arresting_hook_handle"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_293",
+              "evidence_refs": [
+                "GATES.S25.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "arresting_hook_handle"
+              ],
+              "frame_id": "1779192063799_000210",
+              "fused_missing_conditions": [
+                "vars.hook_handle_value in [0,0]"
+              ],
+              "fused_step_id": "S25",
+              "generation_mode": "model",
+              "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 86,
+              "target": "arresting_hook_handle",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779192063799_000210"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "explanations": [
+            "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+          ],
+          "message": "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。",
+          "next": {
+            "step_id": "S25"
+          }
+        },
+        "frame_id": "1779192063799_000210",
+        "fused_missing_conditions": [
+          "vars.hook_handle_value in [0,0]"
+        ],
+        "fused_step_id": "S25",
+        "generation_mode": "model",
+        "generation_prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+        "generation_prompt_tokens_est": 5547,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S25",
+          "source": "validator_action_hint",
+          "step_id": "S25",
+          "targets": [
+            "arresting_hook_handle"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "pitot_heater_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S26",
+              "supporting_evidence_refs": [
+                "GATES.S26.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "parking_brake_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S28",
+              "supporting_evidence_refs": [
+                "GATES.S28.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S29",
+              "supporting_evidence_refs": [
+                "GATES.S29.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_altimeter_bug_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S31",
+              "supporting_evidence_refs": [
+                "GATES.S31.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "arresting_hook_handle"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S25",
+            "supporting_evidence_refs": [
+              "GATES.S25.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 10625,
+              "frame_count": 20,
+              "latest_seq": 10644
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+            "source_observation_seq": 10644,
+            "source_observation_t_wall": 1779192063.7441182,
+            "telemetry_window_first_seq": 10625,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 10644,
+            "telemetry_window_latest_t_wall": 1779192063.7441182,
+            "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "overlay_step_id": "S25",
+            "source": "validator_action_hint",
+            "step_id": "S25",
+            "targets": [
+              "arresting_hook_handle"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "arresting_hook_handle"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S25.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "arresting_hook_handle"
+            ],
+            "status": "ok",
+            "step_id": "S25"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "validator_action_hint"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+            "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [],
+            "rejected": true,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779192063799_000210"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 86,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [],
+        "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "explanations": [
+            "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+          ],
+          "next": {
+            "step_id": "S25"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S25.completion",
+                "target": "arresting_hook_handle",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "arresting_hook_handle"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "explanations": [
+            "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+          ],
+          "next": {
+            "step_id": "S25"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S25.completion",
+                "target": "arresting_hook_handle",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "arresting_hook_handle"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4083,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S25"
+        },
+        "model_raw_explanations": [
+          "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "explanations": [
+            "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+          ],
+          "next": {
+            "step_id": "S25"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S25.completion",
+                "target": "arresting_hook_handle",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "arresting_hook_handle"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S25"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779192063799_000210"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779192063799_000210",
+        "next": {
+          "step_id": "S25"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5576,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.hook_handle_value",
+            "GATES.S20.completion",
+            "GATES.S22.completion",
+            "GATES.S25.completion",
+            "GATES.S25.precondition",
+            "GATES.S26.completion",
+            "GATES.S28.completion",
+            "GATES.S29.completion",
+            "GATES.S31.completion",
+            "RAG_SNIPPETS.fa18c_scoring_sheet_template_2",
+            "RAG_SNIPPETS.fa18c_nasatlx_vr_0",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_63",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+            "RAG_SNIPPETS.fa18c_nasatlx_vr_1"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "arresting_hook_handle",
+          "prompt_chars": 22185,
+          "prompt_tokens_est": 5547,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_scoring_sheet_template_2",
+            "fa18c_nasatlx_vr_0",
+            "DCS FA-18C Early Access Guide EN_63",
+            "fa18c_coldstart_quiz_1",
+            "fa18c_nasatlx_vr_1"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+        "prompt_tokens_est": 5547,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "e7965c5a4360ec6328a020732a1d1d6826fde7710f9e4501ad3accbf7b137ca6",
+        "request_prompt_tokens_est": 5547,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 118,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S25"
+          },
+          "next": {
+            "step_id": "S25"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+          "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+        },
+        "state_key": "d7526d828db0d74c57eb1e07f38fa6d7a4bbb13cb73426b366a5edaa0b4eb16a",
+        "sync_delta_ms": 86,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779192063799_000210",
+          "frame_ids": [
+            "1779192063799_000210"
+          ],
+          "frame_stale": false,
+          "observation_ref": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+          "observation_seq": 10644,
+          "observation_t_wall_ms": 1779192063744,
+          "observation_t_wall_s": 1779192063.7441182,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779192063799,
+              "channel": "composite_panel",
+              "frame_id": "1779192063799_000210",
+              "frame_seq": 210,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192063799_000210_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192063799_000210.png",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779192063799,
+            "channel": "composite_panel",
+            "frame_id": "1779192063799_000210",
+            "frame_seq": 210,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779192063799_000210_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779192063799_000210.png",
+            "sync_delta_ms": 86,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779192063713,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S25"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779192063799_000210"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779192063799_000210"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "a792102c-9957-41f4-8311-04028e35bd63",
+      "status": "ok",
+      "timestamp": "2026-05-19T12:01:08.335891+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S25",
+    "expected_overlay_target_ids": [
+      "arresting_hook_handle"
+    ],
+    "final_response_source": "validator_action_hint",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "pitot_heater_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S26",
+        "supporting_evidence_refs": [
+          "GATES.S26.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "parking_brake_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S28",
+        "supporting_evidence_refs": [
+          "GATES.S28.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "GATES.S29.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_altimeter_bug_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S31",
+        "supporting_evidence_refs": [
+          "GATES.S31.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+      "overlay_step_id": "S25",
+      "source": "validator_action_hint",
+      "step_id": "S25",
+      "targets": [
+        "arresting_hook_handle"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S25.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "arresting_hook_handle"
+      ],
+      "status": "ok",
+      "step_id": "S25"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "validator_action_hint"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "pitot_heater_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S26",
+          "supporting_evidence_refs": [
+            "GATES.S26.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "parking_brake_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S28",
+          "supporting_evidence_refs": [
+            "GATES.S28.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S29",
+          "supporting_evidence_refs": [
+            "GATES.S29.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_altimeter_bug_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S31",
+          "supporting_evidence_refs": [
+            "GATES.S31.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 10625,
+          "frame_count": 20,
+          "latest_seq": 10644
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "final_decision_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "model_request_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "source_observation_id": "246eb226-2051-48b9-b4c5-0a32205a1ab3",
+        "source_observation_seq": 10644,
+        "source_observation_t_wall": 1779192063.7441182,
+        "telemetry_window_first_seq": 10625,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 10644,
+        "telemetry_window_latest_t_wall": 1779192063.7441182,
+        "validator_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "overlay_step_id": "S25",
+        "source": "validator_action_hint",
+        "step_id": "S25",
+        "targets": [
+          "arresting_hook_handle"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "arresting_hook_handle"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S25.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "arresting_hook_handle"
+        ],
+        "status": "ok",
+        "step_id": "S25"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "validator_action_hint"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "final_decision": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "model_request": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12",
+        "validator": "550c64f6b65686d0c2e6dce02b41053215623e99e2f5e6216d1878fcf7796a12"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [],
+        "rejected": true,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779192063799_000210"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 86,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [],
+      "rejected": true,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S25"
+      },
+      "explanations": [
+        "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+      ],
+      "next": {
+        "step_id": "S25"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S25.completion",
+            "target": "arresting_hook_handle",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "arresting_hook_handle"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S25"
+      },
+      "explanations": [
+        "当前步骤 S25 未完成，需放下阻钩手柄以伸出阻钩。请左键点击 arresting_hook_handle。"
+      ],
+      "next": {
+        "step_id": "S25"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S25.completion",
+            "target": "arresting_hook_handle",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "arresting_hook_handle"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "da08da4a-0909-4acb-a2e6-7027324fa989",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 12408,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_115004.jsonl"
+  }
+}

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2504,6 +2504,48 @@ def _refuel_probe_completion_latches_from_context(context: Mapping[str, Any]) ->
     }
 
 
+def _four_down_completion_latches_from_context(context: Mapping[str, Any]) -> dict[str, bool]:
+    raw_latches = context.get("four_down_completion_latches")
+    legacy_refuel = _refuel_probe_completion_latches_from_context(context)
+    out = {
+        "s20_latched_complete": legacy_refuel.get("s20_latched_complete") is True,
+        "s21_latched_complete": legacy_refuel.get("s21_latched_complete") is True,
+        "s22_latched_complete": False,
+        "s23_latched_complete": False,
+        "s24_latched_complete": False,
+        "s25_latched_complete": False,
+    }
+    if isinstance(raw_latches, Mapping):
+        for step_id in ("s20", "s21", "s22", "s23", "s24", "s25"):
+            key = f"{step_id}_latched_complete"
+            out[key] = raw_latches.get(key) is True
+    return out
+
+
+def _launch_bar_extended(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("launch_bar_extended") is True:
+        return True
+    return _coerce_int(vars_selected.get("launch_bar_switch_value")) == 1
+
+
+def _launch_bar_retracted(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("launch_bar_retracted") is True:
+        return True
+    return _coerce_int(vars_selected.get("launch_bar_switch_value")) == 0
+
+
+def _hook_down(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("hook_extended") is True:
+        return True
+    return _coerce_int(vars_selected.get("hook_handle_value")) == 1
+
+
+def _hook_up(vars_selected: Mapping[str, Any]) -> bool:
+    if vars_selected.get("hook_retracted") is True:
+        return True
+    return _coerce_int(vars_selected.get("hook_handle_value")) == 0
+
+
 def _missing_conditions_satisfied_by_vars(
     missing_conditions: Sequence[str],
     vars_selected: Mapping[str, Any],
@@ -3797,6 +3839,14 @@ class LiveDcsTutorLoop:
         self._sticky_inference_missing_conditions: tuple[str, ...] = ()
         self._refuel_probe_s20_latched_complete = False
         self._refuel_probe_s21_latched_complete = False
+        self._launch_bar_s22_latched_complete = False
+        self._launch_bar_s23_latched_complete = False
+        self._hook_s24_latched_complete = False
+        self._hook_s25_latched_complete = False
+        self._four_down_first_incomplete_seen: dict[str, bool] = {
+            "S22": False,
+            "S24": False,
+        }
         self._pending_help_trigger_t_wall: float | None = None
         self._stats = LiveLoopStats()
 
@@ -3826,6 +3876,14 @@ class LiveDcsTutorLoop:
         self._sticky_inference_missing_conditions = ()
         self._refuel_probe_s20_latched_complete = False
         self._refuel_probe_s21_latched_complete = False
+        self._launch_bar_s22_latched_complete = False
+        self._launch_bar_s23_latched_complete = False
+        self._hook_s24_latched_complete = False
+        self._hook_s25_latched_complete = False
+        self._four_down_first_incomplete_seen = {
+            "S22": False,
+            "S24": False,
+        }
 
     def _remember_step_interactions(self, targets: Sequence[str] | None) -> None:
         if not isinstance(self._last_inferred_step_id, str) or not self._last_inferred_step_id:
@@ -3839,6 +3897,11 @@ class LiveDcsTutorLoop:
         s20_idx = self._step_order_index.get("S20")
         return idx is not None and s20_idx is not None and idx >= s20_idx
 
+    def _step_reached_for_four_down_latch(self, step_id: str | None, start_step_id: str) -> bool:
+        idx = self._step_order_index.get(step_id) if isinstance(step_id, str) else None
+        start_idx = self._step_order_index.get(start_step_id)
+        return idx is not None and start_idx is not None and idx >= start_idx
+
     def _update_refuel_probe_completion_latches(
         self,
         vars_selected: Mapping[str, Any],
@@ -3850,17 +3913,91 @@ class LiveDcsTutorLoop:
             or self._step_reached_for_refuel_probe_latch(self._sticky_inference_step_id)
         ):
             return
-        if self._refuel_probe_s21_latched_complete and not _refuel_probe_retracted(vars_selected):
+        has_probe_evidence = (
+            "probe_retracted" in vars_selected
+            or "probe_extended" in vars_selected
+            or "ext_refuel_probe_value" in vars_selected
+        )
+        if (
+            has_probe_evidence
+            and self._refuel_probe_s21_latched_complete
+            and not _refuel_probe_retracted(vars_selected)
+        ):
             self._refuel_probe_s21_latched_complete = False
         if _refuel_probe_extended(vars_selected):
             self._refuel_probe_s20_latched_complete = True
         if self._refuel_probe_s20_latched_complete and _refuel_probe_retracted(vars_selected):
             self._refuel_probe_s21_latched_complete = True
+        self._update_four_down_switch_completion_latches(vars_selected, current_step_id=current_step_id)
+
+    def _update_four_down_switch_completion_latches(
+        self,
+        vars_selected: Mapping[str, Any],
+        *,
+        current_step_id: str | None = None,
+    ) -> None:
+        if (
+            self._step_reached_for_four_down_latch(current_step_id, "S22")
+            or self._step_reached_for_four_down_latch(self._sticky_inference_step_id, "S22")
+        ):
+            has_launch_bar_evidence = (
+                "launch_bar_switch_value" in vars_selected
+                or "launch_bar_extended" in vars_selected
+                or "launch_bar_retracted" in vars_selected
+            )
+            if (
+                has_launch_bar_evidence
+                and self._launch_bar_s23_latched_complete
+                and not _launch_bar_retracted(vars_selected)
+            ):
+                self._launch_bar_s23_latched_complete = False
+            if not self._launch_bar_s22_latched_complete:
+                if _launch_bar_extended(vars_selected):
+                    if self._four_down_first_incomplete_seen.get("S22") is True:
+                        self._launch_bar_s22_latched_complete = True
+                else:
+                    self._four_down_first_incomplete_seen["S22"] = True
+            if self._launch_bar_s22_latched_complete and _launch_bar_retracted(vars_selected):
+                self._launch_bar_s23_latched_complete = True
+
+        if (
+            self._step_reached_for_four_down_latch(current_step_id, "S24")
+            or self._step_reached_for_four_down_latch(self._sticky_inference_step_id, "S24")
+        ):
+            has_hook_evidence = (
+                "hook_handle_value" in vars_selected
+                or "hook_extended" in vars_selected
+                or "hook_retracted" in vars_selected
+            )
+            if (
+                has_hook_evidence
+                and self._hook_s25_latched_complete
+                and not _hook_up(vars_selected)
+            ):
+                self._hook_s25_latched_complete = False
+            if not self._hook_s24_latched_complete:
+                if _hook_down(vars_selected):
+                    if self._four_down_first_incomplete_seen.get("S24") is True:
+                        self._hook_s24_latched_complete = True
+                else:
+                    self._four_down_first_incomplete_seen["S24"] = True
+            if self._hook_s24_latched_complete and _hook_up(vars_selected):
+                self._hook_s25_latched_complete = True
 
     def _refuel_probe_completion_latches_dict(self) -> dict[str, bool]:
         return {
             "s20_latched_complete": self._refuel_probe_s20_latched_complete,
             "s21_latched_complete": self._refuel_probe_s21_latched_complete,
+        }
+
+    def _four_down_completion_latches_dict(self) -> dict[str, bool]:
+        return {
+            "s20_latched_complete": self._refuel_probe_s20_latched_complete,
+            "s21_latched_complete": self._refuel_probe_s21_latched_complete,
+            "s22_latched_complete": self._launch_bar_s22_latched_complete,
+            "s23_latched_complete": self._launch_bar_s23_latched_complete,
+            "s24_latched_complete": self._hook_s24_latched_complete,
+            "s25_latched_complete": self._hook_s25_latched_complete,
         }
 
     def _ensure_knowledge(self) -> KnowledgePort:
@@ -4429,12 +4566,14 @@ class LiveDcsTutorLoop:
             deterministic_hint["action_hint"] = dict(action_hint)
 
         refuel_probe_completion_latches = self._refuel_probe_completion_latches_dict()
+        four_down_completion_latches = self._four_down_completion_latches_dict()
         context = {
             "vars": vars_selected,
             "gates": gates,
             "recent_deltas": recent_deltas,
             "recent_actions": recent_actions,
             "refuel_probe_completion_latches": refuel_probe_completion_latches,
+            "four_down_completion_latches": four_down_completion_latches,
             "pack_path": str(self.pack_path),
             "telemetry_map_path": str(self.telemetry_map_path),
             "candidate_steps": candidate_step_payload,
@@ -4523,6 +4662,7 @@ class LiveDcsTutorLoop:
             "candidate_steps": candidate_step_payload,
             "overlay_target_allowlist": self.overlay_allowlist,
             "refuel_probe_completion_latches": refuel_probe_completion_latches,
+            "four_down_completion_latches": four_down_completion_latches,
             "deterministic_step_hint": deterministic_hint,
             "scenario_profile": self.scenario_profile,
             "vision": {
@@ -4613,6 +4753,75 @@ class LiveDcsTutorLoop:
                 self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
                 return advanced
         if (
+            self._launch_bar_s23_latched_complete
+            and _launch_bar_retracted(vars_selected)
+            and current_step_id in {"S22", "S23"}
+        ):
+            advanced = self._infer_after_completed_step(
+                "S23",
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            advanced = self._clamp_four_down_transition_advance("S23", advanced)
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
+        if current_step_id == "S23" and not self._launch_bar_s22_latched_complete:
+            forced = StepInferenceResult(
+                inferred_step_id="S22",
+                missing_conditions=("session.launch_bar_extension_transition_observed==true",),
+            )
+            self._sticky_inference_step_id = forced.inferred_step_id
+            self._sticky_inference_missing_conditions = tuple(forced.missing_conditions)
+            return forced
+        if self._launch_bar_s22_latched_complete and current_step_id == "S22":
+            advanced = self._infer_after_completed_step(
+                "S22",
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
+        if current_step_id == "S25" and not self._hook_s24_latched_complete:
+            forced = StepInferenceResult(
+                inferred_step_id="S24",
+                missing_conditions=("session.hook_down_transition_observed==true",),
+            )
+            self._sticky_inference_step_id = forced.inferred_step_id
+            self._sticky_inference_missing_conditions = tuple(forced.missing_conditions)
+            return forced
+        if (
+            self._hook_s25_latched_complete
+            and _hook_up(vars_selected)
+            and current_step_id in {"S24", "S25"}
+        ):
+            advanced = self._infer_after_completed_step(
+                "S25",
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
+        if self._hook_s24_latched_complete and current_step_id == "S24":
+            advanced = self._infer_after_completed_step(
+                "S24",
+                vars_selected,
+                recent_ui_targets=recent_ui_targets,
+                vision_facts=None,
+            )
+            if advanced is not None:
+                self._sticky_inference_step_id = advanced.inferred_step_id
+                self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
+                return advanced
+        if (
             current_step_id == "S19"
             and _s19_final_go_hold_satisfied_by_facts(
                 inference.missing_conditions,
@@ -4683,6 +4892,25 @@ class LiveDcsTutorLoop:
             inferred_step_id=sticky_step_id,
             missing_conditions=self._sticky_inference_missing_conditions,
         )
+
+    def _clamp_four_down_transition_advance(
+        self,
+        completed_step_id: str,
+        advanced: StepInferenceResult | None,
+    ) -> StepInferenceResult | None:
+        if advanced is None:
+            return None
+        if (
+            completed_step_id == "S23"
+            and isinstance(advanced.inferred_step_id, str)
+            and self._step_order_index.get(advanced.inferred_step_id, -1) > self._step_order_index.get("S24", -1)
+            and not self._hook_s24_latched_complete
+        ):
+            return StepInferenceResult(
+                inferred_step_id="S24",
+                missing_conditions=("session.hook_down_transition_observed==true",),
+            )
+        return advanced
 
     def _infer_after_completed_step(
         self,
@@ -6581,7 +6809,10 @@ class LiveDcsTutorLoop:
         if not targets:
             help_response = response.metadata.get("help_response")
             targets = _help_response_overlay_targets(help_response)
-        latched_reason = self._refuel_probe_latched_completion_conflict(context, accepted_step_id)
+        forced_step_id = self._four_down_forced_step_from_context(context, accepted_step_id)
+        latched_reason = self._four_down_latched_completion_conflict(context, accepted_step_id)
+        if forced_step_id is not None:
+            latched_reason = f"four_down_missing_prior_latch:{forced_step_id}"
         if latched_reason is not None:
             rejected_missing = [
                 item for item in accepted_missing_conditions if isinstance(item, str) and item
@@ -6594,6 +6825,8 @@ class LiveDcsTutorLoop:
             response.metadata.setdefault("final_action_plan_source", "final_evidence_consistency_validator")
             if isinstance(accepted_step_id, str) and accepted_step_id:
                 response.metadata.setdefault("rejected_model_step_id", accepted_step_id)
+            if forced_step_id is not None:
+                response.metadata["final_evidence_consistency_forced_step_id"] = forced_step_id
 
             existing_reasons = response.metadata.get("harness_validation_reasons")
             merged_reasons = (
@@ -6644,7 +6877,10 @@ class LiveDcsTutorLoop:
         context = request.context if isinstance(request.context, Mapping) else {}
         vars_selected = context.get("vars")
         vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
-        latched_reason = self._refuel_probe_latched_completion_conflict(context, step_id)
+        forced_step_id = self._four_down_forced_step_from_context(context, step_id)
+        if forced_step_id is not None:
+            return f"evidence_conflict:four_down_missing_prior_latch:{forced_step_id}"
+        latched_reason = self._four_down_latched_completion_conflict(context, step_id)
         if latched_reason is not None:
             return f"evidence_conflict:{latched_reason}"
         if not missing_conditions and not include_completion_gate:
@@ -6668,27 +6904,69 @@ class LiveDcsTutorLoop:
             return "evidence_conflict"
         return f"evidence_conflict:{'|'.join(reasons[:3])}"
 
-    def _refuel_probe_latched_completion_conflict(
+    def _four_down_forced_step_from_context(
         self,
         context: Mapping[str, Any],
         step_id: str | None,
     ) -> str | None:
-        if step_id not in {"S20", "S21"}:
+        if step_id == "S23":
+            latches = _four_down_completion_latches_from_context(context)
+            if not latches.get("s22_latched_complete"):
+                return "S22"
             return None
-        latches = _refuel_probe_completion_latches_from_context(context)
+        if step_id != "S25":
+            return None
+        latches = _four_down_completion_latches_from_context(context)
+        if not latches.get("s24_latched_complete"):
+            return "S24"
+        return None
+
+    def _four_down_latched_completion_conflict(
+        self,
+        context: Mapping[str, Any],
+        step_id: str | None,
+    ) -> str | None:
+        if step_id not in {"S20", "S21", "S22", "S23", "S24", "S25"}:
+            return None
+        latches = _four_down_completion_latches_from_context(context)
         vars_selected = context.get("vars")
         vars_map = vars_selected if isinstance(vars_selected, Mapping) else {}
+        if step_id in {"S20", "S21"}:
+            if (
+                step_id == "S20"
+                and latches.get("s20_latched_complete")
+                and _refuel_probe_extended(vars_map)
+            ):
+                return "refuel_probe_latched_completion:S20"
+            if (
+                latches.get("s21_latched_complete")
+                and _refuel_probe_retracted(vars_map)
+            ):
+                return "refuel_probe_latched_completion:S21"
         if (
-            step_id == "S20"
-            and latches.get("s20_latched_complete")
-            and _refuel_probe_extended(vars_map)
+            step_id == "S22"
+            and latches.get("s22_latched_complete")
+            and _launch_bar_extended(vars_map)
         ):
-            return "refuel_probe_latched_completion:S20"
+            return "four_down_latched_completion:S22"
         if (
-            latches.get("s21_latched_complete")
-            and _refuel_probe_retracted(vars_map)
+            latches.get("s23_latched_complete")
+            and _launch_bar_retracted(vars_map)
+            and step_id in {"S22", "S23"}
         ):
-            return "refuel_probe_latched_completion:S21"
+            return "four_down_latched_completion:S23"
+        if (
+            step_id == "S24"
+            and latches.get("s24_latched_complete")
+            and _hook_down(vars_map)
+        ):
+            return "four_down_latched_completion:S24"
+        if (
+            latches.get("s25_latched_complete")
+            and _hook_up(vars_map)
+            and step_id in {"S24", "S25"}
+        ):
+            return "four_down_latched_completion:S25"
         return None
 
     def _context_with_full_pack_gates(self, context: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -6746,18 +7024,24 @@ class LiveDcsTutorLoop:
             if isinstance(recent_actions, Mapping)
             else []
         )
-        advanced = self._infer_after_completed_step(
-            rejected_step_id,
-            vars_map,
-            recent_ui_targets=recent_buttons,
-            vision_facts=context.get("vision_facts"),
-        )
+        forced_step_id = response.metadata.get("final_evidence_consistency_forced_step_id")
+        advanced = None
+        if not isinstance(forced_step_id, str) or not forced_step_id:
+            advanced = self._infer_after_completed_step(
+                rejected_step_id,
+                vars_map,
+                recent_ui_targets=recent_buttons,
+                vision_facts=context.get("vision_facts"),
+            )
         s08_visual_recovery = rejected_step_id == "S08" and _s08_visual_recovery_needed(context)
-        next_step_id = (
-            advanced.inferred_step_id
-            if advanced is not None and isinstance(advanced.inferred_step_id, str)
-            else self._next_step_id_after(rejected_step_id)
-        )
+        if isinstance(forced_step_id, str) and forced_step_id:
+            next_step_id = forced_step_id
+        else:
+            next_step_id = (
+                advanced.inferred_step_id
+                if advanced is not None and isinstance(advanced.inferred_step_id, str)
+                else self._next_step_id_after(rejected_step_id)
+            )
         s08_visual_hint = _s08_visual_hint_from_vision_summary(context) if s08_visual_recovery else None
         s08_visual_target = s08_visual_hint[0] if s08_visual_hint is not None else "left_mdi_pb18"
         s08_visual_evidence_ref = (
@@ -6779,6 +7063,10 @@ class LiveDcsTutorLoop:
             rewritten = "当前仍在 S08：左 DDI 还在 TAC 页面，FCS 页面尚未出现。请先按左 DDI PB18 进入 SUPT，再进入 FCS。"
         elif s08_visual_recovery:
             rewritten = "You are still on S08: the left DDI is on TAC and the FCS page is not visible. Press Left DDI PB18 to reach SUPT, then enter FCS."
+        elif next_step_id == "S24" and response.metadata.get("final_evidence_consistency_forced_step_id") == "S24" and self.lang == "zh":
+            rewritten = "现在进入 S24。请放下阻钩手柄，确认阻钩已伸出。"
+        elif next_step_id == "S24" and response.metadata.get("final_evidence_consistency_forced_step_id") == "S24":
+            rewritten = "Continue to S24. Lower the arresting hook handle and confirm the hook is down."
         elif self.lang == "zh":
             rewritten = f"{rejected_step_id} 的最新证据已经满足。现在进入 {next_step_id}。"
         else:
@@ -7577,14 +7865,20 @@ class LiveDcsTutorLoop:
         if overridden_inferred_step:
             gate_blockers = []
 
-        conflict_reason = self._fallback_evidence_conflict_reason(
-            request,
-            step_id=inferred_step_id,
-            missing_conditions=missing_conditions,
-            include_completion_gate=True,
+        latches = _four_down_completion_latches_from_context(context)
+        ignore_static_completion_conflict = (
+            inferred_step_id == "S24"
+            and not latches.get("s24_latched_complete")
         )
-        if conflict_reason is not None:
-            return None, conflict_reason
+        if not ignore_static_completion_conflict:
+            conflict_reason = self._fallback_evidence_conflict_reason(
+                request,
+                step_id=inferred_step_id,
+                missing_conditions=missing_conditions,
+                include_completion_gate=True,
+            )
+            if conflict_reason is not None:
+                return None, conflict_reason
 
         if inferred_step_id == "S33" and not missing_conditions and not gate_blockers:
             return None, "all_steps_complete"
@@ -7826,6 +8120,20 @@ class LiveDcsTutorLoop:
             and _s08_power_condition_missing_for_target(fallback_target, missing_set, vars_map)
         ):
             fallback_guidance = _s08_power_guidance_for_target(fallback_target, self.lang)
+        elif self.lang == "zh" and overlay_step_id in {"S22", "S23", "S24", "S25"}:
+            fallback_guidance = {
+                "S22": "请放下 launch bar，确认 launch bar 已伸出。",
+                "S23": "请收起 launch bar，确认 launch bar 已收回。",
+                "S24": "请放下阻钩手柄，确认阻钩已伸出。",
+                "S25": "请抬起阻钩手柄，确认阻钩已收起。",
+            }[overlay_step_id]
+        elif overlay_step_id in {"S22", "S23", "S24", "S25"}:
+            fallback_guidance = {
+                "S22": "Extend the launch bar and confirm it is down.",
+                "S23": "Retract the launch bar after confirming extension.",
+                "S24": "Lower the arresting hook handle and confirm the hook is down.",
+                "S25": "Raise the arresting hook handle and confirm the hook is up.",
+            }[overlay_step_id]
 
         fallback_help_obj = {
             "diagnosis": {

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -7417,6 +7417,194 @@ def test_live_build_request_serializes_refuel_probe_latch_history(tmp_path: Path
     assert retracted_state_key != extended_state_key
 
 
+def test_live_build_request_serializes_four_down_transition_latch_history(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_four_down_latch_request.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-four-down-latch-request",
+    )
+    try:
+        loop._refuel_probe_s20_latched_complete = True
+        loop._refuel_probe_s21_latched_complete = True
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S22",
+                missing_conditions=("vars.launch_bar_switch_value in [1,1]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "launch_bar_switch_value": 0,
+                "hook_handle_value": 1,
+            },
+        )
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S22",
+                missing_conditions=("vars.launch_bar_switch_value in [1,1]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "launch_bar_switch_value": 1,
+                "hook_handle_value": 1,
+            },
+        )
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S23",
+                missing_conditions=("vars.launch_bar_switch_value in [0,0]",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "launch_bar_switch_value": 0,
+                "hook_handle_value": 1,
+            },
+        )
+        before_hook_latch_obs = Observation(
+            source="mock",
+            payload={
+                "seq": 1,
+                "t_wall": 10.0,
+                "vars": {
+                    "battery_on": True,
+                    "power_available": True,
+                    "launch_bar_switch_value": 0,
+                    "hook_handle_value": 1,
+                },
+            },
+        )
+        before_hook_latch_vision = loop._build_vision_selection(
+            observation=before_hook_latch_obs,
+            trigger_t_wall=10.0,
+        )
+        before_hook_latch_request, _prompt_meta, before_hook_latch_state_key = loop._build_request(
+            before_hook_latch_obs,
+            vision_selection=before_hook_latch_vision,
+            vision_fact_context=loop._extract_vision_fact_context(vision_selection=before_hook_latch_vision),
+        )
+
+        hook_initial_down = loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S24",
+                missing_conditions=("session.hook_down_transition_observed==true",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "launch_bar_switch_value": 0,
+                "hook_handle_value": 1,
+            },
+        )
+        loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S24",
+                missing_conditions=("session.hook_down_transition_observed==true",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "launch_bar_switch_value": 0,
+                "hook_handle_value": 0,
+            },
+        )
+        hook_transition_down = loop._stabilize_live_inference(
+            StepInferenceResult(
+                inferred_step_id="S24",
+                missing_conditions=("session.hook_down_transition_observed==true",),
+            ),
+            {
+                "battery_on": True,
+                "power_available": True,
+                "launch_bar_switch_value": 0,
+                "hook_handle_value": 1,
+            },
+        )
+
+        hook_cold_loop = LiveDcsTutorLoop(
+            source=ReplayBiosReceiver(replay_path),
+            model=FailingModel(),
+            action_executor=RecordingExecutor(),
+            session_id="sess-four-down-hook-cold",
+        )
+        try:
+            hook_cold_s25 = hook_cold_loop._stabilize_live_inference(
+                StepInferenceResult(
+                    inferred_step_id="S25",
+                    missing_conditions=("vars.hook_handle_value in [0,0]",),
+                ),
+                {
+                    "battery_on": True,
+                    "power_available": True,
+                    "launch_bar_switch_value": 0,
+                    "hook_handle_value": 1,
+                },
+            )
+        finally:
+            hook_cold_loop.close()
+        launch_bar_cold_loop = LiveDcsTutorLoop(
+            source=ReplayBiosReceiver(replay_path),
+            model=FailingModel(),
+            action_executor=RecordingExecutor(),
+            session_id="sess-four-down-launch-cold",
+        )
+        try:
+            launch_bar_cold_s23 = launch_bar_cold_loop._stabilize_live_inference(
+                StepInferenceResult(
+                    inferred_step_id="S23",
+                    missing_conditions=("vars.launch_bar_switch_value in [0,0]",),
+                ),
+                {
+                    "battery_on": True,
+                    "power_available": True,
+                    "launch_bar_switch_value": 1,
+                },
+            )
+        finally:
+            launch_bar_cold_loop.close()
+
+        obs = Observation(
+            source="mock",
+            payload={
+                "seq": 1,
+                "t_wall": 10.0,
+                "vars": {
+                    "battery_on": True,
+                    "power_available": True,
+                    "launch_bar_switch_value": 0,
+                    "hook_handle_value": 1,
+                },
+            },
+        )
+        vision_selection = loop._build_vision_selection(observation=obs, trigger_t_wall=10.0)
+        request, _prompt_meta, _state_key = loop._build_request(
+            obs,
+            vision_selection=vision_selection,
+            vision_fact_context=loop._extract_vision_fact_context(vision_selection=vision_selection),
+        )
+    finally:
+        loop.close()
+
+    assert hook_initial_down.inferred_step_id == "S24"
+    assert hook_cold_s25.inferred_step_id == "S24"
+    assert launch_bar_cold_s23.inferred_step_id == "S22"
+    assert hook_transition_down.inferred_step_id == "S25"
+    assert before_hook_latch_request.context["four_down_completion_latches"]["s24_latched_complete"] is False
+    assert request.context["four_down_completion_latches"] == {
+        "s20_latched_complete": True,
+        "s21_latched_complete": True,
+        "s22_latched_complete": True,
+        "s23_latched_complete": True,
+        "s24_latched_complete": True,
+        "s25_latched_complete": False,
+    }
+    assert before_hook_latch_state_key != _state_key
+
+
 def test_live_dcs_cli_parses_raw_bios_source_args() -> None:
     parser = build_arg_parser()
     args = parser.parse_args(
@@ -10976,6 +11164,29 @@ def _public_response_text(response: TutorResponse) -> str:
     return "\n".join(parts)
 
 
+def _assert_live_fixture_expectations(fixture: dict[str, Any], response: TutorResponse) -> None:
+    expectations = fixture.get("expectations")
+    assert isinstance(expectations, dict)
+    expected_step = expectations.get("expected_final_step_id")
+    if isinstance(expected_step, str) and expected_step:
+        assert response.metadata["diagnosis"]["step_id"] == expected_step
+        assert response.metadata["next"]["step_id"] == expected_step
+        assert response.metadata["final_public_response"]["next"]["step_id"] == expected_step
+    expected_targets = expectations.get("expected_overlay_target_ids")
+    if isinstance(expected_targets, list):
+        assert response.metadata["final_overlay_targets"] == [
+            item for item in expected_targets if isinstance(item, str)
+        ]
+    expected_source = expectations.get("final_response_source")
+    if isinstance(expected_source, str) and expected_source:
+        assert response.metadata["final_action_plan"]["source"] == expected_source
+    if expectations.get("llm_decision_status") == "repaired":
+        assert response.metadata["repair_applied"] is True
+    expected_vlm_status = expectations.get("vlm_call_status")
+    if isinstance(expected_vlm_status, str) and expected_vlm_status:
+        assert response.metadata["vlm_call_status"] == expected_vlm_status
+
+
 def test_live_help_fixture_311_replays_real_s09_comm1_complete_fixture() -> None:
     fixture = _load_live_help_fixture(
         "artifacts/live_fixtures/168fc73d-f98c-498e-a35c-fef91b06ee2e.fixture.json"
@@ -11167,6 +11378,7 @@ def test_live_help_fixture_306_1ab3_retracted_after_latch_advances_to_s22() -> N
 
     repaired = _validate_compact_live_help_response(request=request, response=response)
 
+    _assert_live_fixture_expectations(fixture, repaired)
     assert repaired.metadata["diagnosis"]["step_id"] == "S22"
     assert repaired.metadata["next"]["step_id"] == "S22"
     assert repaired.metadata["validator_rejected"] is True
@@ -11188,6 +11400,7 @@ def test_live_help_fixture_306_2e04_extended_probe_advances_to_s21() -> None:
 
     repaired = _validate_compact_live_help_response(request=request, response=response)
 
+    _assert_live_fixture_expectations(fixture, repaired)
     assert repaired.metadata["diagnosis"]["step_id"] == "S21"
     assert repaired.metadata["next"]["step_id"] == "S21"
     assert repaired.metadata["validator_rejected"] is True
@@ -11199,6 +11412,62 @@ def test_live_help_fixture_306_2e04_extended_probe_advances_to_s21() -> None:
     public_text = _public_response_text(repaired)
     assert "S20 未完成" not in public_text
     assert "收起" in public_text
+
+
+def test_live_help_fixture_306_20c_retracted_probe_latch_advances_to_s22() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/20c79783-092e-4128-ad47-5fa7d3774ed7.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    _assert_live_fixture_expectations(fixture, repaired)
+    assert repaired.metadata["diagnosis"]["step_id"] == "S22"
+    assert repaired.metadata["next"]["step_id"] == "S22"
+    assert repaired.metadata["final_action_plan"]["source"] == "final_evidence_consistency_validator"
+    assert repaired.metadata["final_overlay_targets"] == ["launch_bar_switch"]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "launch_bar_switch"
+
+
+def test_live_help_fixture_306_6232_launch_bar_cycle_stops_at_s24_without_hook_latch() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/6232bd96-95f8-4905-9ae9-8f27e4515c3d.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    _assert_live_fixture_expectations(fixture, repaired)
+    assert repaired.metadata["diagnosis"]["step_id"] == "S24"
+    assert repaired.metadata["next"]["step_id"] == "S24"
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["final_action_plan"]["source"] == "final_evidence_consistency_validator"
+    assert repaired.metadata["final_overlay_targets"] == ["arresting_hook_handle"]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "arresting_hook_handle"
+    public_text = _public_response_text(repaired)
+    assert "S23" not in public_text
+    assert "S25" not in public_text
+
+
+def test_live_help_fixture_306_da08_s25_hook_guidance_matches_retract_direction() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/da08da4a-0909-4acb-a2e6-7027324fa989.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    _assert_live_fixture_expectations(fixture, repaired)
+    assert repaired.metadata["diagnosis"]["step_id"] == "S25"
+    assert repaired.metadata["next"]["step_id"] == "S25"
+    assert repaired.metadata["final_overlay_targets"] == ["arresting_hook_handle"]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "arresting_hook_handle"
+    public_text = _public_response_text(repaired)
+    assert "抬起" in public_text or "收起" in public_text
+    assert "放下阻钩" not in public_text
+    assert "伸出阻钩" not in public_text
 
 
 def test_live_help_fixture_294_s09_comm1_complete_advances_to_s10() -> None:


### PR DESCRIPTION
## Summary
- extend session transition latches from refuel probe to launch bar and arresting hook four-down checks
- prevent cold physical state from satisfying both halves of S22/S23 or S24/S25 without an observed in-session transition
- align S24/S25 fallback text with hook direction, and add fixtures for 20c79783, 6232bd96, and da08da4a from the latest #306 live log

## Tests
- python -m pytest -q tests/test_live_dcs.py::test_live_inference_latches_refuel_probe_cycle_after_observed_s20_completion tests/test_live_dcs.py::test_live_inference_does_not_skip_s20_from_initial_retracted_probe tests/test_live_dcs.py::test_live_inference_ignores_probe_motion_seen_before_s20 tests/test_live_dcs.py::test_live_inference_requires_probe_to_remain_retracted_for_s21_latch tests/test_live_dcs.py::test_live_build_request_serializes_refuel_probe_latch_history tests/test_live_dcs.py::test_live_build_request_serializes_four_down_transition_latch_history tests/test_live_dcs.py::test_live_help_fixture_306_2e04_extended_probe_advances_to_s21 tests/test_live_dcs.py::test_live_help_fixture_306_1ab3_retracted_after_latch_advances_to_s22 tests/test_live_dcs.py::test_live_help_fixture_306_20c_retracted_probe_latch_advances_to_s22 tests/test_live_dcs.py::test_live_help_fixture_306_6232_launch_bar_cycle_stops_at_s24_without_hook_latch tests/test_live_dcs.py::test_live_help_fixture_306_da08_s25_hook_guidance_matches_retract_direction tests/test_live_dcs.py::test_fallback_overlay_for_s20_uses_only_refuel_probe_target tests/test_harness_validation.py::test_final_evidence_consistency_rejects_missing_condition_satisfied_by_telemetry tests/test_harness_validation.py::test_final_evidence_consistency_rejects_numeric_missing_condition_satisfied_by_telemetry tests/test_harness_validation.py::test_final_evidence_consistency_does_not_use_stale_last_seen_true_when_latest_false tests/test_harness_validation.py::test_final_evidence_consistency_rejects_already_satisfied_completion_gate tests/test_harness_validation.py::test_final_evidence_consistency_rejects_allowed_completion_gate_but_ignores_no_rules tests/test_harness_validation.py::test_final_evidence_consistency_rejects_late_allowed_completion_gate_after_detail_window

Fixes #306