### PR TITLE
Refresh final consistency public guidance

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -7072,6 +7072,7 @@ class LiveDcsTutorLoop:
         else:
             rewritten = f"The latest evidence satisfies {rejected_step_id}. Continue to {next_step_id}."
 
+        public_guidance = rewritten
         original_actions = copy.deepcopy([dict(action) for action in response.actions if isinstance(action, Mapping)])
         if original_actions:
             response.metadata["final_evidence_consistency_original_actions"] = original_actions
@@ -7085,8 +7086,6 @@ class LiveDcsTutorLoop:
                 response.metadata["rejected_model_target"] = response.metadata["rejected_model_targets"][0]
 
         response.actions = []
-        response.message = rewritten
-        response.explanations = [rewritten]
         response.metadata["diagnosis"] = {"step_id": next_step_id, "error_category": "OM"}
         response.metadata["next"] = {"step_id": next_step_id}
         response.metadata["final_action_plan_source"] = "final_evidence_consistency_validator"
@@ -7123,9 +7122,14 @@ class LiveDcsTutorLoop:
         fallback_used = False
         if isinstance(fallback_help_obj, Mapping):
             planned_help_obj = copy.deepcopy(dict(fallback_help_obj))
+            fallback_explanations = planned_help_obj.get("explanations")
+            if isinstance(fallback_explanations, list):
+                fallback_guidance = next((item for item in fallback_explanations if isinstance(item, str) and item), None)
+                if isinstance(fallback_guidance, str) and fallback_guidance:
+                    public_guidance = fallback_guidance
             planned_help_obj["diagnosis"] = {"step_id": next_step_id, "error_category": "OM"}
             planned_help_obj["next"] = {"step_id": next_step_id}
-            planned_help_obj["explanations"] = [rewritten]
+            planned_help_obj["explanations"] = [public_guidance]
             mapped = map_help_response_to_tutor_response(
                 planned_help_obj,
                 request=request,
@@ -7147,27 +7151,32 @@ class LiveDcsTutorLoop:
                     "diagnosis": {"step_id": next_step_id, "error_category": "OM"},
                     "next": {"step_id": next_step_id},
                     "overlay": {"targets": [], "evidence": []},
-                    "explanations": [rewritten],
+                    "explanations": [public_guidance],
                 }
         else:
             response.metadata["help_response"] = {
                 "diagnosis": {"step_id": next_step_id, "error_category": "OM"},
                 "next": {"step_id": next_step_id},
                 "overlay": {"targets": [], "evidence": []},
-                "explanations": [rewritten],
+                "explanations": [public_guidance],
             }
 
+        response.message = public_guidance
+        response.explanations = [public_guidance]
         final_targets = _overlay_targets_from_actions(response.actions)
