### PR TITLE
Fix S20 VLM gate with sticky final GO

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2576,7 +2576,11 @@ def _s19_final_go_hold_satisfied_by_facts(
     vision_facts: Mapping[str, Any],
 ) -> bool:
     conditions = [item for item in missing_conditions if isinstance(item, str) and item]
-    if conditions != ["vision_facts.fcsmc_final_go_result_visible==seen"]:
+    allowed_conditions = {
+        "vision_facts.fcsmc_page_visible==seen",
+        "vision_facts.fcsmc_final_go_result_visible==seen",
+    }
+    if not conditions or any(item not in allowed_conditions for item in conditions):
         return False
     fact = vision_facts.get("fcsmc_final_go_result_visible")
     return (

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -8634,11 +8634,11 @@ def test_live_loop_advances_satisfied_s19_visual_hold_before_vlm_gate(tmp_path: 
     )
     loop._infer_preliminary_step_for_vision_facts = lambda obs: StepInferenceResult(
         "S19",
-        ("vision_facts.fcsmc_final_go_result_visible==seen",),
+        ("vision_facts.fcsmc_page_visible==seen",),
     )
     loop._last_inferred_step_id = "S19"
     loop._sticky_inference_step_id = "S19"
-    loop._sticky_inference_missing_conditions = ("vision_facts.fcsmc_final_go_result_visible==seen",)
+    loop._sticky_inference_missing_conditions = ("vision_facts.fcsmc_page_visible==seen",)
     loop._vision_fact_snapshot = {
         "fcsmc_final_go_result_visible": {
             "fact_id": "fcsmc_final_go_result_visible",


### PR DESCRIPTION
## Summary
- treat sticky S19 final GO as satisfying S19 visual hold even when preliminary missing condition is the FCS-MC page predicate
- prevent c58743f4-style S20/refuel-probe cycles from fresh-calling the VLM extractor
- keep the scope limited to S19 final GO sticky facts

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k advances_satisfied_s19_visual_hold_before_vlm_gate
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_issue_298_vlm_progress.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k "satisfied_s19 or unresolved_visual_sticky_hold or stale_s19_visual_facts_for_s20 or ignores_stale_s19_visual_facts_for_s21"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_evidence_packet.py -k "sticky_visual_state or telemetry_only or sticky_state"

Full suite intentionally not run per request.