### PR TITLE
Fix final consistency precondition advance

### DIFF
--- a/artifacts/live_fixtures/c2a80099-8375-42a1-89eb-b09544b474e2.fixture.json
+++ b/artifacts/live_fixtures/c2a80099-8375-42a1-89eb-b09544b474e2.fixture.json
@@ -1,0 +1,152 @@
+{
+  "context": {
+    "observation_ref": "77fb3314-a2eb-451e-b53d-b33a2df0c041",
+    "observations": [
+      {
+        "observation_id": "77fb3314-a2eb-451e-b53d-b33a2df0c041",
+        "payload": {
+          "seq": 6726,
+          "t_wall": 1779198474.829246,
+          "recent_ui_targets": [],
+          "vars": {
+            "battery_on": true,
+            "power_available": true,
+            "hud_on": true,
+            "left_ddi_on": true,
+            "right_ddi_on": true,
+            "mpcd_on": true,
+            "comm1_freq_134_000": true,
+            "right_engine_nominal_start_params": true,
+            "engine_crank_left_complete": true,
+            "rpm_l": 64,
+            "rpm_l_gte_60": true,
+            "throttle_l_not_off": true,
+            "ins_mode": 0,
+            "ins_mode_set": false,
+            "ins_mode_cv_or_gnd": false,
+            "ins_fast_align_complete": false,
+            "radar_mode_opr": false
+          }
+        }
+      }
+    ]
+  },
+  "cycle": {
+    "tutor_request": {
+      "request_id": "c2a80099-8375-42a1-89eb-b09544b474e2",
+      "message": "help",
+      "observation_ref": "77fb3314-a2eb-451e-b53d-b33a2df0c041",
+      "context": {
+        "scenario_profile": "airfield",
+        "deterministic_step_hint": {
+          "inferred_step_id": "S12",
+          "overlay_step_id": "S12",
+          "observability": "observable",
+          "observability_status": "observable",
+          "requires_visual_confirmation": false,
+          "missing_conditions_count": 1,
+          "step_ui_targets": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "action_hint": {
+            "target": "ins_mode_knob"
+          }
+        },
+        "state_harness": {
+          "conflicts": [],
+          "telemetry_evidence": {
+            "source_status": "nominal",
+            "confidence": "medium",
+            "observation_seq": 6726
+          },
+          "vision_evidence": {
+            "source_status": "vision_not_required",
+            "confidence": "low",
+            "seen_fact_ids": [],
+            "fresh_fact_ids": []
+          },
+          "deterministic_candidate": {
+            "step_id": "S12",
+            "overlay_step_id": "S12",
+            "missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "role": "candidate_not_authoritative"
+          },
+          "telemetry_window_digest": {
+            "frame_count": 20,
+            "first_seq": 6707,
+            "latest_seq": 6726,
+            "stable_true_vars": [
+              "battery_on",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "stable_false_vars": [],
+            "contradictions": [],
+            "changed_vars": []
+          }
+        },
+        "evidence_packet_summary": {
+          "telemetry_status": "nominal",
+          "vision_status": "vision_not_required",
+          "blocked_gate_count": 7,
+          "recent_action_count": 0,
+          "conflicts": []
+        },
+        "vision_fact_summary": {
+          "status": "vision_not_required",
+          "seen_fact_ids": [],
+          "fresh_fact_ids": []
+        },
+        "vision_facts": [],
+        "overlay_target_allowlist": [
+          "ins_mode_knob",
+          "ampcd_pb19",
+          "radar_mode_knob"
+        ],
+        "rag_topk": []
+      },
+      "metadata": {}
+    }
+  },
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "step_id": "S12",
+        "error_category": "OM"
+      },
+      "next": {
+        "step_id": "S12"
+      },
+      "overlay": {
+        "targets": [
+          "ins_mode_knob"
+        ],
+        "evidence": [
+          {
+            "target": "ins_mode_knob",
+            "type": "gate",
+            "ref": "GATES.S12.completion",
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "grounding_confidence": 0.95
+          }
+        ]
+      },
+      "explanations": [
+        "当前步骤 S12 未完成，INS 模式未设置为 GND。请操作 ins_mode_knob。"
+      ]
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S12",
+    "expected_overlay_target_ids": [
+      "ins_mode_knob"
+    ],
+    "final_response_source": "model"
+  }
+}

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -56,7 +56,7 @@ from adapters.step_harness_specs import (
     step_fallback_profiles_from_specs,
     step_signal_profiles_from_specs,
 )