-        response.metadata["harness_action_plan"] = {
+        final_action_plan = {
             "step_id": next_step_id,
             "overlay_step_id": next_step_id,
             "targets": list(final_targets),
             "text_only": not bool(final_targets),
             "source": "final_evidence_consistency_validator",
         }
+        response.metadata["harness_action_plan"] = dict(final_action_plan)
+        response.metadata["final_action_plan"] = dict(final_action_plan)
         response.metadata["final_evidence_consistency_repair_applied"] = True
         response.metadata["final_evidence_consistency_overlay_applied"] = fallback_used
         response.metadata["final_evidence_consistency_overlay_reason"] = fallback_reason
+        self._annotate_response_audit_metadata(response)
         return True, "final_evidence_consistency_validator"
 
     def _final_response_step_id(self, response: TutorResponse) -> str | None:
@@ -8133,6 +8142,22 @@ class LiveDcsTutorLoop:
                 "S23": "Retract the launch bar after confirming extension.",
                 "S24": "Lower the arresting hook handle and confirm the hook is down.",
                 "S25": "Raise the arresting hook handle and confirm the hook is up.",
+            }[overlay_step_id]
+        elif self.lang == "zh" and overlay_step_id in {"S28", "S29", "S30", "S31", "S32"}:
+            fallback_guidance = {
+                "S28": "现在进入 S28。请释放停车刹车手柄，准备滑行。",
+                "S29": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。",
+                "S30": "现在进入 S30。请调整备用气压高度表到当前机场标高/QNH。",
+                "S31": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。",
+                "S32": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。",
+            }[overlay_step_id]
+        elif overlay_step_id in {"S28", "S29", "S30", "S31", "S32"}:
+            fallback_guidance = {
+                "S28": "Continue to S28. Release the parking brake handle when ready to taxi.",
+                "S29": "Continue to S29. Use the IFEI UP/DOWN buttons to set the BINGO fuel.",
+                "S30": "Continue to S30. Adjust the standby pressure altimeter to the local field elevation or QNH.",
+                "S31": "Continue to S31. Set the radar altimeter bug to 200 ft for airfield or 40 ft for carrier.",
+                "S32": "Continue to S32. Uncage the standby attitude indicator.",
             }[overlay_step_id]
 
         fallback_help_obj = {

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11769,6 +11769,110 @@ def test_final_evidence_validator_rechecks_repaired_fallback_step() -> None:
     assert "ins_mode_knob" not in [action["target"] for action in response.actions]
 
 
+@pytest.mark.parametrize(
+    ("next_step_id", "target", "expected_text"),
+    [
+        ("S28", "parking_brake_handle", "parking brake"),
+        ("S29", "ifei_up_button", "bingo"),
+        ("S30", "standby_altimeter_pressure_knob", "standby pressure altimeter"),
+        ("S31", "radar_altimeter_bug_knob", "radar altimeter"),
+        ("S32", "standby_attitude_cage_knob", "standby attitude"),
+    ],
+)
+def test_final_evidence_consistency_repair_uses_repaired_action_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+    next_step_id: str,
+    target: str,
+    expected_text: str,
+) -> None:
+    request = TutorRequest(
+        request_id=f"issue-315-final-public-guidance-{next_step_id.lower()}",
+        message="help",
+        context={
+            "vars": {},
+            "gates": {
+                f"{next_step_id}.completion": {"status": "blocked", "reason": f"{target} still needs action."},
+                f"{next_step_id}.precondition": {"status": "allowed"},
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S26",
+                "overlay_step_id": "S26",
+                "missing_conditions": ["vars.pitot_heat_on==true"],
+                "step_ui_targets": ["pitot_heat_switch"],
+            },
+            "overlay_target_allowlist": [target],
+            "rag_topk": [],
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message=f"S26 latest evidence satisfied. Now entering {next_step_id}.",
+        actions=[],
+        explanations=[f"S26 latest evidence satisfied. Now entering {next_step_id}."],
+        metadata={
+            "provider": "fallback",
+            "generation_mode": "fallback",
+            "diagnosis": {"step_id": "S26", "error_category": "OM"},
+            "next": {"step_id": "S26"},
+            "help_response": {
+                "diagnosis": {"step_id": "S26", "error_category": "OM"},
+                "next": {"step_id": "S26"},
+                "overlay": {"targets": [], "evidence": []},
+                "explanations": [f"S26 latest evidence satisfied. Now entering {next_step_id}."],
+            },
+            "final_public_response": {
+                "message": f"S26 latest evidence satisfied. Now entering {next_step_id}.",
+                "explanations": [f"S26 latest evidence satisfied. Now entering {next_step_id}."],
+                "diagnosis": {"step_id": "S26", "error_category": "OM"},
+                "next": {"step_id": "S26"},
+                "actions": [],
+            },
+        },
+    )
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-issue-315-final-public-guidance",
+        rag_top_k=0,
+        lang="en",
+    )
+    monkeypatch.setattr(
+        loop,
+        "_infer_after_completed_step",
+        lambda *args, **kwargs: StepInferenceResult(next_step_id, (f"vars.{target}_complete==true",)),
+    )
+    try:
+        used, reason = loop._rewrite_final_evidence_consistency_conflict_response(
+            response,
+            request,
+            rejected_step_id="S26",
+            rejected_missing_conditions=["vars.pitot_heat_on==true"],
+        )
+    finally:
+        loop.close()
+
+    assert used is True
+    assert reason == "final_evidence_consistency_validator"
+    assert response.metadata["next"]["step_id"] == next_step_id
+    assert response.metadata["harness_action_plan"]["targets"] == [target]
+    assert response.metadata["final_action_plan"]["step_id"] == next_step_id
+    assert response.metadata["final_action_plan"]["targets"] == [target]
+    assert response.metadata["final_action_plan_source"] == "final_evidence_consistency_validator"
+    assert [action["target"] for action in response.actions] == [target]
+    assert response.actions[0]["evidence_refs"] == [f"GATES.{next_step_id}.completion"]
+    assert response.metadata["help_response"]["overlay"]["evidence"][0]["ref"] == response.actions[0]["evidence_refs"][0]
+    assert "latest evidence satisfied" not in response.message
+    assert expected_text in response.message.lower()
+    assert response.metadata["help_response"]["explanations"] == [response.message]
+    final_public = response.metadata["final_public_response"]
+    assert final_public["message"] == response.message
+    assert final_public["next"]["step_id"] == next_step_id
+    assert final_public["actions"][0]["target"] == target
+    assert "latest evidence satisfied" not in json.dumps(final_public)
+
+
 def test_live_help_fixture_310_does_not_fall_back_to_s10_when_next_overlay_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- regenerate the public message from the repaired final consistency fallback plan
- refresh final_public_response after final consistency repair so message, next step, actions, and targets stay aligned
- add S28-S32 repaired-step fallback guidance and regression coverage for stale internal audit wording

## Tests
- python -m pytest -q -s --basetemp=.tmp/pytest-315-final-guidance tests/test_live_dcs.py::test_final_evidence_consistency_repair_uses_repaired_action_guidance
- python -m pytest -q -s --basetemp=.tmp/pytest-315-final-related tests/test_live_dcs.py::test_final_evidence_validator_rechecks_repaired_fallback_step tests/test_live_dcs.py::test_final_evidence_consistency_repair_uses_repaired_action_guidance tests/test_live_dcs.py::test_live_help_fixture_306_1ab3_retracted_after_latch_advances_to_s22 tests/test_live_dcs.py::test_live_help_fixture_306_2e04_extended_probe_advances_to_s21 tests/test_live_dcs.py::test_live_help_fixture_306_20c_retracted_probe_latch_advances_to_s22 tests/test_live_dcs.py::test_live_help_fixture_306_6232_launch_bar_cycle_stops_at_s24_without_hook_latch tests/test_live_dcs.py::test_live_help_fixture_306_da08_s25_hook_guidance_matches_retract_direction
- python3 tools/ci_guard.py

Full test suite intentionally not run per request.