### PR TITLE
Fix planner interaction wording rules

### DIFF
--- a/artifacts/live_fixtures/3de0e688-8bc4-4df1-b062-72f3134bc775.fixture.json
+++ b/artifacts/live_fixtures/3de0e688-8bc4-4df1-b062-72f3134bc775.fixture.json
@@ -1,0 +1,3333 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 3,
+      "telemetry_missing_source_count": 1,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 5,
+        "contradiction_count": 0,
+        "first_seq": 4826,
+        "frame_count": 20,
+        "latest_seq": 4845
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+      "source_observation_seq": 4845,
+      "source_observation_t_wall": 1779198382.0057023,
+      "telemetry_window_first_seq": 4826,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 4845,
+      "telemetry_window_latest_t_wall": 1779198382.0057023,
+      "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+    },
+    "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:64396",
+          "raw_delta_count": 1,
+          "seq": 4845
+        },
+        "observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41456
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 4845,
+          "t_wall": 1779198382.0057023,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": false,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 0,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 0.0,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 0,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 0,
+            "rpm_l_gte_25": false,
+            "rpm_l_gte_60": false,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 10,
+            "temp_r": 322,
+            "throttle_l_not_off": false,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": " 134.000",
+            "ufc_scratchpad_string_1_display": " 1",
+            "ufc_scratchpad_string_2_display": "--",
+            "vars_source_missing": [
+              "ins_fast_align_pressed"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T13:46:22.005702+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 5,
+      "contradiction_count": 0,
+      "first_seq": 4826,
+      "frame_count": 20,
+      "latest_seq": 4845
+    },
+    "vision": {
+      "frame_ids": [
+        "1779198382295_000234"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779198382295_000234",
+        "frame_ids": [
+          "1779198382295_000234"
+        ],
+        "frame_stale": false,
+        "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+        "observation_seq": 4845,
+        "observation_t_wall_ms": 1779198382006,
+        "observation_t_wall_s": 1779198382.0057023,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779198382295,
+            "channel": "composite_panel",
+            "frame_id": "1779198382295_000234",
+            "frame_seq": 234,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198382295_000234_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198382295_000234.png",
+            "sync_delta_ms": 67,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 67,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779198382295,
+          "channel": "composite_panel",
+          "frame_id": "1779198382295_000234",
+          "frame_seq": 234,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198382295_000234_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198382295_000234.png",
+          "sync_delta_ms": 67,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779198382228,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779198382295_000234"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "kind": "tutor_request",
+        "lineno": 5388,
+        "metadata": {
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 67,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S10",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S10",
+              "recent_ui_targets": [
+                "ufc_ent_button",
+                "ufc_comm1_channel_selector_rotate",
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "eng_crank_switch"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 3,
+              "telemetry_missing_source_count": 1,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 5,
+                "contradiction_count": 0,
+                "first_seq": 4826,
+                "frame_count": 20,
+                "latest_seq": 4845
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+              "source_observation_seq": 4845,
+              "source_observation_t_wall": 1779198382.0057023,
+              "telemetry_window_first_seq": 4826,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4845,
+              "telemetry_window_latest_t_wall": 1779198382.0057023,
+              "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 38.93446879639516,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_153",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 154,
+                "score": 34.98159536679122,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_153"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_142",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 143,
+                "score": 32.73748860454453,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_142"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_201",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 202,
+                "score": 29.556704359662675,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_201"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_46",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 47,
+                "score": 26.97209623444198,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_46"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.engine_crank_left_complete==true"
+                ],
+                "overlay_step_id": "S10",
+                "role": "candidate_not_authoritative",
+                "step_id": "S10"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 4845,
+                "source_status": "nominal",
+                "vars_source_missing_count": 1
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": false,
+                    "last_value": true,
+                    "latest_transition_age_s": 0.838,
+                    "transition_count": 1,
+                    "var": "comm1_freq_134_000"
+                  },
+                  {
+                    "first_value": 30500,
+                    "last_value": 13400,
+                    "latest_transition_age_s": 0.838,
+                    "transition_count": 1,
+                    "var": "comm1_freq_value"
+                  },
+                  {
+                    "first_value": false,
+                    "last_value": false,
+                    "latest_transition_age_s": 0.167,
+                    "transition_count": 2,
+                    "var": "ufc_ent_pressed"
+                  },
+                  {
+                    "first_value": " 134.000",
+                    "last_value": " 134.000",
+                    "latest_transition_age_s": 0.566,
+                    "transition_count": 2,
+                    "var": "ufc_scratchpad_number_display"
+                  },
+                  {
+                    "first_value": "['ins_fast_align_pressed']",
+                    "last_value": "['ins_fast_align_pressed']",
+                    "latest_transition_age_s": 0.566,
+                    "transition_count": 2,
+                    "var": "vars_source_missing"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 4826,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4845,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 4845,
+                "latest_t_wall": 1779198382.0057023,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed"
+                ],
+                "window_duration_s": 1.285
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779198382295_000234",
+              "frame_ids": [
+                "1779198382295_000234"
+              ],
+              "frame_stale": false,
+              "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+              "observation_seq": 4845,
+              "observation_t_wall_ms": 1779198382006,
+              "observation_t_wall_s": 1779198382.0057023,
+              "status": "partial",
+              "sync_delta_ms": 67,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779198382228,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198382295_000234"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 3,
+              "telemetry_missing_source_count": 1,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 5,
+                "contradiction_count": 0,
+                "first_seq": 4826,
+                "frame_count": 20,
+                "latest_seq": 4845
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+              "source_observation_seq": 4845,
+              "source_observation_t_wall": 1779198382.0057023,
+              "telemetry_window_first_seq": 4826,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4845,
+              "telemetry_window_latest_t_wall": 1779198382.0057023,
+              "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "frame_id": "1779198382295_000234",
+            "fused_missing_conditions": [
+              "vars.engine_crank_left_complete==true"
+            ],
+            "fused_step_id": "S10",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN_153",
+              "DCS FA-18C Early Access Guide EN_142",
+              "DCS FA-18C Early Access Guide EN_201",
+              "DCS FA-18C Early Access Guide EN_46"
+            ],
+            "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+            "prompt_tokens_est": 5487,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "source_chunk_refs": [
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_153",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_142",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_201",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_46"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 67,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198382295_000234"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779198382295_000234"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+          "request_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "timestamp": "2026-05-19T13:46:22.760142+00:00",
+          "version": "v1"
+        },
+        "related_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "vision_refs": [
+          "1779198382295_000234"
+        ]
+      },
+      {
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "kind": "overlay_requested",
+        "lineno": 5389,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 67,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "0d87f76b-b67f-479d-8362-059e0b932527",
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 67,
+          "target": "pnt_111",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "kind": "overlay_requested",
+        "lineno": 5390,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 67,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "000140d6-3f67-44a5-a8dc-697c3b4b5717",
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 67,
+          "target": "pnt_113",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "kind": "overlay_requested",
+        "lineno": 5391,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 67,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "28832c14-c6f7-4269-9774-ce57bd852fbd",
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 67,
+          "target": "pnt_114",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "kind": "overlay_requested",
+        "lineno": 5392,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 67,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "3e3dd5fb-a306-4580-83b1-d09da06d2bb5",
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 67,
+          "target": "pnt_120",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "kind": "overlay_requested",
+        "lineno": 5393,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 67,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "cb4fc6d6-ea50-430b-807e-fbb9c7e2d6eb",
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 67,
+          "target": "pnt_377",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "kind": "tutor_response",
+        "lineno": 5394,
+        "metadata": {
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 67,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_377",
+              "evidence_refs": [
+                "GATES.S10.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "eng_crank_switch"
+              ],
+              "frame_id": "1779198382295_000234",
+              "fused_missing_conditions": [
+                "vars.engine_crank_left_complete==true"
+              ],
+              "fused_step_id": "S10",
+              "generation_mode": "model",
+              "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 67,
+              "target": "eng_crank_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198382295_000234"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+          ],
+          "in_reply_to": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "message": "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。",
+          "metadata": {
+            "allowed_evidence_ref_count": 125,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "3f5a8bf9-7a57-460e-b444-29453a4742f4",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "ufc_ent_button",
+                "ufc_comm1_channel_selector_rotate",
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S10"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+              "source_observation_seq": 4845,
+              "source_observation_t_wall": 1779198382.0057023,
+              "telemetry_window_first_seq": 4826,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4845,
+              "telemetry_window_latest_t_wall": 1779198382.0057023,
+              "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "overlay_step_id": "S10",
+              "source": "model",
+              "step_id": "S10",
+              "targets": [
+                "eng_crank_switch"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "model",
+            "final_overlay_targets": [
+              "eng_crank_switch"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_377",
+                  "evidence_refs": [
+                    "GATES.S10.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "eng_crank_switch"
+                  ],
+                  "frame_id": "1779198382295_000234",
+                  "fused_missing_conditions": [
+                    "vars.engine_crank_left_complete==true"
+                  ],
+                  "fused_step_id": "S10",
+                  "generation_mode": "model",
+                  "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "model",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 67,
+                  "target": "eng_crank_switch",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779198382295_000234"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+              ],
+              "message": "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。",
+              "next": {
+                "step_id": "S10"
+              }
+            },
+            "frame_id": "1779198382295_000234",
+            "fused_missing_conditions": [
+              "vars.engine_crank_left_complete==true"
+            ],
+            "fused_step_id": "S10",
+            "generation_mode": "model",
+            "generation_prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+            "generation_prompt_tokens_est": 5487,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S10",
+              "source": "model",
+              "step_id": "S10",
+              "targets": [
+                "eng_crank_switch"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": [
+                    "GATES.S10.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": [
+                    "GATES.S10.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S11",
+                  "supporting_evidence_refs": [
+                    "GATES.S11.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "GATES.S13.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.5,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "recent_action",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+                    "RECENT_ACTIONS.ufc_ent_button"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "eng_crank_switch"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S10",
+                "supporting_evidence_refs": [
+                  "GATES.S10.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 3,
+                "telemetry_missing_source_count": 1,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 5,
+                  "contradiction_count": 0,
+                  "first_seq": 4826,
+                  "frame_count": 20,
+                  "latest_seq": 4845
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+                "source_observation_seq": 4845,
+                "source_observation_t_wall": 1779198382.0057023,
+                "telemetry_window_first_seq": 4826,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 4845,
+                "telemetry_window_latest_t_wall": 1779198382.0057023,
+                "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "overlay_step_id": "S10",
+                "source": "model",
+                "step_id": "S10",
+                "targets": [
+                  "eng_crank_switch"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "eng_crank_switch"
+              ],
+              "message_category": "model",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S10.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "eng_crank_switch"
+                ],
+                "status": "ok",
+                "step_id": "S10"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": false,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": null
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+                "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779198382295_000234"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 67,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [],
+            "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+              ],
+              "next": {
+                "step_id": "S10"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S10.completion",
+                    "target": "eng_crank_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "eng_crank_switch"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+              ],
+              "next": {
+                "step_id": "S10"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S10.completion",
+                    "target": "eng_crank_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "eng_crank_switch"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4169,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "model",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S10"
+            },
+            "model_raw_explanations": [
+              "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S10"
+              },
+              "explanations": [
+                "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+              ],
+              "next": {
+                "step_id": "S10"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S10.completion",
+                    "target": "eng_crank_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "eng_crank_switch"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S10"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779198382295_000234"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779198382295_000234",
+            "next": {
+              "step_id": "S10"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5565,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.engine_crank_left_complete",
+                "GATES.S10.completion",
+                "GATES.S10.precondition",
+                "GATES.S11.completion",
+                "GATES.S11.precondition",
+                "GATES.S12.completion",
+                "GATES.S12.precondition",
+                "GATES.S13.completion",
+                "GATES.S13.precondition",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_153",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_142",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_201",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_46"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 18,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": null,
+              "prompt_chars": 21945,
+              "prompt_tokens_est": 5487,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_startup_master_1",
+                "DCS FA-18C Early Access Guide EN_153",
+                "DCS FA-18C Early Access Guide EN_142",
+                "DCS FA-18C Early Access Guide EN_201",
+                "DCS FA-18C Early Access Guide EN_46"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+            "prompt_tokens_est": 5487,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+            "request_prompt_tokens_est": 5487,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 125,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S10"
+              },
+              "next": {
+                "step_id": "S10"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+              "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+            },
+            "state_key": "9b45dd2f5893da0fdc3bfbc35b828145f3725478e8a04ed2f8cc8b6dd6b47a93",
+            "sync_delta_ms": 67,
+            "validator_rejected": false,
+            "vision": {
+              "frame_id": "1779198382295_000234",
+              "frame_ids": [
+                "1779198382295_000234"
+              ],
+              "frame_stale": false,
+              "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+              "observation_seq": 4845,
+              "observation_t_wall_ms": 1779198382006,
+              "observation_t_wall_s": 1779198382.0057023,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779198382295,
+                  "channel": "composite_panel",
+                  "frame_id": "1779198382295_000234",
+                  "frame_seq": 234,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198382295_000234_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198382295_000234.png",
+                  "sync_delta_ms": 67,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 67,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779198382295,
+                "channel": "composite_panel",
+                "frame_id": "1779198382295_000234",
+                "frame_seq": 234,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198382295_000234_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198382295_000234.png",
+                "sync_delta_ms": 67,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779198382228,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S09"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198382295_000234"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779198382295_000234"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "7c0b30a6-fa03-44fb-888a-9ac55946862d",
+          "status": "ok",
+          "timestamp": "2026-05-19T13:46:26.930385+00:00",
+          "version": "v1"
+        },
+        "related_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "vision_refs": [
+          "1779198382295_000234"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S10",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S10",
+          "recent_ui_targets": [
+            "ufc_ent_button",
+            "ufc_comm1_channel_selector_rotate",
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "eng_crank_switch"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 3,
+          "telemetry_missing_source_count": 1,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 5,
+            "contradiction_count": 0,
+            "first_seq": 4826,
+            "frame_count": 20,
+            "latest_seq": 4845
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+          "source_observation_seq": 4845,
+          "source_observation_t_wall": 1779198382.0057023,
+          "telemetry_window_first_seq": 4826,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4845,
+          "telemetry_window_latest_t_wall": 1779198382.0057023,
+          "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 38.93446879639516,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_153",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 154,
+            "score": 34.98159536679122,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_153"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_142",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 143,
+            "score": 32.73748860454453,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_142"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_201",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 202,
+            "score": 29.556704359662675,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_201"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_46",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 47,
+            "score": 26.97209623444198,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_46"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.engine_crank_left_complete==true"
+            ],
+            "overlay_step_id": "S10",
+            "role": "candidate_not_authoritative",
+            "step_id": "S10"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 4845,
+            "source_status": "nominal",
+            "vars_source_missing_count": 1
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": false,
+                "last_value": true,
+                "latest_transition_age_s": 0.838,
+                "transition_count": 1,
+                "var": "comm1_freq_134_000"
+              },
+              {
+                "first_value": 30500,
+                "last_value": 13400,
+                "latest_transition_age_s": 0.838,
+                "transition_count": 1,
+                "var": "comm1_freq_value"
+              },
+              {
+                "first_value": false,
+                "last_value": false,
+                "latest_transition_age_s": 0.167,
+                "transition_count": 2,
+                "var": "ufc_ent_pressed"
+              },
+              {
+                "first_value": " 134.000",
+                "last_value": " 134.000",
+                "latest_transition_age_s": 0.566,
+                "transition_count": 2,
+                "var": "ufc_scratchpad_number_display"
+              },
+              {
+                "first_value": "['ins_fast_align_pressed']",
+                "last_value": "['ins_fast_align_pressed']",
+                "latest_transition_age_s": 0.566,
+                "transition_count": 2,
+                "var": "vars_source_missing"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 4826,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4845,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 4845,
+            "latest_t_wall": 1779198382.0057023,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed"
+            ],
+            "window_duration_s": 1.285
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779198382295_000234",
+          "frame_ids": [
+            "1779198382295_000234"
+          ],
+          "frame_stale": false,
+          "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+          "observation_seq": 4845,
+          "observation_t_wall_ms": 1779198382006,
+          "observation_t_wall_s": 1779198382.0057023,
+          "status": "partial",
+          "sync_delta_ms": 67,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779198382228,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198382295_000234"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 3,
+          "telemetry_missing_source_count": 1,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 5,
+            "contradiction_count": 0,
+            "first_seq": 4826,
+            "frame_count": 20,
+            "latest_seq": 4845
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+          "source_observation_seq": 4845,
+          "source_observation_t_wall": 1779198382.0057023,
+          "telemetry_window_first_seq": 4826,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4845,
+          "telemetry_window_latest_t_wall": 1779198382.0057023,
+          "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "frame_id": "1779198382295_000234",
+        "fused_missing_conditions": [
+          "vars.engine_crank_left_complete==true"
+        ],
+        "fused_step_id": "S10",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN_153",
+          "DCS FA-18C Early Access Guide EN_142",
+          "DCS FA-18C Early Access Guide EN_201",
+          "DCS FA-18C Early Access Guide EN_46"
+        ],
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+        "prompt_tokens_est": 5487,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "source_chunk_refs": [
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_153",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_142",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_201",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_46"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 67,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198382295_000234"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779198382295_000234"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+      "request_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+      "timestamp": "2026-05-19T13:46:22.760142+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_377",
+          "evidence_refs": [
+            "GATES.S10.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "frame_id": "1779198382295_000234",
+          "fused_missing_conditions": [
+            "vars.engine_crank_left_complete==true"
+          ],
+          "fused_step_id": "S10",
+          "generation_mode": "model",
+          "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 67,
+          "target": "eng_crank_switch",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+      ],
+      "in_reply_to": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+      "message": "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。",
+      "metadata": {
+        "allowed_evidence_ref_count": 125,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "3f5a8bf9-7a57-460e-b444-29453a4742f4",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "ufc_ent_button",
+            "ufc_comm1_channel_selector_rotate",
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S10"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+          "source_observation_seq": 4845,
+          "source_observation_t_wall": 1779198382.0057023,
+          "telemetry_window_first_seq": 4826,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4845,
+          "telemetry_window_latest_t_wall": 1779198382.0057023,
+          "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "overlay_step_id": "S10",
+          "source": "model",
+          "step_id": "S10",
+          "targets": [
+            "eng_crank_switch"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "model",
+        "final_overlay_targets": [
+          "eng_crank_switch"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_377",
+              "evidence_refs": [
+                "GATES.S10.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "eng_crank_switch"
+              ],
+              "frame_id": "1779198382295_000234",
+              "fused_missing_conditions": [
+                "vars.engine_crank_left_complete==true"
+              ],
+              "fused_step_id": "S10",
+              "generation_mode": "model",
+              "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 67,
+              "target": "eng_crank_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198382295_000234"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+          ],
+          "message": "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。",
+          "next": {
+            "step_id": "S10"
+          }
+        },
+        "frame_id": "1779198382295_000234",
+        "fused_missing_conditions": [
+          "vars.engine_crank_left_complete==true"
+        ],
+        "fused_step_id": "S10",
+        "generation_mode": "model",
+        "generation_prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+        "generation_prompt_tokens_est": 5487,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S10",
+          "source": "model",
+          "step_id": "S10",
+          "targets": [
+            "eng_crank_switch"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S10",
+              "supporting_evidence_refs": [
+                "GATES.S10.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S10",
+              "supporting_evidence_refs": [
+                "GATES.S10.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S11",
+              "supporting_evidence_refs": [
+                "GATES.S11.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "GATES.S13.completion"
+              ]
+            },
+            {
+              "confidence": 0.5,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "recent_action",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+                "RECENT_ACTIONS.ufc_ent_button"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "eng_crank_switch"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S10",
+            "supporting_evidence_refs": [
+              "GATES.S10.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 3,
+            "telemetry_missing_source_count": 1,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 5,
+              "contradiction_count": 0,
+              "first_seq": 4826,
+              "frame_count": 20,
+              "latest_seq": 4845
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+            "source_observation_seq": 4845,
+            "source_observation_t_wall": 1779198382.0057023,
+            "telemetry_window_first_seq": 4826,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 4845,
+            "telemetry_window_latest_t_wall": 1779198382.0057023,
+            "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "overlay_step_id": "S10",
+            "source": "model",
+            "step_id": "S10",
+            "targets": [
+              "eng_crank_switch"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "eng_crank_switch"
+          ],
+          "message_category": "model",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S10.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "eng_crank_switch"
+            ],
+            "status": "ok",
+            "step_id": "S10"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": false,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": null
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+            "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779198382295_000234"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 67,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [],
+        "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+          ],
+          "next": {
+            "step_id": "S10"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S10.completion",
+                "target": "eng_crank_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "eng_crank_switch"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+          ],
+          "next": {
+            "step_id": "S10"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S10.completion",
+                "target": "eng_crank_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "eng_crank_switch"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4169,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "model",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S10"
+        },
+        "model_raw_explanations": [
+          "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S10"
+          },
+          "explanations": [
+            "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+          ],
+          "next": {
+            "step_id": "S10"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S10.completion",
+                "target": "eng_crank_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "eng_crank_switch"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S10"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779198382295_000234"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779198382295_000234",
+        "next": {
+          "step_id": "S10"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5565,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.engine_crank_left_complete",
+            "GATES.S10.completion",
+            "GATES.S10.precondition",
+            "GATES.S11.completion",
+            "GATES.S11.precondition",
+            "GATES.S12.completion",
+            "GATES.S12.precondition",
+            "GATES.S13.completion",
+            "GATES.S13.precondition",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_153",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_142",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_201",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_46"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 18,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": null,
+          "prompt_chars": 21945,
+          "prompt_tokens_est": 5487,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_startup_master_1",
+            "DCS FA-18C Early Access Guide EN_153",
+            "DCS FA-18C Early Access Guide EN_142",
+            "DCS FA-18C Early Access Guide EN_201",
+            "DCS FA-18C Early Access Guide EN_46"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+        "prompt_tokens_est": 5487,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "4c2c0787599f823ec7bd90bd6f3d97d2dff3341aae56327bed080bae8709b8b0",
+        "request_prompt_tokens_est": 5487,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 125,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S10"
+          },
+          "next": {
+            "step_id": "S10"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+          "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+        },
+        "state_key": "9b45dd2f5893da0fdc3bfbc35b828145f3725478e8a04ed2f8cc8b6dd6b47a93",
+        "sync_delta_ms": 67,
+        "validator_rejected": false,
+        "vision": {
+          "frame_id": "1779198382295_000234",
+          "frame_ids": [
+            "1779198382295_000234"
+          ],
+          "frame_stale": false,
+          "observation_ref": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+          "observation_seq": 4845,
+          "observation_t_wall_ms": 1779198382006,
+          "observation_t_wall_s": 1779198382.0057023,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779198382295,
+              "channel": "composite_panel",
+              "frame_id": "1779198382295_000234",
+              "frame_seq": 234,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198382295_000234_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198382295_000234.png",
+              "sync_delta_ms": 67,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 67,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779198382295,
+            "channel": "composite_panel",
+            "frame_id": "1779198382295_000234",
+            "frame_seq": 234,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198382295_000234_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198382295_000234.png",
+            "sync_delta_ms": 67,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779198382228,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S09"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198382295_000234"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779198382295_000234"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "7c0b30a6-fa03-44fb-888a-9ac55946862d",
+      "status": "ok",
+      "timestamp": "2026-05-19T13:46:26.930385+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S10",
+    "expected_overlay_target_ids": [
+      "eng_crank_switch"
+    ],
+    "final_response_source": "model",
+    "llm_decision_status": "accepted",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S11",
+        "supporting_evidence_refs": [
+          "GATES.S11.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      },
+      {
+        "confidence": 0.5,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "recent_action",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+          "RECENT_ACTIONS.ufc_ent_button"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+      "overlay_step_id": "S10",
+      "source": "model",
+      "step_id": "S10",
+      "targets": [
+        "eng_crank_switch"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S10.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "eng_crank_switch"
+      ],
+      "status": "ok",
+      "step_id": "S10"
+    },
+    "repair_result": {
+      "applied": false,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": null
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S10",
+          "supporting_evidence_refs": [
+            "GATES.S10.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S10",
+          "supporting_evidence_refs": [
+            "GATES.S10.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S11",
+          "supporting_evidence_refs": [
+            "GATES.S11.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "GATES.S13.completion"
+          ]
+        },
+        {
+          "confidence": 0.5,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "recent_action",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+            "RECENT_ACTIONS.ufc_ent_button"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 3,
+        "telemetry_missing_source_count": 1,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 5,
+          "contradiction_count": 0,
+          "first_seq": 4826,
+          "frame_count": 20,
+          "latest_seq": 4845
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "final_decision_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "model_request_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "source_observation_id": "5d5923c9-0c3f-437e-b3eb-4c177792e6d3",
+        "source_observation_seq": 4845,
+        "source_observation_t_wall": 1779198382.0057023,
+        "telemetry_window_first_seq": 4826,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 4845,
+        "telemetry_window_latest_t_wall": 1779198382.0057023,
+        "validator_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "overlay_step_id": "S10",
+        "source": "model",
+        "step_id": "S10",
+        "targets": [
+          "eng_crank_switch"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "eng_crank_switch"
+      ],
+      "message_category": "model",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S10.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "eng_crank_switch"
+        ],
+        "status": "ok",
+        "step_id": "S10"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": false,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": null
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "final_decision": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "model_request": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6",
+        "validator": "3aa913998fe65b7162d469f60a7ad6f4f0e6e66e12e7e5027120aa1bce1575d6"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779198382295_000234"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 67,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S10"
+      },
+      "explanations": [
+        "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+      ],
+      "next": {
+        "step_id": "S10"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S10.completion",
+            "target": "eng_crank_switch",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "eng_crank_switch"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S10"
+      },
+      "explanations": [
+        "当前处于 S10 步骤，左发启动尚未开始。请将 eng_crank_switch 拨到 R 位置（右键点击）以启动左发。"
+      ],
+      "next": {
+        "step_id": "S10"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S10.completion",
+            "target": "eng_crank_switch",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "eng_crank_switch"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "3de0e688-8bc4-4df1-b062-72f3134bc775",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 14472,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_134129.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/5a7d5df7-2f08-4321-9a4a-6858131b4e6e.fixture.json
+++ b/artifacts/live_fixtures/5a7d5df7-2f08-4321-9a4a-6858131b4e6e.fixture.json
@@ -1,0 +1,3216 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 5,
+      "conflicts": [],
+      "recent_action_count": 1,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 12732,
+        "frame_count": 20,
+        "latest_seq": 12751
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+      "source_observation_seq": 12751,
+      "source_observation_t_wall": 1779198861.827461,
+      "telemetry_window_first_seq": 12732,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 12751,
+      "telemetry_window_latest_t_wall": 1779198861.827461,
+      "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+    },
+    "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 1,
+          "from_addr": "192.168.0.105:64396",
+          "raw_delta_count": 2,
+          "seq": 12751
+        },
+        "observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "IFEI_BINGO"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {
+                "blacklist": 1
+              },
+              "dropped_total": 1
+            },
+            "raw_delta_count": 2,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "IFEI_BINGO",
+                "ui_targets": [],
+                "value": " 1000"
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 12751,
+          "t_wall": 1779198861.827461,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": true,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": true,
+            "pitot_heat_on": true,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 310,
+            "temp_r": 322,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T13:54:21.827461+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 12732,
+      "frame_count": 20,
+      "latest_seq": 12751
+    },
+    "vision": {
+      "frame_ids": [
+        "1779198862202_000263"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779198862202_000263",
+        "frame_ids": [
+          "1779198862202_000263"
+        ],
+        "frame_stale": false,
+        "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+        "observation_seq": 12751,
+        "observation_t_wall_ms": 1779198861827,
+        "observation_t_wall_s": 1779198861.827461,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779198862202,
+            "channel": "composite_panel",
+            "frame_id": "1779198862202_000263",
+            "frame_seq": 263,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198862202_000263_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198862202_000263.png",
+            "sync_delta_ms": 71,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 71,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779198862202,
+          "channel": "composite_panel",
+          "frame_id": "1779198862202_000263",
+          "frame_seq": 263,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198862202_000263_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198862202_000263.png",
+          "sync_delta_ms": 71,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779198862131,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779198862202_000263"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "kind": "tutor_request",
+        "lineno": 13431,
+        "metadata": {
+          "frame_id": "1779198862202_000263",
+          "fused_missing_conditions": [
+            "vars.bingo_fuel_set==true"
+          ],
+          "fused_step_id": "S29",
+          "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 71,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 1,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S29",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S29",
+              "recent_ui_targets": [
+                "ifei_up_button"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 5,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 12732,
+                "frame_count": 20,
+                "latest_seq": 12751
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+              "source_observation_seq": 12751,
+              "source_observation_t_wall": 1779198861.827461,
+              "telemetry_window_first_seq": 12732,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12751,
+              "telemetry_window_latest_t_wall": 1779198861.827461,
+              "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_40",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 41,
+                "score": 25.7540966642691,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_40"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 20.495739034746354,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_8",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "score": 18.650519398830408,
+                "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "snippet_id": "Appendix - Training Task Syllabus_8"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_1",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "1. Scenario Definition",
+                "score": 18.052490795031357,
+                "section": "1. Scenario Definition",
+                "snippet_id": "Appendix - Training Task Syllabus_1"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_10",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "3. Step Criticality",
+                "score": 16.87251127238796,
+                "section": "3. Step Criticality",
+                "snippet_id": "fa18c_error_coding_guide_10"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.bingo_fuel_set==true"
+                ],
+                "overlay_step_id": "S29",
+                "role": "candidate_not_authoritative",
+                "step_id": "S29"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 12751,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 12732,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12751,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 12751,
+                "latest_t_wall": 1779198861.827461,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "pitot_heat_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.429
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779198862202_000263",
+              "frame_ids": [
+                "1779198862202_000263"
+              ],
+              "frame_stale": false,
+              "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+              "observation_seq": 12751,
+              "observation_t_wall_ms": 1779198861827,
+              "observation_t_wall_s": 1779198861.827461,
+              "status": "partial",
+              "sync_delta_ms": 71,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779198862131,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198862202_000263"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 5,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 12732,
+                "frame_count": 20,
+                "latest_seq": 12751
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+              "source_observation_seq": 12751,
+              "source_observation_t_wall": 1779198861.827461,
+              "telemetry_window_first_seq": 12732,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12751,
+              "telemetry_window_latest_t_wall": 1779198861.827461,
+              "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "frame_id": "1779198862202_000263",
+            "fused_missing_conditions": [
+              "vars.bingo_fuel_set==true"
+            ],
+            "fused_step_id": "S29",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "DCS FA-18C Early Access Guide EN_40",
+              "fa18c_startup_master_1",
+              "Appendix - Training Task Syllabus_8",
+              "Appendix - Training Task Syllabus_1",
+              "fa18c_error_coding_guide_10"
+            ],
+            "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+            "prompt_tokens_est": 5601,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "source_chunk_refs": [
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_40",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_10"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 71,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198862202_000263"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779198862202_000263"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+          "request_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "timestamp": "2026-05-19T13:54:22.643425+00:00",
+          "version": "v1"
+        },
+        "related_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "vision_refs": [
+          "1779198862202_000263"
+        ]
+      },
+      {
+        "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "kind": "overlay_requested",
+        "lineno": 13432,
+        "metadata": {
+          "final_overlay_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "frame_id": "1779198862202_000263",
+          "fused_missing_conditions": [
+            "vars.bingo_fuel_set==true"
+          ],
+          "fused_step_id": "S29",
+          "generation_mode": "model",
+          "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 71,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "a7fb7115-9270-40db-861e-922835bc7c83",
+          "final_overlay_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "frame_id": "1779198862202_000263",
+          "fused_missing_conditions": [
+            "vars.bingo_fuel_set==true"
+          ],
+          "fused_step_id": "S29",
+          "generation_mode": "model",
+          "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 71,
+          "target": "pnt_170",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "kind": "overlay_requested",
+        "lineno": 13433,
+        "metadata": {
+          "final_overlay_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "frame_id": "1779198862202_000263",
+          "fused_missing_conditions": [
+            "vars.bingo_fuel_set==true"
+          ],
+          "fused_step_id": "S29",
+          "generation_mode": "model",
+          "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 71,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "7a669403-5c98-49a5-8774-488025176bed",
+          "final_overlay_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "frame_id": "1779198862202_000263",
+          "fused_missing_conditions": [
+            "vars.bingo_fuel_set==true"
+          ],
+          "fused_step_id": "S29",
+          "generation_mode": "model",
+          "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 71,
+          "target": "pnt_291",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "kind": "tutor_response",
+        "lineno": 13434,
+        "metadata": {
+          "final_overlay_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "frame_id": "1779198862202_000263",
+          "fused_missing_conditions": [
+            "vars.bingo_fuel_set==true"
+          ],
+          "fused_step_id": "S29",
+          "generation_mode": "model",
+          "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 71,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_291",
+              "evidence_refs": [
+                "GATES.S31.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "radar_altimeter_bug_knob"
+              ],
+              "frame_id": "1779198862202_000263",
+              "fused_missing_conditions": [
+                "vars.bingo_fuel_set==true"
+              ],
+              "fused_step_id": "S29",
+              "generation_mode": "model",
+              "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 71,
+              "target": "radar_altimeter_bug_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198862202_000263"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+          ],
+          "in_reply_to": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "message": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。",
+          "metadata": {
+            "allowed_evidence_ref_count": 121,
+            "completion_conflict_original_actions": [
+              {
+                "element_id": "pnt_170",
+                "evidence_refs": [
+                  "VARS.bingo_fuel_set"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "ifei_up_button",
+                "type": "overlay"
+              }
+            ],
+            "completion_conflict_original_explanations": [
+              "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+            ],
+            "completion_conflict_original_message": "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。",
+            "completion_conflict_original_next": {
+              "step_id": "S29"
+            },
+            "completion_conflict_overlay_cleared": true,
+            "completion_conflict_rewritten": true,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "3a3dc2ab-79b4-495f-b6e8-1e3fdbdfa145",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+            },
+            "delta_dropped_count": 1,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "ifei_up_button"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S31"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+              "source_observation_seq": 12751,
+              "source_observation_t_wall": 1779198861.827461,
+              "telemetry_window_first_seq": 12732,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12751,
+              "telemetry_window_latest_t_wall": 1779198861.827461,
+              "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "overlay_step_id": "S31",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S31",
+              "targets": [
+                "radar_altimeter_bug_knob"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 121,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S31"
+              },
+              "next": {
+                "step_id": "S31"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S31",
+            "final_evidence_consistency_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+              "completion_gate_already_satisfied:S29"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "radar_altimeter_bug_knob"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_291",
+                  "evidence_refs": [
+                    "GATES.S31.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "radar_altimeter_bug_knob"
+                  ],
+                  "frame_id": "1779198862202_000263",
+                  "fused_missing_conditions": [
+                    "vars.bingo_fuel_set==true"
+                  ],
+                  "fused_step_id": "S29",
+                  "generation_mode": "model",
+                  "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "completion_conflict_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 71,
+                  "target": "radar_altimeter_bug_knob",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779198862202_000263"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S31"
+              },
+              "explanations": [
+                "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+              ],
+              "message": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。",
+              "next": {
+                "step_id": "S31"
+              }
+            },
+            "frame_id": "1779198862202_000263",
+            "fused_missing_conditions": [
+              "vars.bingo_fuel_set==true"
+            ],
+            "fused_step_id": "S29",
+            "generation_mode": "model",
+            "generation_prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+            "generation_prompt_tokens_est": 5601,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S31",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S31",
+              "targets": [
+                "radar_altimeter_bug_knob"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button",
+                    "ifei_down_button"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_altimeter_bug_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S31",
+                  "supporting_evidence_refs": [
+                    "GATES.S31.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "standby_attitude_cage_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S32",
+                  "supporting_evidence_refs": [
+                    "GATES.S32.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.5,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button"
+                  ],
+                  "role": "candidate",
+                  "source": "recent_action",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": [
+                    "RECENT_ACTIONS.ifei_up_button"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.66,
+                "proposed_next_action_target_ids": [
+                  "radar_altimeter_bug_knob"
+                ],
+                "role": "candidate",
+                "source": "gate_blocker",
+                "step_id": "S31",
+                "supporting_evidence_refs": [
+                  "GATES.S31.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 5,
+                "conflicts": [],
+                "recent_action_count": 1,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 12732,
+                  "frame_count": 20,
+                  "latest_seq": 12751
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+                "source_observation_seq": 12751,
+                "source_observation_t_wall": 1779198861.827461,
+                "telemetry_window_first_seq": 12732,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 12751,
+                "telemetry_window_latest_t_wall": 1779198861.827461,
+                "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "overlay_step_id": "S31",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S31",
+                "targets": [
+                  "radar_altimeter_bug_knob"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "radar_altimeter_bug_knob"
+              ],
+              "message_category": "completion_conflict_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "VARS.bingo_fuel_set"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "ifei_up_button"
+                ],
+                "status": "ok",
+                "step_id": "S29"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S29"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+                "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+                  "completion_gate_already_satisfied:S29"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S29"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779198862202_000263"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 71,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+              "completion_gate_already_satisfied:S29"
+            ],
+            "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S31"
+              },
+              "explanations": [
+                "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+              ],
+              "next": {
+                "step_id": "S31"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S31.completion",
+                    "target": "radar_altimeter_bug_knob",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "radar_altimeter_bug_knob"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S29"
+              },
+              "explanations": [
+                "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+              ],
+              "next": {
+                "step_id": "S29"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.bingo_fuel_set",
+                    "target": "ifei_up_button",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ifei_up_button"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 5162,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "completion_conflict_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S29"
+            },
+            "model_raw_explanations": [
+              "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S29"
+              },
+              "explanations": [
+                "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+              ],
+              "next": {
+                "step_id": "S29"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.bingo_fuel_set",
+                    "target": "ifei_up_button",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ifei_up_button"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S29"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779198862202_000263"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779198862202_000263",
+            "next": {
+              "step_id": "S31"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5548,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.engine_crank_left",
+                "GATES.S01.completion",
+                "GATES.S20.completion",
+                "GATES.S22.completion",
+                "GATES.S25.completion",
+                "GATES.S29.completion",
+                "GATES.S29.precondition",
+                "GATES.S31.completion",
+                "GATES.S32.completion",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_40",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_1",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_10"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "ifei_up_button",
+              "prompt_chars": 22402,
+              "prompt_tokens_est": 5601,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "DCS FA-18C Early Access Guide EN_40",
+                "fa18c_startup_master_1",
+                "Appendix - Training Task Syllabus_8",
+                "Appendix - Training Task Syllabus_1",
+                "fa18c_error_coding_guide_10"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+            "prompt_tokens_est": 5601,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.bingo_fuel_set==true"
+            ],
+            "rejected_model_step_id": "S29",
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+            "request_prompt_tokens_est": 5601,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 121,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S29"
+              },
+              "next": {
+                "step_id": "S29"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+              "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+            },
+            "state_key": "eb9c117d6afc4065705ad07f192ae696135d3a6be466094a26de597fb51aad51",
+            "sync_delta_ms": 71,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779198862202_000263",
+              "frame_ids": [
+                "1779198862202_000263"
+              ],
+              "frame_stale": false,
+              "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+              "observation_seq": 12751,
+              "observation_t_wall_ms": 1779198861827,
+              "observation_t_wall_s": 1779198861.827461,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779198862202,
+                  "channel": "composite_panel",
+                  "frame_id": "1779198862202_000263",
+                  "frame_seq": 263,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198862202_000263_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198862202_000263.png",
+                  "sync_delta_ms": 71,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 71,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779198862202,
+                "channel": "composite_panel",
+                "frame_id": "1779198862202_000263",
+                "frame_seq": 263,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198862202_000263_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198862202_000263.png",
+                "sync_delta_ms": 71,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779198862131,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S29"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198862202_000263"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779198862202_000263"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "ef186073-34a3-4def-9116-26ad10370eb1",
+          "status": "ok",
+          "timestamp": "2026-05-19T13:54:27.807579+00:00",
+          "version": "v1"
+        },
+        "related_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "vision_refs": [
+          "1779198862202_000263"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 1,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S29",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S29",
+          "recent_ui_targets": [
+            "ifei_up_button"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 5,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 12732,
+            "frame_count": 20,
+            "latest_seq": 12751
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+          "source_observation_seq": 12751,
+          "source_observation_t_wall": 1779198861.827461,
+          "telemetry_window_first_seq": 12732,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12751,
+          "telemetry_window_latest_t_wall": 1779198861.827461,
+          "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_40",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 41,
+            "score": 25.7540966642691,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_40"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 20.495739034746354,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_8",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "score": 18.650519398830408,
+            "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "snippet_id": "Appendix - Training Task Syllabus_8"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_1",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "1. Scenario Definition",
+            "score": 18.052490795031357,
+            "section": "1. Scenario Definition",
+            "snippet_id": "Appendix - Training Task Syllabus_1"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_10",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "3. Step Criticality",
+            "score": 16.87251127238796,
+            "section": "3. Step Criticality",
+            "snippet_id": "fa18c_error_coding_guide_10"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.bingo_fuel_set==true"
+            ],
+            "overlay_step_id": "S29",
+            "role": "candidate_not_authoritative",
+            "step_id": "S29"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 12751,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 12732,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12751,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 12751,
+            "latest_t_wall": 1779198861.827461,
+            "stable_false_vars": [
+              "fcs_bit_switch_up"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "pitot_heat_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.429
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779198862202_000263",
+          "frame_ids": [
+            "1779198862202_000263"
+          ],
+          "frame_stale": false,
+          "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+          "observation_seq": 12751,
+          "observation_t_wall_ms": 1779198861827,
+          "observation_t_wall_s": 1779198861.827461,
+          "status": "partial",
+          "sync_delta_ms": 71,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779198862131,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198862202_000263"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 5,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 12732,
+            "frame_count": 20,
+            "latest_seq": 12751
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+          "source_observation_seq": 12751,
+          "source_observation_t_wall": 1779198861.827461,
+          "telemetry_window_first_seq": 12732,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12751,
+          "telemetry_window_latest_t_wall": 1779198861.827461,
+          "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "frame_id": "1779198862202_000263",
+        "fused_missing_conditions": [
+          "vars.bingo_fuel_set==true"
+        ],
+        "fused_step_id": "S29",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "DCS FA-18C Early Access Guide EN_40",
+          "fa18c_startup_master_1",
+          "Appendix - Training Task Syllabus_8",
+          "Appendix - Training Task Syllabus_1",
+          "fa18c_error_coding_guide_10"
+        ],
+        "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+        "prompt_tokens_est": 5601,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "source_chunk_refs": [
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_40",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_10"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 71,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198862202_000263"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779198862202_000263"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+      "request_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+      "timestamp": "2026-05-19T13:54:22.643425+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_291",
+          "evidence_refs": [
+            "GATES.S31.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "frame_id": "1779198862202_000263",
+          "fused_missing_conditions": [
+            "vars.bingo_fuel_set==true"
+          ],
+          "fused_step_id": "S29",
+          "generation_mode": "model",
+          "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 71,
+          "target": "radar_altimeter_bug_knob",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+      ],
+      "in_reply_to": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+      "message": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。",
+      "metadata": {
+        "allowed_evidence_ref_count": 121,
+        "completion_conflict_original_actions": [
+          {
+            "element_id": "pnt_170",
+            "evidence_refs": [
+              "VARS.bingo_fuel_set"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "ifei_up_button",
+            "type": "overlay"
+          }
+        ],
+        "completion_conflict_original_explanations": [
+          "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+        ],
+        "completion_conflict_original_message": "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。",
+        "completion_conflict_original_next": {
+          "step_id": "S29"
+        },
+        "completion_conflict_overlay_cleared": true,
+        "completion_conflict_rewritten": true,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "3a3dc2ab-79b4-495f-b6e8-1e3fdbdfa145",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+        },
+        "delta_dropped_count": 1,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "ifei_up_button"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S31"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+          "source_observation_seq": 12751,
+          "source_observation_t_wall": 1779198861.827461,
+          "telemetry_window_first_seq": 12732,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12751,
+          "telemetry_window_latest_t_wall": 1779198861.827461,
+          "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "overlay_step_id": "S31",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S31",
+          "targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 121,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S31"
+          },
+          "next": {
+            "step_id": "S31"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S31",
+        "final_evidence_consistency_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+          "completion_gate_already_satisfied:S29"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "radar_altimeter_bug_knob"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_291",
+              "evidence_refs": [
+                "GATES.S31.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "radar_altimeter_bug_knob"
+              ],
+              "frame_id": "1779198862202_000263",
+              "fused_missing_conditions": [
+                "vars.bingo_fuel_set==true"
+              ],
+              "fused_step_id": "S29",
+              "generation_mode": "model",
+              "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 71,
+              "target": "radar_altimeter_bug_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198862202_000263"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S31"
+          },
+          "explanations": [
+            "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+          ],
+          "message": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。",
+          "next": {
+            "step_id": "S31"
+          }
+        },
+        "frame_id": "1779198862202_000263",
+        "fused_missing_conditions": [
+          "vars.bingo_fuel_set==true"
+        ],
+        "fused_step_id": "S29",
+        "generation_mode": "model",
+        "generation_prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+        "generation_prompt_tokens_est": 5601,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S31",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S31",
+          "targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S29",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_altimeter_bug_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S31",
+              "supporting_evidence_refs": [
+                "GATES.S31.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "standby_attitude_cage_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S32",
+              "supporting_evidence_refs": [
+                "GATES.S32.completion"
+              ]
+            },
+            {
+              "confidence": 0.5,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button"
+              ],
+              "role": "candidate",
+              "source": "recent_action",
+              "step_id": "S29",
+              "supporting_evidence_refs": [
+                "RECENT_ACTIONS.ifei_up_button"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.66,
+            "proposed_next_action_target_ids": [
+              "radar_altimeter_bug_knob"
+            ],
+            "role": "candidate",
+            "source": "gate_blocker",
+            "step_id": "S31",
+            "supporting_evidence_refs": [
+              "GATES.S31.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 5,
+            "conflicts": [],
+            "recent_action_count": 1,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 12732,
+              "frame_count": 20,
+              "latest_seq": 12751
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+            "source_observation_seq": 12751,
+            "source_observation_t_wall": 1779198861.827461,
+            "telemetry_window_first_seq": 12732,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 12751,
+            "telemetry_window_latest_t_wall": 1779198861.827461,
+            "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "overlay_step_id": "S31",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S31",
+            "targets": [
+              "radar_altimeter_bug_knob"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "message_category": "completion_conflict_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "VARS.bingo_fuel_set"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "ifei_up_button"
+            ],
+            "status": "ok",
+            "step_id": "S29"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S29"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+            "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+              "completion_gate_already_satisfied:S29"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S29"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779198862202_000263"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 71,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+          "completion_gate_already_satisfied:S29"
+        ],
+        "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S31"
+          },
+          "explanations": [
+            "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+          ],
+          "next": {
+            "step_id": "S31"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S31.completion",
+                "target": "radar_altimeter_bug_knob",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "radar_altimeter_bug_knob"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S29"
+          },
+          "explanations": [
+            "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+          ],
+          "next": {
+            "step_id": "S29"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.bingo_fuel_set",
+                "target": "ifei_up_button",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ifei_up_button"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 5162,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "completion_conflict_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S29"
+        },
+        "model_raw_explanations": [
+          "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S29"
+          },
+          "explanations": [
+            "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+          ],
+          "next": {
+            "step_id": "S29"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.bingo_fuel_set",
+                "target": "ifei_up_button",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ifei_up_button"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S29"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779198862202_000263"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779198862202_000263",
+        "next": {
+          "step_id": "S31"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5548,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.engine_crank_left",
+            "GATES.S01.completion",
+            "GATES.S20.completion",
+            "GATES.S22.completion",
+            "GATES.S25.completion",
+            "GATES.S29.completion",
+            "GATES.S29.precondition",
+            "GATES.S31.completion",
+            "GATES.S32.completion",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_40",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_1",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_10"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "ifei_up_button",
+          "prompt_chars": 22402,
+          "prompt_tokens_est": 5601,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "DCS FA-18C Early Access Guide EN_40",
+            "fa18c_startup_master_1",
+            "Appendix - Training Task Syllabus_8",
+            "Appendix - Training Task Syllabus_1",
+            "fa18c_error_coding_guide_10"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+        "prompt_tokens_est": 5601,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.bingo_fuel_set==true"
+        ],
+        "rejected_model_step_id": "S29",
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "ac943c1c34464a1fab69c4db3cec6d9dbe15d43000c6c5ce02259fb0b52af502",
+        "request_prompt_tokens_est": 5601,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 121,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S29"
+          },
+          "next": {
+            "step_id": "S29"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+          "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+        },
+        "state_key": "eb9c117d6afc4065705ad07f192ae696135d3a6be466094a26de597fb51aad51",
+        "sync_delta_ms": 71,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779198862202_000263",
+          "frame_ids": [
+            "1779198862202_000263"
+          ],
+          "frame_stale": false,
+          "observation_ref": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+          "observation_seq": 12751,
+          "observation_t_wall_ms": 1779198861827,
+          "observation_t_wall_s": 1779198861.827461,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779198862202,
+              "channel": "composite_panel",
+              "frame_id": "1779198862202_000263",
+              "frame_seq": 263,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198862202_000263_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198862202_000263.png",
+              "sync_delta_ms": 71,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 71,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779198862202,
+            "channel": "composite_panel",
+            "frame_id": "1779198862202_000263",
+            "frame_seq": 263,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198862202_000263_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198862202_000263.png",
+            "sync_delta_ms": 71,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779198862131,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S29"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198862202_000263"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779198862202_000263"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "ef186073-34a3-4def-9116-26ad10370eb1",
+      "status": "ok",
+      "timestamp": "2026-05-19T13:54:27.807579+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S31",
+    "expected_overlay_target_ids": [
+      "radar_altimeter_bug_knob"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S29",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_altimeter_bug_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S31",
+        "supporting_evidence_refs": [
+          "GATES.S31.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "standby_attitude_cage_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S32",
+        "supporting_evidence_refs": [
+          "GATES.S32.completion"
+        ]
+      },
+      {
+        "confidence": 0.5,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button"
+        ],
+        "role": "candidate",
+        "source": "recent_action",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "RECENT_ACTIONS.ifei_up_button"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+      "overlay_step_id": "S31",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S31",
+      "targets": [
+        "radar_altimeter_bug_knob"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VARS.bingo_fuel_set"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "ifei_up_button"
+      ],
+      "status": "ok",
+      "step_id": "S29"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S29",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_altimeter_bug_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S31",
+          "supporting_evidence_refs": [
+            "GATES.S31.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "standby_attitude_cage_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S32",
+          "supporting_evidence_refs": [
+            "GATES.S32.completion"
+          ]
+        },
+        {
+          "confidence": 0.5,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button"
+          ],
+          "role": "candidate",
+          "source": "recent_action",
+          "step_id": "S29",
+          "supporting_evidence_refs": [
+            "RECENT_ACTIONS.ifei_up_button"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_altimeter_bug_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S31",
+        "supporting_evidence_refs": [
+          "GATES.S31.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 5,
+        "conflicts": [],
+        "recent_action_count": 1,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 12732,
+          "frame_count": 20,
+          "latest_seq": 12751
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "final_decision_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "model_request_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "source_observation_id": "7a28da02-81c2-44b8-9ae1-e0edc251a053",
+        "source_observation_seq": 12751,
+        "source_observation_t_wall": 1779198861.827461,
+        "telemetry_window_first_seq": 12732,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 12751,
+        "telemetry_window_latest_t_wall": 1779198861.827461,
+        "validator_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "overlay_step_id": "S31",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S31",
+        "targets": [
+          "radar_altimeter_bug_knob"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "radar_altimeter_bug_knob"
+      ],
+      "message_category": "completion_conflict_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "VARS.bingo_fuel_set"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "ifei_up_button"
+        ],
+        "status": "ok",
+        "step_id": "S29"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S29"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "final_decision": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "model_request": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0",
+        "validator": "1966d03761e11bf8a3ef41c04b3bbc05d313ea0e92bfd50366c4fe79cbed85c0"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+          "completion_gate_already_satisfied:S29"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S29"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779198862202_000263"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 71,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "missing_condition_satisfied_by_latest_telemetry:vars.bingo_fuel_set==true",
+        "completion_gate_already_satisfied:S29"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S29"
+    }
+  },
+  "help_cycle_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S31"
+      },
+      "explanations": [
+        "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。"
+      ],
+      "next": {
+        "step_id": "S31"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S31.completion",
+            "target": "radar_altimeter_bug_knob",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "radar_altimeter_bug_knob"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S29"
+      },
+      "explanations": [
+        "当前步骤 S29 已完成（Bingo fuel 已设置）。根据候选步骤和门控状态，下一步应处理 S20（释放刹车/检查加油探头）。由于 S20 门控被阻塞（加油探头未伸出），且当前无视觉证据支持其他步骤，建议确认当前操作意图。若需调整 IFEI 设置，可使用 ifei_up_button。"
+      ],
+      "next": {
+        "step_id": "S29"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.bingo_fuel_set",
+            "target": "ifei_up_button",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "ifei_up_button"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "5a7d5df7-2f08-4321-9a4a-6858131b4e6e",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 14472,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_134129.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/7bea22f8-a4d1-4744-917b-f7ddc957f709.fixture.json
+++ b/artifacts/live_fixtures/7bea22f8-a4d1-4744-917b-f7ddc957f709.fixture.json
@@ -1,0 +1,2568 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 3,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 12990,
+        "frame_count": 20,
+        "latest_seq": 13009
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+      "source_observation_seq": 13009,
+      "source_observation_t_wall": 1779198947.0997646,
+      "telemetry_window_first_seq": 12990,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 13009,
+      "telemetry_window_latest_t_wall": 1779198947.0997646,
+      "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+    },
+    "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 1,
+          "from_addr": "192.168.0.105:64396",
+          "raw_delta_count": 1,
+          "seq": 13009
+        },
+        "observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [],
+            "delta_count": 0,
+            "dropped_stats": {
+              "dropped_by_reason": {
+                "epsilon": 1
+              },
+              "dropped_total": 1
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 13009,
+          "t_wall": 1779198947.0997646,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": true,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": true,
+            "pitot_heat_on": true,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": true,
+            "radar_altimeter_bug_value": 182.17,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": true,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 310,
+            "temp_r": 322,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T13:55:47.099764+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 12990,
+      "frame_count": 20,
+      "latest_seq": 13009
+    },
+    "vision": {
+      "frame_ids": [
+        "1779198947154_000265"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779198947154_000265",
+        "frame_ids": [
+          "1779198947154_000265"
+        ],
+        "frame_stale": false,
+        "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+        "observation_seq": 13009,
+        "observation_t_wall_ms": 1779198947100,
+        "observation_t_wall_s": 1779198947.0997646,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779198947154,
+            "channel": "composite_panel",
+            "frame_id": "1779198947154_000265",
+            "frame_seq": 265,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198947154_000265_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198947154_000265.png",
+            "sync_delta_ms": 61,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 61,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779198947154,
+          "channel": "composite_panel",
+          "frame_id": "1779198947154_000265",
+          "frame_seq": 265,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198947154_000265_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198947154_000265.png",
+          "sync_delta_ms": 61,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779198947093,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779198947154_000265"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+        "kind": "tutor_request",
+        "lineno": 13699,
+        "metadata": {
+          "frame_id": "1779198947154_000265",
+          "fused_missing_conditions": [
+            "vars.standby_attitude_uncaged==true"
+          ],
+          "fused_step_id": "S32",
+          "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 61,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198947154_000265"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 1,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S32",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S32",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "standby_attitude_cage_knob"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 3,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 12990,
+                "frame_count": 20,
+                "latest_seq": 13009
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+              "source_observation_seq": 13009,
+              "source_observation_t_wall": 1779198947.0997646,
+              "telemetry_window_first_seq": 12990,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 13009,
+              "telemetry_window_latest_t_wall": 1779198947.0997646,
+              "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_8",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "score": 15.797613761271396,
+                "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "snippet_id": "Appendix - Training Task Syllabus_8"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_10",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q10. Final Instrument Settings Before Taxi",
+                "score": 15.03807799269629,
+                "section": "Q10. Final Instrument Settings Before Taxi",
+                "snippet_id": "fa18c_coldstart_quiz_10"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.29554266378183,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_53",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 54,
+                "score": 12.87720040280044,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_53"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_1",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "1. Scenario Definition",
+                "score": 12.236927730713054,
+                "section": "1. Scenario Definition",
+                "snippet_id": "Appendix - Training Task Syllabus_1"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.standby_attitude_uncaged==true"
+                ],
+                "overlay_step_id": "S32",
+                "role": "candidate_not_authoritative",
+                "step_id": "S32"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 13009,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 12990,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 13009,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 13009,
+                "latest_t_wall": 1779198947.0997646,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "pitot_heat_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.051
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779198947154_000265",
+              "frame_ids": [
+                "1779198947154_000265"
+              ],
+              "frame_stale": false,
+              "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+              "observation_seq": 13009,
+              "observation_t_wall_ms": 1779198947100,
+              "observation_t_wall_s": 1779198947.0997646,
+              "status": "partial",
+              "sync_delta_ms": 61,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779198947093,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198947154_000265"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 3,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 12990,
+                "frame_count": 20,
+                "latest_seq": 13009
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+              "source_observation_seq": 13009,
+              "source_observation_t_wall": 1779198947.0997646,
+              "telemetry_window_first_seq": 12990,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 13009,
+              "telemetry_window_latest_t_wall": 1779198947.0997646,
+              "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "frame_id": "1779198947154_000265",
+            "fused_missing_conditions": [
+              "vars.standby_attitude_uncaged==true"
+            ],
+            "fused_step_id": "S32",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "Appendix - Training Task Syllabus_8",
+              "fa18c_coldstart_quiz_10",
+              "fa18c_coldstart_quiz_1",
+              "DCS FA-18C Early Access Guide EN_53",
+              "Appendix - Training Task Syllabus_1"
+            ],
+            "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+            "prompt_tokens_est": 5433,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "source_chunk_refs": [
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_10",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_53",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 61,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198947154_000265"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779198947154_000265"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+          "request_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+          "timestamp": "2026-05-19T13:55:47.590805+00:00",
+          "version": "v1"
+        },
+        "related_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+        "vision_refs": [
+          "1779198947154_000265"
+        ]
+      },
+      {
+        "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+        "kind": "tutor_response",
+        "lineno": 13700,
+        "metadata": {
+          "final_overlay_targets": [],
+          "frame_id": "1779198947154_000265",
+          "fused_missing_conditions": [
+            "vars.standby_attitude_uncaged==true"
+          ],
+          "fused_step_id": "S32",
+          "generation_mode": "model",
+          "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 61,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198947154_000265"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [],
+          "actor": "tutor",
+          "explanations": [
+            "S33 的最新证据已经满足。现在进入 S33。"
+          ],
+          "in_reply_to": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+          "message": "S33 的最新证据已经满足。现在进入 S33。",
+          "metadata": {
+            "allowed_evidence_ref_count": 119,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "83dd295e-33b7-46e5-af45-1a3a7bd4002f",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "S33 的最新证据已经满足。现在进入 S33。"
+            },
+            "delta_dropped_count": 1,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S33"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+              "source_observation_seq": 13009,
+              "source_observation_t_wall": 1779198947.0997646,
+              "telemetry_window_first_seq": 12990,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 13009,
+              "telemetry_window_latest_t_wall": 1779198947.0997646,
+              "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "fallback_overlay_reason": "final_evidence_consistency_validator",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "overlay_step_id": "S33",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S33",
+              "targets": [],
+              "text_only": true
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_original_actions": [
+              {
+                "element_id": "pnt_213",
+                "evidence_refs": [
+                  "VARS.attitude_source_auto"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "standby_attitude_cage_knob",
+                "type": "overlay"
+              }
+            ],
+            "final_evidence_consistency_overlay_applied": false,
+            "final_evidence_consistency_overlay_reason": "evidence_conflict:completion_gate_already_satisfied:S33",
+            "final_evidence_consistency_reasons": [
+              "completion_gate_already_satisfied:S33"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [],
+            "final_public_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S33"
+              },
+              "explanations": [
+                "S33 的最新证据已经满足。现在进入 S33。"
+              ],
+              "message": "S33 的最新证据已经满足。现在进入 S33。",
+              "next": {
+                "step_id": "S33"
+              }
+            },
+            "frame_id": "1779198947154_000265",
+            "fused_missing_conditions": [
+              "vars.standby_attitude_uncaged==true"
+            ],
+            "fused_step_id": "S32",
+            "generation_mode": "model",
+            "generation_prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+            "generation_prompt_tokens_est": 5433,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S33",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S33",
+              "targets": [],
+              "text_only": true
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "standby_attitude_cage_knob"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S32",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "source": "final_action_plan",
+                "step_id": "S33"
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 3,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 12990,
+                  "frame_count": 20,
+                  "latest_seq": 13009
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+                "source_observation_seq": 13009,
+                "source_observation_t_wall": 1779198947.0997646,
+                "telemetry_window_first_seq": 12990,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 13009,
+                "telemetry_window_latest_t_wall": 1779198947.0997646,
+                "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "overlay_step_id": "S33",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S33",
+                "targets": [],
+                "text_only": true
+              },
+              "final_overlay_targets": [],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "VARS.attitude_source_auto"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "standby_attitude_cage_knob"
+                ],
+                "status": "ok",
+                "step_id": "S32"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S33"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+                "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "final_evidence_consistency_validator",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "missing_condition_satisfied_by_latest_telemetry:vars.standby_attitude_uncaged==true",
+                  "completion_gate_already_satisfied:S32",
+                  "completion_gate_already_satisfied:S33"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S33"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779198947154_000265"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 61,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.standby_attitude_uncaged==true",
+              "completion_gate_already_satisfied:S32",
+              "completion_gate_already_satisfied:S33"
+            ],
+            "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S33"
+              },
+              "explanations": [
+                "S33 的最新证据已经满足。现在进入 S33。"
+              ],
+              "next": {
+                "step_id": "S33"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S32"
+              },
+              "explanations": [
+                "当前步骤 S32 未完成。请检查备用姿态仪，若未对准，请操作 standby_attitude_cage_knob 进行归位。"
+              ],
+              "next": {
+                "step_id": "S32"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.8,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.attitude_source_auto",
+                    "target": "standby_attitude_cage_knob",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "standby_attitude_cage_knob"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4362,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S32"
+            },
+            "model_raw_explanations": [
+              "当前步骤 S32 未完成。请检查备用姿态仪，若未对准，请操作 standby_attitude_cage_knob 进行归位。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S32"
+              },
+              "explanations": [
+                "当前步骤 S32 未完成。请检查备用姿态仪，若未对准，请操作 standby_attitude_cage_knob 进行归位。"
+              ],
+              "next": {
+                "step_id": "S32"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.8,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.attitude_source_auto",
+                    "target": "standby_attitude_cage_knob",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "standby_attitude_cage_knob"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S32"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779198947154_000265"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779198947154_000265",
+            "next": {
+              "step_id": "S33"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5563,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.standby_attitude_uncaged",
+                "GATES.S01.completion",
+                "GATES.S01.precondition",
+                "GATES.S02.completion",
+                "GATES.S20.completion",
+                "GATES.S22.completion",
+                "GATES.S25.completion",
+                "GATES.S32.completion",
+                "GATES.S32.precondition",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_10",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_53",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_1"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": null,
+              "prompt_chars": 21729,
+              "prompt_tokens_est": 5433,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "Appendix - Training Task Syllabus_8",
+                "fa18c_coldstart_quiz_10",
+                "fa18c_coldstart_quiz_1",
+                "DCS FA-18C Early Access Guide EN_53",
+                "Appendix - Training Task Syllabus_1"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+            "prompt_tokens_est": 5433,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [],
+            "rejected_model_step_id": "S33",
+            "rejected_model_target": "standby_attitude_cage_knob",
+            "rejected_model_targets": [
+              "standby_attitude_cage_knob"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+            "request_prompt_tokens_est": 5433,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 119,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S32"
+              },
+              "next": {
+                "step_id": "S32"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+              "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+            },
+            "state_key": "d8b02d0938eebad4b21100b71ba9484d0a241240465f9fe9e95e4005661f90e6",
+            "sync_delta_ms": 61,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779198947154_000265",
+              "frame_ids": [
+                "1779198947154_000265"
+              ],
+              "frame_stale": false,
+              "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+              "observation_seq": 13009,
+              "observation_t_wall_ms": 1779198947100,
+              "observation_t_wall_s": 1779198947.0997646,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779198947154,
+                  "channel": "composite_panel",
+                  "frame_id": "1779198947154_000265",
+                  "frame_seq": 265,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198947154_000265_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198947154_000265.png",
+                  "sync_delta_ms": 61,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 61,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779198947154,
+                "channel": "composite_panel",
+                "frame_id": "1779198947154_000265",
+                "frame_seq": 265,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198947154_000265_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198947154_000265.png",
+                "sync_delta_ms": 61,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779198947093,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S32"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198947154_000265"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779198947154_000265"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "559ceb2a-d075-4c08-acc4-e0fcbdde3364",
+          "status": "ok",
+          "timestamp": "2026-05-19T13:55:51.953739+00:00",
+          "version": "v1"
+        },
+        "related_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+        "vision_refs": [
+          "1779198947154_000265"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 1,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S32",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S32",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "standby_attitude_cage_knob"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 3,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 12990,
+            "frame_count": 20,
+            "latest_seq": 13009
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+          "source_observation_seq": 13009,
+          "source_observation_t_wall": 1779198947.0997646,
+          "telemetry_window_first_seq": 12990,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 13009,
+          "telemetry_window_latest_t_wall": 1779198947.0997646,
+          "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_8",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "score": 15.797613761271396,
+            "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "snippet_id": "Appendix - Training Task Syllabus_8"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_10",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q10. Final Instrument Settings Before Taxi",
+            "score": 15.03807799269629,
+            "section": "Q10. Final Instrument Settings Before Taxi",
+            "snippet_id": "fa18c_coldstart_quiz_10"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.29554266378183,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_53",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 54,
+            "score": 12.87720040280044,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_53"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_1",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "1. Scenario Definition",
+            "score": 12.236927730713054,
+            "section": "1. Scenario Definition",
+            "snippet_id": "Appendix - Training Task Syllabus_1"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.standby_attitude_uncaged==true"
+            ],
+            "overlay_step_id": "S32",
+            "role": "candidate_not_authoritative",
+            "step_id": "S32"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 13009,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 12990,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 13009,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 13009,
+            "latest_t_wall": 1779198947.0997646,
+            "stable_false_vars": [
+              "fcs_bit_switch_up"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "pitot_heat_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.051
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779198947154_000265",
+          "frame_ids": [
+            "1779198947154_000265"
+          ],
+          "frame_stale": false,
+          "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+          "observation_seq": 13009,
+          "observation_t_wall_ms": 1779198947100,
+          "observation_t_wall_s": 1779198947.0997646,
+          "status": "partial",
+          "sync_delta_ms": 61,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779198947093,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198947154_000265"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 3,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 12990,
+            "frame_count": 20,
+            "latest_seq": 13009
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+          "source_observation_seq": 13009,
+          "source_observation_t_wall": 1779198947.0997646,
+          "telemetry_window_first_seq": 12990,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 13009,
+          "telemetry_window_latest_t_wall": 1779198947.0997646,
+          "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "frame_id": "1779198947154_000265",
+        "fused_missing_conditions": [
+          "vars.standby_attitude_uncaged==true"
+        ],
+        "fused_step_id": "S32",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "Appendix - Training Task Syllabus_8",
+          "fa18c_coldstart_quiz_10",
+          "fa18c_coldstart_quiz_1",
+          "DCS FA-18C Early Access Guide EN_53",
+          "Appendix - Training Task Syllabus_1"
+        ],
+        "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+        "prompt_tokens_est": 5433,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "source_chunk_refs": [
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_10",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_53",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 61,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198947154_000265"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779198947154_000265"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+      "request_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+      "timestamp": "2026-05-19T13:55:47.590805+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [],
+      "actor": "tutor",
+      "explanations": [
+        "S33 的最新证据已经满足。现在进入 S33。"
+      ],
+      "in_reply_to": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+      "message": "S33 的最新证据已经满足。现在进入 S33。",
+      "metadata": {
+        "allowed_evidence_ref_count": 119,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "83dd295e-33b7-46e5-af45-1a3a7bd4002f",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "S33 的最新证据已经满足。现在进入 S33。"
+        },
+        "delta_dropped_count": 1,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S33"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+          "source_observation_seq": 13009,
+          "source_observation_t_wall": 1779198947.0997646,
+          "telemetry_window_first_seq": 12990,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 13009,
+          "telemetry_window_latest_t_wall": 1779198947.0997646,
+          "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "fallback_overlay_reason": "final_evidence_consistency_validator",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "overlay_step_id": "S33",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S33",
+          "targets": [],
+          "text_only": true
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_original_actions": [
+          {
+            "element_id": "pnt_213",
+            "evidence_refs": [
+              "VARS.attitude_source_auto"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "standby_attitude_cage_knob",
+            "type": "overlay"
+          }
+        ],
+        "final_evidence_consistency_overlay_applied": false,
+        "final_evidence_consistency_overlay_reason": "evidence_conflict:completion_gate_already_satisfied:S33",
+        "final_evidence_consistency_reasons": [
+          "completion_gate_already_satisfied:S33"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [],
+        "final_public_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S33"
+          },
+          "explanations": [
+            "S33 的最新证据已经满足。现在进入 S33。"
+          ],
+          "message": "S33 的最新证据已经满足。现在进入 S33。",
+          "next": {
+            "step_id": "S33"
+          }
+        },
+        "frame_id": "1779198947154_000265",
+        "fused_missing_conditions": [
+          "vars.standby_attitude_uncaged==true"
+        ],
+        "fused_step_id": "S32",
+        "generation_mode": "model",
+        "generation_prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+        "generation_prompt_tokens_est": 5433,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S33",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S33",
+          "targets": [],
+          "text_only": true
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "standby_attitude_cage_knob"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S32",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "source": "final_action_plan",
+            "step_id": "S33"
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 3,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 12990,
+              "frame_count": 20,
+              "latest_seq": 13009
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+            "source_observation_seq": 13009,
+            "source_observation_t_wall": 1779198947.0997646,
+            "telemetry_window_first_seq": 12990,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 13009,
+            "telemetry_window_latest_t_wall": 1779198947.0997646,
+            "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "overlay_step_id": "S33",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S33",
+            "targets": [],
+            "text_only": true
+          },
+          "final_overlay_targets": [],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "VARS.attitude_source_auto"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "standby_attitude_cage_knob"
+            ],
+            "status": "ok",
+            "step_id": "S32"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S33"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+            "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "final_evidence_consistency_validator",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.standby_attitude_uncaged==true",
+              "completion_gate_already_satisfied:S32",
+              "completion_gate_already_satisfied:S33"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S33"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779198947154_000265"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 61,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.standby_attitude_uncaged==true",
+          "completion_gate_already_satisfied:S32",
+          "completion_gate_already_satisfied:S33"
+        ],
+        "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S33"
+          },
+          "explanations": [
+            "S33 的最新证据已经满足。现在进入 S33。"
+          ],
+          "next": {
+            "step_id": "S33"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S32"
+          },
+          "explanations": [
+            "当前步骤 S32 未完成。请检查备用姿态仪，若未对准，请操作 standby_attitude_cage_knob 进行归位。"
+          ],
+          "next": {
+            "step_id": "S32"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.8,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.attitude_source_auto",
+                "target": "standby_attitude_cage_knob",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "standby_attitude_cage_knob"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4362,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S32"
+        },
+        "model_raw_explanations": [
+          "当前步骤 S32 未完成。请检查备用姿态仪，若未对准，请操作 standby_attitude_cage_knob 进行归位。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S32"
+          },
+          "explanations": [
+            "当前步骤 S32 未完成。请检查备用姿态仪，若未对准，请操作 standby_attitude_cage_knob 进行归位。"
+          ],
+          "next": {
+            "step_id": "S32"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.8,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.attitude_source_auto",
+                "target": "standby_attitude_cage_knob",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "standby_attitude_cage_knob"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S32"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779198947154_000265"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779198947154_000265",
+        "next": {
+          "step_id": "S33"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5563,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.standby_attitude_uncaged",
+            "GATES.S01.completion",
+            "GATES.S01.precondition",
+            "GATES.S02.completion",
+            "GATES.S20.completion",
+            "GATES.S22.completion",
+            "GATES.S25.completion",
+            "GATES.S32.completion",
+            "GATES.S32.precondition",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_10",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_53",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_1"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": null,
+          "prompt_chars": 21729,
+          "prompt_tokens_est": 5433,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "Appendix - Training Task Syllabus_8",
+            "fa18c_coldstart_quiz_10",
+            "fa18c_coldstart_quiz_1",
+            "DCS FA-18C Early Access Guide EN_53",
+            "Appendix - Training Task Syllabus_1"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+        "prompt_tokens_est": 5433,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [],
+        "rejected_model_step_id": "S33",
+        "rejected_model_target": "standby_attitude_cage_knob",
+        "rejected_model_targets": [
+          "standby_attitude_cage_knob"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "60aab4e00e8dcde6f60b9599e8ec09f1e96e835a1176f1d60577d58598158d04",
+        "request_prompt_tokens_est": 5433,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 119,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S32"
+          },
+          "next": {
+            "step_id": "S32"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+          "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+        },
+        "state_key": "d8b02d0938eebad4b21100b71ba9484d0a241240465f9fe9e95e4005661f90e6",
+        "sync_delta_ms": 61,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779198947154_000265",
+          "frame_ids": [
+            "1779198947154_000265"
+          ],
+          "frame_stale": false,
+          "observation_ref": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+          "observation_seq": 13009,
+          "observation_t_wall_ms": 1779198947100,
+          "observation_t_wall_s": 1779198947.0997646,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779198947154,
+              "channel": "composite_panel",
+              "frame_id": "1779198947154_000265",
+              "frame_seq": 265,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198947154_000265_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198947154_000265.png",
+              "sync_delta_ms": 61,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 61,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779198947154,
+            "channel": "composite_panel",
+            "frame_id": "1779198947154_000265",
+            "frame_seq": 265,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198947154_000265_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198947154_000265.png",
+            "sync_delta_ms": 61,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779198947093,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S32"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198947154_000265"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779198947154_000265"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "559ceb2a-d075-4c08-acc4-e0fcbdde3364",
+      "status": "ok",
+      "timestamp": "2026-05-19T13:55:51.953739+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S33",
+    "expected_overlay_target_ids": [],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "standby_attitude_cage_knob"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S32",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+      "overlay_step_id": "S33",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S33",
+      "targets": [],
+      "text_only": true
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VARS.attitude_source_auto"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "standby_attitude_cage_knob"
+      ],
+      "status": "ok",
+      "step_id": "S32"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "standby_attitude_cage_knob"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S32",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "source": "final_action_plan",
+        "step_id": "S33"
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 3,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 12990,
+          "frame_count": 20,
+          "latest_seq": 13009
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "final_decision_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "model_request_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "source_observation_id": "0ddcfb79-382a-41c4-a73f-89fd89f89a13",
+        "source_observation_seq": 13009,
+        "source_observation_t_wall": 1779198947.0997646,
+        "telemetry_window_first_seq": 12990,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 13009,
+        "telemetry_window_latest_t_wall": 1779198947.0997646,
+        "validator_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "overlay_step_id": "S33",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S33",
+        "targets": [],
+        "text_only": true
+      },
+      "final_overlay_targets": [],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "VARS.attitude_source_auto"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "standby_attitude_cage_knob"
+        ],
+        "status": "ok",
+        "step_id": "S32"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S33"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "final_decision": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "model_request": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999",
+        "validator": "7a67c1ee0e632e8b9150de57a1281d9974a4dd371420f552242d5f064989e999"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "final_evidence_consistency_validator",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.standby_attitude_uncaged==true",
+          "completion_gate_already_satisfied:S32",
+          "completion_gate_already_satisfied:S33"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S33"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779198947154_000265"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 61,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "final_evidence_consistency_validator",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "missing_condition_satisfied_by_latest_telemetry:vars.standby_attitude_uncaged==true",
+        "completion_gate_already_satisfied:S32",
+        "completion_gate_already_satisfied:S33"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S33"
+    }
+  },
+  "help_cycle_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S33"
+      },
+      "explanations": [
+        "S33 的最新证据已经满足。现在进入 S33。"
+      ],
+      "next": {
+        "step_id": "S33"
+      },
+      "overlay": {
+        "evidence": [],
+        "targets": []
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S32"
+      },
+      "explanations": [
+        "当前步骤 S32 未完成。请检查备用姿态仪，若未对准，请操作 standby_attitude_cage_knob 进行归位。"
+      ],
+      "next": {
+        "step_id": "S32"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.8,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.attitude_source_auto",
+            "target": "standby_attitude_cage_knob",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "standby_attitude_cage_knob"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "7bea22f8-a4d1-4744-917b-f7ddc957f709",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 14472,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_134129.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/ffb5e69b-664b-47d8-9150-57d7cd75d233.fixture.json
+++ b/artifacts/live_fixtures/ffb5e69b-664b-47d8-9150-57d7cd75d233.fixture.json
@@ -1,0 +1,3166 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 4,
+      "conflicts": [],
+      "recent_action_count": 1,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 1,
+        "contradiction_count": 0,
+        "first_seq": 12834,
+        "frame_count": 20,
+        "latest_seq": 12853
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+      "source_observation_seq": 12853,
+      "source_observation_t_wall": 1779198877.5485222,
+      "telemetry_window_first_seq": 12834,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 12853,
+      "telemetry_window_latest_t_wall": 1779198877.5485222,
+      "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+    },
+    "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:64396",
+          "raw_delta_count": 1,
+          "seq": 12853
+        },
+        "observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "RADALT_ALT_PTR"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "RADALT_ALT_PTR",
+                "ui_targets": [],
+                "value": 3425
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 12853,
+          "t_wall": 1779198877.5485222,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": true,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": true,
+            "pitot_heat_on": true,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": true,
+            "radar_altimeter_bug_value": 182.17,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 310,
+            "temp_r": 322,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T13:54:37.548522+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 1,
+      "contradiction_count": 0,
+      "first_seq": 12834,
+      "frame_count": 20,
+      "latest_seq": 12853
+    },
+    "vision": {
+      "frame_ids": [
+        "1779198877598_000264"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779198877598_000264",
+        "frame_ids": [
+          "1779198877598_000264"
+        ],
+        "frame_stale": false,
+        "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+        "observation_seq": 12853,
+        "observation_t_wall_ms": 1779198877549,
+        "observation_t_wall_s": 1779198877.5485222,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779198877598,
+            "channel": "composite_panel",
+            "frame_id": "1779198877598_000264",
+            "frame_seq": 264,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198877598_000264_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198877598_000264.png",
+            "sync_delta_ms": 86,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 86,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779198877598,
+          "channel": "composite_panel",
+          "frame_id": "1779198877598_000264",
+          "frame_seq": 264,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198877598_000264_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198877598_000264.png",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779198877512,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779198877598_000264"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "kind": "tutor_request",
+        "lineno": 13538,
+        "metadata": {
+          "frame_id": "1779198877598_000264",
+          "fused_missing_conditions": [
+            "vars.radar_altimeter_bug_value in [180,220]"
+          ],
+          "fused_step_id": "S31",
+          "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S31",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S31",
+              "recent_ui_targets": [
+                "radar_altimeter_bug_knob"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "radar_altimeter_bug_knob"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 4,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "first_seq": 12834,
+                "frame_count": 20,
+                "latest_seq": 12853
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+              "source_observation_seq": 12853,
+              "source_observation_t_wall": 1779198877.5485222,
+              "telemetry_window_first_seq": 12834,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12853,
+              "telemetry_window_latest_t_wall": 1779198877.5485222,
+              "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_error_coding_guide_6",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.4 Parameter / Setting Error (PA)",
+                "score": 35.8179364364382,
+                "section": "2.4 Parameter / Setting Error (PA)",
+                "snippet_id": "fa18c_error_coding_guide_6"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_8",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "score": 32.64140708275691,
+                "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "snippet_id": "Appendix - Training Task Syllabus_8"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_10",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q10. Final Instrument Settings Before Taxi",
+                "score": 31.846740133861815,
+                "section": "Q10. Final Instrument Settings Before Taxi",
+                "snippet_id": "fa18c_coldstart_quiz_10"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 20.84343711214175,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_53",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 54,
+                "score": 18.85033747437686,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_53"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.radar_altimeter_bug_value in [180,220]"
+                ],
+                "overlay_step_id": "S31",
+                "role": "candidate_not_authoritative",
+                "step_id": "S31"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 12853,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": 165.99,
+                    "last_value": 182.17,
+                    "latest_transition_age_s": 0.573,
+                    "transition_count": 7,
+                    "var": "radar_altimeter_bug_value"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 12834,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12853,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 12853,
+                "latest_t_wall": 1779198877.5485222,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "pitot_heat_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.218
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779198877598_000264",
+              "frame_ids": [
+                "1779198877598_000264"
+              ],
+              "frame_stale": false,
+              "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+              "observation_seq": 12853,
+              "observation_t_wall_ms": 1779198877549,
+              "observation_t_wall_s": 1779198877.5485222,
+              "status": "partial",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779198877512,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198877598_000264"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 4,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 1,
+                "contradiction_count": 0,
+                "first_seq": 12834,
+                "frame_count": 20,
+                "latest_seq": 12853
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+              "source_observation_seq": 12853,
+              "source_observation_t_wall": 1779198877.5485222,
+              "telemetry_window_first_seq": 12834,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12853,
+              "telemetry_window_latest_t_wall": 1779198877.5485222,
+              "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "frame_id": "1779198877598_000264",
+            "fused_missing_conditions": [
+              "vars.radar_altimeter_bug_value in [180,220]"
+            ],
+            "fused_step_id": "S31",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_error_coding_guide_6",
+              "Appendix - Training Task Syllabus_8",
+              "fa18c_coldstart_quiz_10",
+              "fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN_53"
+            ],
+            "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+            "prompt_tokens_est": 5610,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "source_chunk_refs": [
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_6",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_10",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_53"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 86,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198877598_000264"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779198877598_000264"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+          "request_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "timestamp": "2026-05-19T13:54:38.053084+00:00",
+          "version": "v1"
+        },
+        "related_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "vision_refs": [
+          "1779198877598_000264"
+        ]
+      },
+      {
+        "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "kind": "overlay_requested",
+        "lineno": 13539,
+        "metadata": {
+          "final_overlay_targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "frame_id": "1779198877598_000264",
+          "fused_missing_conditions": [
+            "vars.radar_altimeter_bug_value in [180,220]"
+          ],
+          "fused_step_id": "S31",
+          "generation_mode": "model",
+          "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "2535f148-e0d2-4e97-96cf-6b5f86bbe15b",
+          "final_overlay_targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "frame_id": "1779198877598_000264",
+          "fused_missing_conditions": [
+            "vars.radar_altimeter_bug_value in [180,220]"
+          ],
+          "fused_step_id": "S31",
+          "generation_mode": "model",
+          "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 86,
+          "target": "pnt_291",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "kind": "overlay_requested",
+        "lineno": 13540,
+        "metadata": {
+          "final_overlay_targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "frame_id": "1779198877598_000264",
+          "fused_missing_conditions": [
+            "vars.radar_altimeter_bug_value in [180,220]"
+          ],
+          "fused_step_id": "S31",
+          "generation_mode": "model",
+          "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "f0a9e27e-2b93-409a-a3e5-fc3f25a0057a",
+          "final_overlay_targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "frame_id": "1779198877598_000264",
+          "fused_missing_conditions": [
+            "vars.radar_altimeter_bug_value in [180,220]"
+          ],
+          "fused_step_id": "S31",
+          "generation_mode": "model",
+          "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 86,
+          "target": "pnt_213",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "kind": "tutor_response",
+        "lineno": 13541,
+        "metadata": {
+          "final_overlay_targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "frame_id": "1779198877598_000264",
+          "fused_missing_conditions": [
+            "vars.radar_altimeter_bug_value in [180,220]"
+          ],
+          "fused_step_id": "S31",
+          "generation_mode": "model",
+          "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_213",
+              "evidence_refs": [
+                "GATES.S32.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "standby_attitude_cage_knob"
+              ],
+              "frame_id": "1779198877598_000264",
+              "fused_missing_conditions": [
+                "vars.radar_altimeter_bug_value in [180,220]"
+              ],
+              "fused_step_id": "S31",
+              "generation_mode": "model",
+              "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 86,
+              "target": "standby_attitude_cage_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198877598_000264"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+          ],
+          "in_reply_to": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "message": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。",
+          "metadata": {
+            "allowed_evidence_ref_count": 119,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "f8b00361-d43d-4b62-9f42-c27d251b08e9",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "radar_altimeter_bug_knob"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S32"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+              "source_observation_seq": 12853,
+              "source_observation_t_wall": 1779198877.5485222,
+              "telemetry_window_first_seq": 12834,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12853,
+              "telemetry_window_latest_t_wall": 1779198877.5485222,
+              "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "overlay_step_id": "S32",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S32",
+              "targets": [
+                "standby_attitude_cage_knob"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 119,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S32"
+              },
+              "next": {
+                "step_id": "S32"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_original_actions": [
+              {
+                "element_id": "pnt_291",
+                "evidence_refs": [
+                  "VARS.battery_on"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "radar_altimeter_bug_knob",
+                "type": "overlay"
+              }
+            ],
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S32",
+            "final_evidence_consistency_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+              "completion_gate_already_satisfied:S31"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "standby_attitude_cage_knob"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_213",
+                  "evidence_refs": [
+                    "GATES.S32.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "standby_attitude_cage_knob"
+                  ],
+                  "frame_id": "1779198877598_000264",
+                  "fused_missing_conditions": [
+                    "vars.radar_altimeter_bug_value in [180,220]"
+                  ],
+                  "fused_step_id": "S31",
+                  "generation_mode": "model",
+                  "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 86,
+                  "target": "standby_attitude_cage_knob",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779198877598_000264"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S32"
+              },
+              "explanations": [
+                "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+              ],
+              "message": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。",
+              "next": {
+                "step_id": "S32"
+              }
+            },
+            "frame_id": "1779198877598_000264",
+            "fused_missing_conditions": [
+              "vars.radar_altimeter_bug_value in [180,220]"
+            ],
+            "fused_step_id": "S31",
+            "generation_mode": "model",
+            "generation_prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+            "generation_prompt_tokens_est": 5610,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S32",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S32",
+              "targets": [
+                "standby_attitude_cage_knob"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "radar_altimeter_bug_knob"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S31",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "standby_attitude_cage_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S32",
+                  "supporting_evidence_refs": [
+                    "GATES.S32.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.5,
+                  "proposed_next_action_target_ids": [
+                    "radar_altimeter_bug_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "recent_action",
+                  "step_id": "S31",
+                  "supporting_evidence_refs": [
+                    "RECENT_ACTIONS.radar_altimeter_bug_knob"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.66,
+                "proposed_next_action_target_ids": [
+                  "standby_attitude_cage_knob"
+                ],
+                "role": "candidate",
+                "source": "gate_blocker",
+                "step_id": "S32",
+                "supporting_evidence_refs": [
+                  "GATES.S32.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 4,
+                "conflicts": [],
+                "recent_action_count": 1,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 1,
+                  "contradiction_count": 0,
+                  "first_seq": 12834,
+                  "frame_count": 20,
+                  "latest_seq": 12853
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+                "source_observation_seq": 12853,
+                "source_observation_t_wall": 1779198877.5485222,
+                "telemetry_window_first_seq": 12834,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 12853,
+                "telemetry_window_latest_t_wall": 1779198877.5485222,
+                "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "overlay_step_id": "S32",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S32",
+                "targets": [
+                  "standby_attitude_cage_knob"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "standby_attitude_cage_knob"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "VARS.battery_on"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "radar_altimeter_bug_knob"
+                ],
+                "status": "ok",
+                "step_id": "S31"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S31"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+                "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+                  "completion_gate_already_satisfied:S31"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S31"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779198877598_000264"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 86,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+              "completion_gate_already_satisfied:S31"
+            ],
+            "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S32"
+              },
+              "explanations": [
+                "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+              ],
+              "next": {
+                "step_id": "S32"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S32.completion",
+                    "target": "standby_attitude_cage_knob",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "standby_attitude_cage_knob"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S31"
+              },
+              "explanations": [
+                "S08 视觉证据缺失且非当前阻塞点。根据候选步骤优先级，当前应执行 S31：设置雷达高度表游标。请旋转 radar_altimeter_bug_knob 将游标设置为 180 或 220 英尺。"
+              ],
+              "next": {
+                "step_id": "S31"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.battery_on",
+                    "target": "radar_altimeter_bug_knob",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "radar_altimeter_bug_knob"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4813,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S31"
+            },
+            "model_raw_explanations": [
+              "S08 视觉证据缺失且非当前阻塞点。根据候选步骤优先级，当前应执行 S31：设置雷达高度表游标。请旋转 radar_altimeter_bug_knob 将游标设置为 180 或 220 英尺。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S31"
+              },
+              "explanations": [
+                "S08 视觉证据缺失且非当前阻塞点。根据候选步骤优先级，当前应执行 S31：设置雷达高度表游标。请旋转 radar_altimeter_bug_knob 将游标设置为 180 或 220 英尺。"
+              ],
+              "next": {
+                "step_id": "S31"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.battery_on",
+                    "target": "radar_altimeter_bug_knob",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "radar_altimeter_bug_knob"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S31"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779198877598_000264"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779198877598_000264",
+            "next": {
+              "step_id": "S32"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5612,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.radar_altimeter_bug_value",
+                "GATES.S01.completion",
+                "GATES.S01.precondition",
+                "GATES.S20.completion",
+                "GATES.S22.completion",
+                "GATES.S25.completion",
+                "GATES.S31.completion",
+                "GATES.S31.precondition",
+                "GATES.S32.completion",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_6",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_10",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_53"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "radar_altimeter_bug_knob",
+              "prompt_chars": 22440,
+              "prompt_tokens_est": 5610,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_error_coding_guide_6",
+                "Appendix - Training Task Syllabus_8",
+                "fa18c_coldstart_quiz_10",
+                "fa18c_startup_master_1",
+                "DCS FA-18C Early Access Guide EN_53"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+            "prompt_tokens_est": 5610,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.radar_altimeter_bug_value in [180,220]"
+            ],
+            "rejected_model_step_id": "S31",
+            "rejected_model_target": "radar_altimeter_bug_knob",
+            "rejected_model_targets": [
+              "radar_altimeter_bug_knob"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+            "request_prompt_tokens_est": 5610,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 119,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S31"
+              },
+              "next": {
+                "step_id": "S31"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+              "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+            },
+            "state_key": "79afaccc9e97ea42552d9f760d0ec9edda216a805ccc82a91fe07e804884cf6b",
+            "sync_delta_ms": 86,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779198877598_000264",
+              "frame_ids": [
+                "1779198877598_000264"
+              ],
+              "frame_stale": false,
+              "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+              "observation_seq": 12853,
+              "observation_t_wall_ms": 1779198877549,
+              "observation_t_wall_s": 1779198877.5485222,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779198877598,
+                  "channel": "composite_panel",
+                  "frame_id": "1779198877598_000264",
+                  "frame_seq": 264,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198877598_000264_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198877598_000264.png",
+                  "sync_delta_ms": 86,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779198877598,
+                "channel": "composite_panel",
+                "frame_id": "1779198877598_000264",
+                "frame_seq": 264,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198877598_000264_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198877598_000264.png",
+                "sync_delta_ms": 86,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779198877512,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S31"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198877598_000264"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779198877598_000264"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "a740dd57-c218-4b68-9c5d-ccff0bdf881d",
+          "status": "ok",
+          "timestamp": "2026-05-19T13:54:42.867427+00:00",
+          "version": "v1"
+        },
+        "related_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "vision_refs": [
+          "1779198877598_000264"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S31",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S31",
+          "recent_ui_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "radar_altimeter_bug_knob"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 4,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "first_seq": 12834,
+            "frame_count": 20,
+            "latest_seq": 12853
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+          "source_observation_seq": 12853,
+          "source_observation_t_wall": 1779198877.5485222,
+          "telemetry_window_first_seq": 12834,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12853,
+          "telemetry_window_latest_t_wall": 1779198877.5485222,
+          "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_error_coding_guide_6",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.4 Parameter / Setting Error (PA)",
+            "score": 35.8179364364382,
+            "section": "2.4 Parameter / Setting Error (PA)",
+            "snippet_id": "fa18c_error_coding_guide_6"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_8",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "score": 32.64140708275691,
+            "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "snippet_id": "Appendix - Training Task Syllabus_8"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_10",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q10. Final Instrument Settings Before Taxi",
+            "score": 31.846740133861815,
+            "section": "Q10. Final Instrument Settings Before Taxi",
+            "snippet_id": "fa18c_coldstart_quiz_10"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 20.84343711214175,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_53",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 54,
+            "score": 18.85033747437686,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_53"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.radar_altimeter_bug_value in [180,220]"
+            ],
+            "overlay_step_id": "S31",
+            "role": "candidate_not_authoritative",
+            "step_id": "S31"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 12853,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": 165.99,
+                "last_value": 182.17,
+                "latest_transition_age_s": 0.573,
+                "transition_count": 7,
+                "var": "radar_altimeter_bug_value"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 12834,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12853,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 12853,
+            "latest_t_wall": 1779198877.5485222,
+            "stable_false_vars": [
+              "fcs_bit_switch_up"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "pitot_heat_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.218
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779198877598_000264",
+          "frame_ids": [
+            "1779198877598_000264"
+          ],
+          "frame_stale": false,
+          "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+          "observation_seq": 12853,
+          "observation_t_wall_ms": 1779198877549,
+          "observation_t_wall_s": 1779198877.5485222,
+          "status": "partial",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779198877512,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198877598_000264"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 4,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 1,
+            "contradiction_count": 0,
+            "first_seq": 12834,
+            "frame_count": 20,
+            "latest_seq": 12853
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+          "source_observation_seq": 12853,
+          "source_observation_t_wall": 1779198877.5485222,
+          "telemetry_window_first_seq": 12834,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12853,
+          "telemetry_window_latest_t_wall": 1779198877.5485222,
+          "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "frame_id": "1779198877598_000264",
+        "fused_missing_conditions": [
+          "vars.radar_altimeter_bug_value in [180,220]"
+        ],
+        "fused_step_id": "S31",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_error_coding_guide_6",
+          "Appendix - Training Task Syllabus_8",
+          "fa18c_coldstart_quiz_10",
+          "fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN_53"
+        ],
+        "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+        "prompt_tokens_est": 5610,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "source_chunk_refs": [
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_6",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_10",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_53"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 86,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198877598_000264"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779198877598_000264"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+      "request_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+      "timestamp": "2026-05-19T13:54:38.053084+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_213",
+          "evidence_refs": [
+            "GATES.S32.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "frame_id": "1779198877598_000264",
+          "fused_missing_conditions": [
+            "vars.radar_altimeter_bug_value in [180,220]"
+          ],
+          "fused_step_id": "S31",
+          "generation_mode": "model",
+          "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 86,
+          "target": "standby_attitude_cage_knob",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+      ],
+      "in_reply_to": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+      "message": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。",
+      "metadata": {
+        "allowed_evidence_ref_count": 119,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "f8b00361-d43d-4b62-9f42-c27d251b08e9",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "radar_altimeter_bug_knob"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S32"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+          "source_observation_seq": 12853,
+          "source_observation_t_wall": 1779198877.5485222,
+          "telemetry_window_first_seq": 12834,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12853,
+          "telemetry_window_latest_t_wall": 1779198877.5485222,
+          "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "overlay_step_id": "S32",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S32",
+          "targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 119,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S32"
+          },
+          "next": {
+            "step_id": "S32"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_original_actions": [
+          {
+            "element_id": "pnt_291",
+            "evidence_refs": [
+              "VARS.battery_on"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "radar_altimeter_bug_knob",
+            "type": "overlay"
+          }
+        ],
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S32",
+        "final_evidence_consistency_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+          "completion_gate_already_satisfied:S31"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "standby_attitude_cage_knob"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_213",
+              "evidence_refs": [
+                "GATES.S32.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "standby_attitude_cage_knob"
+              ],
+              "frame_id": "1779198877598_000264",
+              "fused_missing_conditions": [
+                "vars.radar_altimeter_bug_value in [180,220]"
+              ],
+              "fused_step_id": "S31",
+              "generation_mode": "model",
+              "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 86,
+              "target": "standby_attitude_cage_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198877598_000264"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S32"
+          },
+          "explanations": [
+            "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+          ],
+          "message": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。",
+          "next": {
+            "step_id": "S32"
+          }
+        },
+        "frame_id": "1779198877598_000264",
+        "fused_missing_conditions": [
+          "vars.radar_altimeter_bug_value in [180,220]"
+        ],
+        "fused_step_id": "S31",
+        "generation_mode": "model",
+        "generation_prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+        "generation_prompt_tokens_est": 5610,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S32",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S32",
+          "targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "radar_altimeter_bug_knob"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S31",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "standby_attitude_cage_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S32",
+              "supporting_evidence_refs": [
+                "GATES.S32.completion"
+              ]
+            },
+            {
+              "confidence": 0.5,
+              "proposed_next_action_target_ids": [
+                "radar_altimeter_bug_knob"
+              ],
+              "role": "candidate",
+              "source": "recent_action",
+              "step_id": "S31",
+              "supporting_evidence_refs": [
+                "RECENT_ACTIONS.radar_altimeter_bug_knob"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.66,
+            "proposed_next_action_target_ids": [
+              "standby_attitude_cage_knob"
+            ],
+            "role": "candidate",
+            "source": "gate_blocker",
+            "step_id": "S32",
+            "supporting_evidence_refs": [
+              "GATES.S32.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 4,
+            "conflicts": [],
+            "recent_action_count": 1,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 1,
+              "contradiction_count": 0,
+              "first_seq": 12834,
+              "frame_count": 20,
+              "latest_seq": 12853
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+            "source_observation_seq": 12853,
+            "source_observation_t_wall": 1779198877.5485222,
+            "telemetry_window_first_seq": 12834,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 12853,
+            "telemetry_window_latest_t_wall": 1779198877.5485222,
+            "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "overlay_step_id": "S32",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S32",
+            "targets": [
+              "standby_attitude_cage_knob"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "standby_attitude_cage_knob"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "VARS.battery_on"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "radar_altimeter_bug_knob"
+            ],
+            "status": "ok",
+            "step_id": "S31"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S31"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+            "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+              "completion_gate_already_satisfied:S31"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S31"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779198877598_000264"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 86,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+          "completion_gate_already_satisfied:S31"
+        ],
+        "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S32"
+          },
+          "explanations": [
+            "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+          ],
+          "next": {
+            "step_id": "S32"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S32.completion",
+                "target": "standby_attitude_cage_knob",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "standby_attitude_cage_knob"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S31"
+          },
+          "explanations": [
+            "S08 视觉证据缺失且非当前阻塞点。根据候选步骤优先级，当前应执行 S31：设置雷达高度表游标。请旋转 radar_altimeter_bug_knob 将游标设置为 180 或 220 英尺。"
+          ],
+          "next": {
+            "step_id": "S31"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.battery_on",
+                "target": "radar_altimeter_bug_knob",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "radar_altimeter_bug_knob"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4813,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S31"
+        },
+        "model_raw_explanations": [
+          "S08 视觉证据缺失且非当前阻塞点。根据候选步骤优先级，当前应执行 S31：设置雷达高度表游标。请旋转 radar_altimeter_bug_knob 将游标设置为 180 或 220 英尺。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S31"
+          },
+          "explanations": [
+            "S08 视觉证据缺失且非当前阻塞点。根据候选步骤优先级，当前应执行 S31：设置雷达高度表游标。请旋转 radar_altimeter_bug_knob 将游标设置为 180 或 220 英尺。"
+          ],
+          "next": {
+            "step_id": "S31"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.battery_on",
+                "target": "radar_altimeter_bug_knob",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "radar_altimeter_bug_knob"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S31"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779198877598_000264"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779198877598_000264",
+        "next": {
+          "step_id": "S32"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5612,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.radar_altimeter_bug_value",
+            "GATES.S01.completion",
+            "GATES.S01.precondition",
+            "GATES.S20.completion",
+            "GATES.S22.completion",
+            "GATES.S25.completion",
+            "GATES.S31.completion",
+            "GATES.S31.precondition",
+            "GATES.S32.completion",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_6",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_10",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_53"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "radar_altimeter_bug_knob",
+          "prompt_chars": 22440,
+          "prompt_tokens_est": 5610,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_error_coding_guide_6",
+            "Appendix - Training Task Syllabus_8",
+            "fa18c_coldstart_quiz_10",
+            "fa18c_startup_master_1",
+            "DCS FA-18C Early Access Guide EN_53"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+        "prompt_tokens_est": 5610,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.radar_altimeter_bug_value in [180,220]"
+        ],
+        "rejected_model_step_id": "S31",
+        "rejected_model_target": "radar_altimeter_bug_knob",
+        "rejected_model_targets": [
+          "radar_altimeter_bug_knob"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "0f9c1b68f797c5f1d4b43798d598bf421172e3bddc63a9a5da333d9f3b5c21b4",
+        "request_prompt_tokens_est": 5610,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 119,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S31"
+          },
+          "next": {
+            "step_id": "S31"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+          "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+        },
+        "state_key": "79afaccc9e97ea42552d9f760d0ec9edda216a805ccc82a91fe07e804884cf6b",
+        "sync_delta_ms": 86,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779198877598_000264",
+          "frame_ids": [
+            "1779198877598_000264"
+          ],
+          "frame_stale": false,
+          "observation_ref": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+          "observation_seq": 12853,
+          "observation_t_wall_ms": 1779198877549,
+          "observation_t_wall_s": 1779198877.5485222,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779198877598,
+              "channel": "composite_panel",
+              "frame_id": "1779198877598_000264",
+              "frame_seq": 264,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198877598_000264_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198877598_000264.png",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779198877598,
+            "channel": "composite_panel",
+            "frame_id": "1779198877598_000264",
+            "frame_seq": 264,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198877598_000264_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198877598_000264.png",
+            "sync_delta_ms": 86,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779198877512,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S31"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198877598_000264"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779198877598_000264"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "a740dd57-c218-4b68-9c5d-ccff0bdf881d",
+      "status": "ok",
+      "timestamp": "2026-05-19T13:54:42.867427+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S32",
+    "expected_overlay_target_ids": [
+      "standby_attitude_cage_knob"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "radar_altimeter_bug_knob"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S31",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "standby_attitude_cage_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S32",
+        "supporting_evidence_refs": [
+          "GATES.S32.completion"
+        ]
+      },
+      {
+        "confidence": 0.5,
+        "proposed_next_action_target_ids": [
+          "radar_altimeter_bug_knob"
+        ],
+        "role": "candidate",
+        "source": "recent_action",
+        "step_id": "S31",
+        "supporting_evidence_refs": [
+          "RECENT_ACTIONS.radar_altimeter_bug_knob"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+      "overlay_step_id": "S32",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S32",
+      "targets": [
+        "standby_attitude_cage_knob"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VARS.battery_on"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "radar_altimeter_bug_knob"
+      ],
+      "status": "ok",
+      "step_id": "S31"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "radar_altimeter_bug_knob"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S31",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "standby_attitude_cage_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S32",
+          "supporting_evidence_refs": [
+            "GATES.S32.completion"
+          ]
+        },
+        {
+          "confidence": 0.5,
+          "proposed_next_action_target_ids": [
+            "radar_altimeter_bug_knob"
+          ],
+          "role": "candidate",
+          "source": "recent_action",
+          "step_id": "S31",
+          "supporting_evidence_refs": [
+            "RECENT_ACTIONS.radar_altimeter_bug_knob"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "standby_attitude_cage_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S32",
+        "supporting_evidence_refs": [
+          "GATES.S32.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 4,
+        "conflicts": [],
+        "recent_action_count": 1,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 1,
+          "contradiction_count": 0,
+          "first_seq": 12834,
+          "frame_count": 20,
+          "latest_seq": 12853
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "final_decision_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "model_request_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "source_observation_id": "5dac0fda-1f48-43d2-bcd0-98cc775b2700",
+        "source_observation_seq": 12853,
+        "source_observation_t_wall": 1779198877.5485222,
+        "telemetry_window_first_seq": 12834,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 12853,
+        "telemetry_window_latest_t_wall": 1779198877.5485222,
+        "validator_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "overlay_step_id": "S32",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S32",
+        "targets": [
+          "standby_attitude_cage_knob"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "standby_attitude_cage_knob"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "VARS.battery_on"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "radar_altimeter_bug_knob"
+        ],
+        "status": "ok",
+        "step_id": "S31"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S31"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "final_decision": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "model_request": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594",
+        "validator": "f40a3eec6d550136d00d09c41147eea7de0ef5fb13ab46f51accd98c3a7b5594"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+          "completion_gate_already_satisfied:S31"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S31"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779198877598_000264"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 86,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "missing_condition_satisfied_by_latest_telemetry:vars.radar_altimeter_bug_value in [180,220]",
+        "completion_gate_already_satisfied:S31"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S31"
+    }
+  },
+  "help_cycle_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S32"
+      },
+      "explanations": [
+        "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。"
+      ],
+      "next": {
+        "step_id": "S32"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S32.completion",
+            "target": "standby_attitude_cage_knob",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "standby_attitude_cage_knob"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S31"
+      },
+      "explanations": [
+        "S08 视觉证据缺失且非当前阻塞点。根据候选步骤优先级，当前应执行 S31：设置雷达高度表游标。请旋转 radar_altimeter_bug_knob 将游标设置为 180 或 220 英尺。"
+      ],
+      "next": {
+        "step_id": "S31"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.battery_on",
+            "target": "radar_altimeter_bug_knob",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "radar_altimeter_bug_knob"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "ffb5e69b-664b-47d8-9150-57d7cd75d233",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 14472,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_134129.jsonl"
+  }
+}

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -614,6 +614,37 @@ def _state_action_plan(
             recent_action_targets=recent_action_targets,
             max_overlay_targets=max_overlay_targets,
         )
+    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
+    if step_id == "S10" and vars_map.get("engine_crank_left_complete") is not True:
+        if "eng_crank_switch" in allowed:
+            return _StateActionPlan(
+                targets=("eng_crank_switch",),
+                guidance="Set the engine crank switch to LEFT with a left-click to start the left engine.",
+                text_only=False,
+                source="state_action_planner",
+                reasons=("s10_left_engine_left_click_guidance",),
+            )
+    if step_id == "S31" and vars_map.get("radar_altimeter_bug_set") is not True:
+        if "radar_altimeter_bug_knob" in allowed:
+            return _StateActionPlan(
+                targets=("radar_altimeter_bug_knob",),
+                guidance=(
+                    "Use the mouse wheel on the radar altimeter bug knob to set 200 ft "
+                    "for airfield or 40 ft for carrier."
+                ),
+                text_only=False,
+                source="state_action_planner",
+                reasons=("s31_radar_altimeter_mouse_wheel_guidance",),
+            )
+    if step_id == "S32" and vars_map.get("standby_attitude_uncaged") is not True:
+        if "standby_attitude_cage_knob" in allowed:
+            return _StateActionPlan(
+                targets=("standby_attitude_cage_knob",),
+                guidance="Use the mouse wheel on the standby attitude cage knob to uncage the standby attitude indicator.",
+                text_only=False,
+                source="state_action_planner",
+                reasons=("s32_standby_attitude_mouse_wheel_guidance",),
+            )
 
     motion_state = _probe_motion_state(step_id, vars_map, evidence_packet=evidence_packet)
     if motion_state == "s20_extending":
@@ -635,7 +666,6 @@ def _state_action_plan(
 
     seen_or_fresh = set(_strings(vision_seen_fact_ids)) | set(_strings(vision_fresh_fact_ids))
     not_seen = set(_strings(vision_not_seen_fact_ids))
-    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
     if step_id == "S18" and "bit_root_page_visible" in seen_or_fresh and "fcsmc_page_visible" in not_seen:
         if "right_mdi_pb5" in allowed:
             return _StateActionPlan(

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -6423,6 +6423,24 @@ class LiveDcsTutorLoop:
                 if self.lang == "zh"
                 else "Enter COMM1 frequency 134.000 on the UFC: press 1-3-4-0-0-0, then ENT."
             )
+        if "s10_left_engine_left_click_guidance" in plan.reasons:
+            plan_guidance = (
+                "当前处于 S10。请将 Engine Crank 开关拨到 LEFT/L 位置：用左键点击 ENG CRANK 开关启动左发。"
+                if self.lang == "zh"
+                else "You are on S10. Set the Engine Crank switch to LEFT/L with a left-click to start the left engine."
+            )
+        elif "s31_radar_altimeter_mouse_wheel_guidance" in plan.reasons:
+            plan_guidance = (
+                "现在进入 S31。请用鼠标滚轮调整雷达高度表告警高度旋钮：机场 200 ft，航母 40 ft。"
+                if self.lang == "zh"
+                else "Continue to S31. Use the mouse wheel on the radar altimeter bug knob: 200 ft for airfield or 40 ft for carrier."
+            )
+        elif "s32_standby_attitude_mouse_wheel_guidance" in plan.reasons:
+            plan_guidance = (
+                "现在进入 S32。请用鼠标滚轮操作备用姿态仪 cage knob，解锁备用姿态仪。"
+                if self.lang == "zh"
+                else "Continue to S32. Use the mouse wheel on the standby attitude cage knob to uncage the standby attitude indicator."
+            )
         if s18_visual_hint_used and (not isinstance(plan_guidance, str) or not plan_guidance):
             plan_guidance = s18_visual_hint_reason
         emergency_presentation_fallback = response.status == "error" or response.metadata.get("provider") == "fallback"
@@ -7177,6 +7195,10 @@ class LiveDcsTutorLoop:
             rewritten = "现在进入 S24。请放下阻钩手柄，确认阻钩已伸出。"
         elif next_step_id == "S24" and response.metadata.get("final_evidence_consistency_forced_step_id") == "S24":
             rewritten = "Continue to S24. Lower the arresting hook handle and confirm the hook is down."
+        elif next_step_id == "S33" and rejected_step_id == "S33" and self.lang == "zh":
+            rewritten = "姿态源选择器已经在 AUTO，S33 检查已满足；冷启动流程已完成，无需继续操作。"
+        elif next_step_id == "S33" and rejected_step_id == "S33":
+            rewritten = "The attitude source selector is already on AUTO, so S33 is satisfied; the cold-start flow is complete."
         elif self.lang == "zh":
             rewritten = f"{rejected_step_id} 的最新证据已经满足。现在进入 {next_step_id}。"
         else:
@@ -8258,16 +8280,16 @@ class LiveDcsTutorLoop:
                 "S28": "现在进入 S28。请释放停车刹车手柄，准备滑行。",
                 "S29": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。",
                 "S30": "现在进入 S30。请调整备用气压高度表到当前机场标高/QNH。",
-                "S31": "现在进入 S31。请设置雷达高度表告警高度：机场 200 ft，航母 40 ft。",
-                "S32": "现在进入 S32。请解锁备用姿态仪，让姿态指示器自由工作。",
+                "S31": "现在进入 S31。请用鼠标滚轮调整雷达高度表告警高度旋钮：机场 200 ft，航母 40 ft。",
+                "S32": "现在进入 S32。请用鼠标滚轮操作备用姿态仪 cage knob，解锁备用姿态仪。",
             }[overlay_step_id]
         elif overlay_step_id in {"S28", "S29", "S30", "S31", "S32"}:
             fallback_guidance = {
                 "S28": "Continue to S28. Release the parking brake handle when ready to taxi.",
                 "S29": "Continue to S29. Use the IFEI UP/DOWN buttons to set the BINGO fuel.",
                 "S30": "Continue to S30. Adjust the standby pressure altimeter to the local field elevation or QNH.",
-                "S31": "Continue to S31. Set the radar altimeter bug to 200 ft for airfield or 40 ft for carrier.",
-                "S32": "Continue to S32. Uncage the standby attitude indicator.",
+                "S31": "Continue to S31. Use the mouse wheel on the radar altimeter bug knob: 200 ft for airfield or 40 ft for carrier.",
+                "S32": "Continue to S32. Use the mouse wheel on the standby attitude cage knob to uncage the standby attitude indicator.",
             }[overlay_step_id]
 
         fallback_help_obj = {

--- a/packs/fa18c_startup/pack.yaml
+++ b/packs/fa18c_startup/pack.yaml
@@ -1068,7 +1068,7 @@ steps:
     ui_targets:
       - radar_altimeter_bug_knob
     tutor_prompts:
-      - "Set radar altimeter bug to 200 ft (airfield) or 40 ft (carrier)."
+      - "Use the mouse wheel on the radar altimeter bug knob to set 200 ft (airfield) or 40 ft (carrier)."
 
   - id: S32
     phase: P6
@@ -1084,7 +1084,7 @@ steps:
     ui_targets:
       - standby_attitude_cage_knob
     tutor_prompts:
-      - "Uncage the standby attitude indicator."
+      - "Use the mouse wheel on the standby attitude cage knob to uncage the standby attitude indicator."
 
   - id: S33
     phase: P6

--- a/packs/fa18c_startup/ui_map.yaml
+++ b/packs/fa18c_startup/ui_map.yaml
@@ -404,11 +404,21 @@ cockpit_elements:
     dcs_id: "pnt_291"
     aliases: ["Radar Altimeter Push to Test/Set Min Alt"]
     panel_area: "right_instrument_panel"
+    interaction:
+      click_type: "wheel_up"
+    interaction_hint:
+      zh: "雷达高度表告警高度旋钮：用鼠标滚轮调整，机场 200 ft，航母 40 ft。"
+      en: "Radar altimeter bug knob: use the mouse wheel; set 200 ft for airfield or 40 ft for carrier."
   standby_attitude_cage_knob:
     description: "Standby attitude indicator cage knob"
     dcs_id: "pnt_213"
     aliases: ["SAI Cage Knob"]
     panel_area: "right_instrument_panel"
+    interaction:
+      click_type: "wheel_up"
+    interaction_hint:
+      zh: "备用姿态仪 cage knob：用鼠标滚轮解锁。"
+      en: "Standby attitude cage knob: use the mouse wheel to uncage."
   attitude_source_selector:
     description: "HUD attitude source selector INS/AUTO/STBY"
     dcs_id: "pnt_148"

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -894,6 +894,52 @@ def test_plan_harness_action_clears_unavailable_s09_state_target_instead_of_repa
     assert plan.final_action_plan_source == "state_action_planner"
 
 
+def test_plan_harness_action_owns_known_control_interaction_guidance() -> None:
+    cases = [
+        (
+            "S10",
+            "eng_crank_switch",
+            {"engine_crank_left_complete": False},
+            ("LEFT", "left-click"),
+            "s10_left_engine_left_click_guidance",
+        ),
+        (
+            "S31",
+            "radar_altimeter_bug_knob",
+            {"radar_altimeter_bug_set": False},
+            ("mouse wheel", "200 ft", "40 ft"),
+            "s31_radar_altimeter_mouse_wheel_guidance",
+        ),
+        (
+            "S32",
+            "standby_attitude_cage_knob",
+            {"standby_attitude_uncaged": False},
+            ("mouse wheel", "standby attitude"),
+            "s32_standby_attitude_mouse_wheel_guidance",
+        ),
+    ]
+
+    for step_id, target, vars_map, expected_parts, expected_reason in cases:
+        plan = plan_harness_action(
+            step_specs={step_id: _spec(step_id, (target,))},
+            inferred_step_id=step_id,
+            model_step_id=step_id,
+            proposed_overlay_targets=[target],
+            candidate_step_ids=[step_id],
+            runtime_overlay_targets=[target],
+            request_overlay_targets=[target],
+            max_overlay_targets=1,
+            latest_vars=vars_map,
+        )
+
+        assert plan.targets == (target,)
+        assert plan.final_action_plan_source == "state_action_planner"
+        assert expected_reason in plan.reasons
+        guidance = plan.guidance or ""
+        for expected in expected_parts:
+            assert expected in guidance
+
+
 def test_plan_harness_action_returns_text_only_when_probe_is_already_moving() -> None:
     cases = [
         (

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11377,6 +11377,69 @@ def test_live_help_fixture_314_s18_pb5_repair_rewrites_public_message() -> None:
     assert "PB18" not in public_text
 
 
+def test_live_help_fixture_314_s10_left_engine_uses_left_click_guidance() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/3de0e688-8bc4-4df1-b062-72f3134bc775.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["final_overlay_targets"] == ["eng_crank_switch"]
+    public_text = _public_response_text(repaired)
+    assert "LEFT" in public_text or "L 位置" in public_text
+    assert "左键" in public_text or "left-click" in public_text
+    assert "R 位置" not in public_text
+    assert "右键" not in public_text
+    assert "right-click" not in public_text
+
+
+def test_live_help_fixture_314_s31_radar_altimeter_uses_mouse_wheel_guidance() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/5a7d5df7-2f08-4321-9a4a-6858131b4e6e.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["final_overlay_targets"] == ["radar_altimeter_bug_knob"]
+    public_text = _public_response_text(repaired)
+    assert "滚轮" in public_text or "mouse wheel" in public_text or "mouse-wheel" in public_text
+    assert "200" in public_text and "40" in public_text
+
+
+def test_live_help_fixture_314_s32_standby_attitude_uses_mouse_wheel_guidance() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/ffb5e69b-664b-47d8-9150-57d7cd75d233.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["final_overlay_targets"] == ["standby_attitude_cage_knob"]
+    public_text = _public_response_text(repaired)
+    assert "滚轮" in public_text or "mouse wheel" in public_text or "mouse-wheel" in public_text
+    assert "备用姿态" in public_text or "standby attitude" in public_text.lower()
+
+
+def test_live_help_fixture_314_s33_default_satisfied_uses_public_completion_message() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/7bea22f8-a4d1-4744-917b-f7ddc957f709.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S33"
+    assert repaired.metadata["next"]["step_id"] == "S33"
+    assert repaired.metadata["final_overlay_targets"] == []
+    public_text = _public_response_text(repaired)
+    assert "最新证据" not in public_text
+    assert "evidence" not in public_text.lower()
+    assert "AUTO" in public_text
+    assert "完成" in public_text
+
+
 def test_safe_fallback_overlay_syncs_message_after_completion_conflict_repair() -> None:
     request = TutorRequest(
         actor="learner",


### PR DESCRIPTION
## Summary
- add state-action planner ownership for S10 LEFT/left-click, S31 radar-altimeter mouse-wheel, and S32 standby-attitude mouse-wheel guidance
- add ui_map/pack interaction hints for S31/S32 wheel-operated controls
- replace S33 evidence-internal completion wording with a user-facing AUTO/completion message
- add live replay fixtures/assertions for the latest issue #314 comment examples

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k '314_s10_left_engine or 314_s31_radar_altimeter or 314_s32_standby_attitude or 314_s33_default'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_pack_ui_targets_valid.py tests/test_step_harness_specs.py tests/test_live_dcs.py -k 'known_control_interaction or 314_s10_left_engine or 314_s31_radar_altimeter or 314_s32_standby_attitude or 314_s33_default or final_public_guidance or interaction or ui_targets'
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_pack_ui_targets_valid.py tests/test_step_harness_specs.py

Related to #314