-from adapters.step_inference import StepInferenceResult, infer_step_id, load_pack_steps
+from adapters.step_inference import StepInferenceResult, format_gate_rule_condition, infer_step_id, load_pack_steps
 from adapters.telemetry_pipeline import enrich_bios_observation
 from adapters.vision_capture_trigger import (
     DEFAULT_VISION_CAPTURE_TRIGGER_HOST,
@@ -6793,6 +6793,102 @@ class LiveDcsTutorLoop:
             response.metadata["manual_throttle_guidance_original_explanations"] = original_explanations
         return True, "manual_throttle_keyboard_guidance"
 
+    @staticmethod
+    def _normalize_missing_condition_key(condition: str) -> str:
+        return re.sub(r"\s+", "", condition)
+
+    def _gate_missing_condition_keys_for_step(self, step_id: str | None, gate_type: str) -> set[str]:
+        if not isinstance(step_id, str) or not step_id:
+            return set()
+        if gate_type == "precondition":
+            gate_map = self.precondition_gates
+        elif gate_type == "completion":
+            gate_map = self.completion_gates
+        else:
+            return set()
+        rules = gate_map.get(step_id)
+        if not isinstance(rules, (list, tuple)):
+            return set()
+        out: set[str] = set()
+        for rule in rules:
+            if not isinstance(rule, Mapping):
+                continue
+            condition = format_gate_rule_condition(rule)
+            if condition:
+                out.add(self._normalize_missing_condition_key(condition))
+        return out
+
+    def _split_completion_missing_conditions(
+        self,
+        step_id: str | None,
+        missing_conditions: Sequence[str],
+    ) -> tuple[list[str], list[str]]:
+        precondition_keys = self._gate_missing_condition_keys_for_step(step_id, "precondition")
+        completion_keys = self._gate_missing_condition_keys_for_step(step_id, "completion")
+        completion_only: list[str] = []
+        precondition_only: list[str] = []
+        for condition in missing_conditions:
+            if not isinstance(condition, str) or not condition:
+                continue
+            key = self._normalize_missing_condition_key(condition)
+            if key in completion_keys:
+                completion_only.append(condition)
+            elif key in precondition_keys:
+                precondition_only.append(condition)
+        return completion_only, precondition_only
+
+    def _record_final_evidence_precondition_metadata(
+        self,
+        response: TutorResponse,
+        *,
+        precondition_missing_conditions: Sequence[str],
+        latest_vars: Mapping[str, Any],
+        evidence_packet: Any,
+    ) -> None:
+        if not precondition_missing_conditions:
+            return
+        precondition_result = validate_final_evidence_consistency(
+            accepted_step_id=None,
+            accepted_overlay_targets=[],
+            accepted_missing_conditions=precondition_missing_conditions,
+            latest_vars=latest_vars,
+            evidence_packet=evidence_packet,
+        )
+        satisfied = [
+            item for item in precondition_result.rejected_missing_conditions
+            if isinstance(item, str) and item
+        ]
+        if not satisfied:
+            return
+        response.metadata["final_evidence_consistency_precondition_satisfied"] = True
+        existing_conditions = response.metadata.get("precondition_satisfied_conditions")
+        merged_conditions = (
+            [item for item in existing_conditions if isinstance(item, str) and item]
+            if isinstance(existing_conditions, list)
+            else []
+        )
+        merged_conditions.extend(satisfied)
+        response.metadata["precondition_satisfied_conditions"] = _dedupe_strings(merged_conditions)
+        precondition_reasons = [f"precondition_satisfied:{condition}" for condition in satisfied]
+        existing_precondition_reasons = response.metadata.get("final_evidence_consistency_precondition_reasons")
+        merged_precondition_reasons = (
+            [item for item in existing_precondition_reasons if isinstance(item, str) and item]
+            if isinstance(existing_precondition_reasons, list)
+            else []
+        )
+        merged_precondition_reasons.extend(precondition_reasons)
+        response.metadata["final_evidence_consistency_precondition_reasons"] = _dedupe_strings(
+            merged_precondition_reasons
+        )
+        existing_reasons = response.metadata.get("harness_validation_reasons")
+        merged_reasons = (
+            [item for item in existing_reasons if isinstance(item, str) and item]
+            if isinstance(existing_reasons, list)
+            else []
+        )
+        merged_reasons.extend(precondition_reasons)
+        response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
+
     def _apply_final_evidence_consistency_metadata(
         self,
         response: TutorResponse,
@@ -6841,10 +6937,19 @@ class LiveDcsTutorLoop:
             merged_reasons.append(latched_reason)
             response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
             return True
+        completion_missing_conditions, precondition_missing_conditions = (
+            self._split_completion_missing_conditions(accepted_step_id, accepted_missing_conditions)
+        )
+        self._record_final_evidence_precondition_metadata(
+            response,
+            precondition_missing_conditions=precondition_missing_conditions,
+            latest_vars=vars_map,
+            evidence_packet=evidence_packet,
+        )
         result = validate_final_evidence_consistency(
             accepted_step_id=accepted_step_id,
             accepted_overlay_targets=targets,
-            accepted_missing_conditions=accepted_missing_conditions,
+            accepted_missing_conditions=completion_missing_conditions,
             latest_vars=vars_map,
             evidence_packet=evidence_packet,
         )
@@ -6887,7 +6992,8 @@ class LiveDcsTutorLoop:
         latched_reason = self._four_down_latched_completion_conflict(context, step_id)
         if latched_reason is not None:
             return f"evidence_conflict:{latched_reason}"
-        if not missing_conditions and not include_completion_gate:
+        completion_missing_conditions, _ = self._split_completion_missing_conditions(step_id, missing_conditions)
+        if not completion_missing_conditions and not include_completion_gate:
             return None
         evidence_context = self._context_with_full_pack_gates(context)
         try:
@@ -6897,7 +7003,7 @@ class LiveDcsTutorLoop:
         result = validate_final_evidence_consistency(
             accepted_step_id=step_id,
             accepted_overlay_targets=[],
-            accepted_missing_conditions=missing_conditions,
+            accepted_missing_conditions=completion_missing_conditions,
             latest_vars=vars_map,
             evidence_packet=evidence_packet,
         )

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11229,6 +11229,65 @@ def test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture() -
     assert "vars.engine_crank_left_complete==true" not in _public_response_text(repaired)
 
 
+def test_live_help_fixture_311_keeps_s12_when_only_precondition_is_satisfied() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/c2a80099-8375-42a1-89eb-b09544b474e2.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+    vars_map = request.context["vars"]
+    assert vars_map["rpm_l_gte_60"] is True
+    assert vars_map["ins_mode"] == 0
+    assert vars_map["ins_mode_set"] is False
+    assert vars_map["ins_mode_cv_or_gnd"] is False
+    assert vars_map["ins_fast_align_complete"] is False
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S12"
+    assert repaired.metadata["next"]["step_id"] == "S12"
+    assert repaired.metadata["final_public_response"]["next"]["step_id"] == "S12"
+    assert repaired.metadata["final_overlay_targets"] == ["ins_mode_knob"]
+    assert [action["target"] for action in repaired.actions] == ["ins_mode_knob"]
+    assert repaired.metadata.get("final_evidence_consistency_repair_applied") is not True
+    assert repaired.metadata.get("rejected_missing_conditions", []) == []
+    assert repaired.metadata["final_evidence_consistency_precondition_satisfied"] is True
+    assert repaired.metadata["precondition_satisfied_conditions"] == ["vars.rpm_l_gte_60==true"]
+    assert "radar_mode_knob" not in repaired.metadata["final_overlay_targets"]
+    assert "completion_gate_already_satisfied:S12" not in repaired.metadata.get(
+        "harness_validation_reasons",
+        [],
+    )
+
+
+def test_final_evidence_split_uses_current_step_completion_predicates_only() -> None:
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(Observation()),
+        model=RecordingModel(),
+        action_executor=RecordingExecutor(),
+        session_id="sess-issue-311-completion-split",
+        rag_top_k=0,
+        lang="zh",
+    )
+    try:
+        completion, precondition = loop._split_completion_missing_conditions(
+            "S12",
+            [
+                "vars.rpm_l_gte_60==true",
+                "vars.ins_mode in [2,2]",
+                "vars.ins_fast_align_complete==true",
+                "vars.some_prior_step_gate==true",
+            ],
+        )
+    finally:
+        loop.close()
+
+    assert completion == [
+        "vars.ins_mode in [2,2]",
+        "vars.ins_fast_align_complete==true",
+    ]
+    assert precondition == ["vars.rpm_l_gte_60==true"]
+
+
 def test_live_help_fixture_315_repairs_unconfirmed_s08_tac_public_response() -> None:
     fixture = _load_live_help_fixture(
         "artifacts/live_fixtures/c2ddd0ad-eb91-416e-a3a8-be16816a9d49.fixture.json"


### PR DESCRIPTION
## Summary
- Limit final evidence consistency repair to current-step completion predicates only
- Record satisfied preconditions separately from completion-gate evidence
- Add c2a80099 replay fixture and S12 regression coverage for issue #311

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-issue311-related tests/test_live_dcs.py::test_live_help_fixture_311_replays_real_s09_comm1_complete_fixture tests/test_live_dcs.py::test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture tests/test_live_dcs.py::test_live_help_fixture_311_keeps_s12_when_only_precondition_is_satisfied tests/test_live_dcs.py::test_final_evidence_split_uses_current_step_completion_predicates_only tests/test_live_dcs.py::test_final_evidence_validator_rechecks_repaired_fallback_step tests/test_live_dcs.py::test_safe_fallback_overlay_rejects_missing_condition_satisfied_by_latest_telemetry

Fixes #311