### PR TITLE
Align repaired evidence refs with final action

### DIFF
--- a/artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json
+++ b/artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json
@@ -1,0 +1,3197 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 12677,
+        "frame_count": 20,
+        "latest_seq": 12696
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+      "source_observation_seq": 12696,
+      "source_observation_t_wall": 1779198850.8817885,
+      "telemetry_window_first_seq": 12677,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 12696,
+      "telemetry_window_latest_t_wall": 1779198850.8817885,
+      "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+    },
+    "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:64396",
+          "raw_delta_count": 1,
+          "seq": 12696
+        },
+        "observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_RIGHT"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_RIGHT",
+                "ui_targets": [],
+                "value": 39030
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 12696,
+          "t_wall": 1779198850.8817885,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": true,
+            "pitot_heat_on": true,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 310,
+            "temp_r": 322,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T13:54:10.881788+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 12677,
+      "frame_count": 20,
+      "latest_seq": 12696
+    },
+    "vision": {
+      "frame_ids": [
+        "1779198850939_000262"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779198850939_000262",
+        "frame_ids": [
+          "1779198850939_000262"
+        ],
+        "frame_stale": false,
+        "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+        "observation_seq": 12696,
+        "observation_t_wall_ms": 1779198850882,
+        "observation_t_wall_s": 1779198850.8817885,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779198850939,
+            "channel": "composite_panel",
+            "frame_id": "1779198850939_000262",
+            "frame_seq": 262,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198850939_000262_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198850939_000262.png",
+            "sync_delta_ms": 88,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 88,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779198850939,
+          "channel": "composite_panel",
+          "frame_id": "1779198850939_000262",
+          "frame_seq": 262,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198850939_000262_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198850939_000262.png",
+          "sync_delta_ms": 88,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779198850851,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779198850939_000262"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "kind": "tutor_request",
+        "lineno": 13371,
+        "metadata": {
+          "frame_id": "1779198850939_000262",
+          "fused_missing_conditions": [
+            "vars.parking_brake_released==true"
+          ],
+          "fused_step_id": "S28",
+          "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 88,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S28",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S28",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "parking_brake_handle"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 12677,
+                "frame_count": 20,
+                "latest_seq": 12696
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+              "source_observation_seq": 12696,
+              "source_observation_t_wall": 1779198850.8817885,
+              "telemetry_window_first_seq": 12677,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12696,
+              "telemetry_window_latest_t_wall": 1779198850.8817885,
+              "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_1",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "1. Scenario Definition",
+                "score": 24.02604652973456,
+                "section": "1. Scenario Definition",
+                "snippet_id": "Appendix - Training Task Syllabus_1"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_12",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q12. Sequence Mini-Task 2",
+                "score": 19.172607698908763,
+                "section": "Q12. Sequence Mini-Task 2",
+                "snippet_id": "fa18c_coldstart_quiz_12"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_115",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 116,
+                "score": 18.920021229840746,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_115"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_8",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "score": 16.916118048536976,
+                "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+                "snippet_id": "Appendix - Training Task Syllabus_8"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_0",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Task Syllabus: F/A-18C Cold Start to Taxi-Ready",
+                "score": 15.137895908381518,
+                "section": "Task Syllabus: F/A-18C Cold Start to Taxi-Ready",
+                "snippet_id": "Appendix - Training Task Syllabus_0"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.parking_brake_released==true"
+                ],
+                "overlay_step_id": "S28",
+                "role": "candidate_not_authoritative",
+                "step_id": "S28"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 12696,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 12677,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 12696,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 12696,
+                "latest_t_wall": 1779198850.8817885,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "pitot_heat_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.656
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779198850939_000262",
+              "frame_ids": [
+                "1779198850939_000262"
+              ],
+              "frame_stale": false,
+              "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+              "observation_seq": 12696,
+              "observation_t_wall_ms": 1779198850882,
+              "observation_t_wall_s": 1779198850.8817885,
+              "status": "partial",
+              "sync_delta_ms": 88,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779198850851,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198850939_000262"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 12677,
+                "frame_count": 20,
+                "latest_seq": 12696
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+              "source_observation_seq": 12696,
+              "source_observation_t_wall": 1779198850.8817885,
+              "telemetry_window_first_seq": 12677,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12696,
+              "telemetry_window_latest_t_wall": 1779198850.8817885,
+              "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "frame_id": "1779198850939_000262",
+            "fused_missing_conditions": [
+              "vars.parking_brake_released==true"
+            ],
+            "fused_step_id": "S28",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "Appendix - Training Task Syllabus_1",
+              "fa18c_coldstart_quiz_12",
+              "DCS FA-18C Early Access Guide EN_115",
+              "Appendix - Training Task Syllabus_8",
+              "Appendix - Training Task Syllabus_0"
+            ],
+            "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+            "prompt_tokens_est": 5526,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "source_chunk_refs": [
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_12",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_115",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_0"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 88,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198850939_000262"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779198850939_000262"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+          "request_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "timestamp": "2026-05-19T13:54:11.379864+00:00",
+          "version": "v1"
+        },
+        "related_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "vision_refs": [
+          "1779198850939_000262"
+        ]
+      },
+      {
+        "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "kind": "overlay_requested",
+        "lineno": 13372,
+        "metadata": {
+          "final_overlay_targets": [
+            "ifei_up_button"
+          ],
+          "frame_id": "1779198850939_000262",
+          "fused_missing_conditions": [
+            "vars.parking_brake_released==true"
+          ],
+          "fused_step_id": "S28",
+          "generation_mode": "model",
+          "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 88,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "3d20e77d-b176-4518-93f0-c2ac96fff03c",
+          "final_overlay_targets": [
+            "ifei_up_button"
+          ],
+          "frame_id": "1779198850939_000262",
+          "fused_missing_conditions": [
+            "vars.parking_brake_released==true"
+          ],
+          "fused_step_id": "S28",
+          "generation_mode": "model",
+          "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 88,
+          "target": "pnt_240",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "kind": "overlay_requested",
+        "lineno": 13373,
+        "metadata": {
+          "final_overlay_targets": [
+            "ifei_up_button"
+          ],
+          "frame_id": "1779198850939_000262",
+          "fused_missing_conditions": [
+            "vars.parking_brake_released==true"
+          ],
+          "fused_step_id": "S28",
+          "generation_mode": "model",
+          "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 88,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "917d6ba5-eacd-4631-baa6-726f43ef4efc",
+          "final_overlay_targets": [
+            "ifei_up_button"
+          ],
+          "frame_id": "1779198850939_000262",
+          "fused_missing_conditions": [
+            "vars.parking_brake_released==true"
+          ],
+          "fused_step_id": "S28",
+          "generation_mode": "model",
+          "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 88,
+          "target": "pnt_170",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "kind": "tutor_response",
+        "lineno": 13374,
+        "metadata": {
+          "final_overlay_targets": [
+            "ifei_up_button"
+          ],
+          "frame_id": "1779198850939_000262",
+          "fused_missing_conditions": [
+            "vars.parking_brake_released==true"
+          ],
+          "fused_step_id": "S28",
+          "generation_mode": "model",
+          "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 88,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_170",
+              "evidence_refs": [
+                "GATES.S29.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ifei_up_button"
+              ],
+              "frame_id": "1779198850939_000262",
+              "fused_missing_conditions": [
+                "vars.parking_brake_released==true"
+              ],
+              "fused_step_id": "S28",
+              "generation_mode": "model",
+              "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 88,
+              "target": "ifei_up_button",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198850939_000262"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+          ],
+          "in_reply_to": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "message": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。",
+          "metadata": {
+            "allowed_evidence_ref_count": 117,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "de55962e-e67d-4189-a62a-1fde41b5ebd5",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S29"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+              "source_observation_seq": 12696,
+              "source_observation_t_wall": 1779198850.8817885,
+              "telemetry_window_first_seq": 12677,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 12696,
+              "telemetry_window_latest_t_wall": 1779198850.8817885,
+              "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "overlay_step_id": "S29",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S29",
+              "targets": [
+                "ifei_up_button"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 117,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S29"
+              },
+              "next": {
+                "step_id": "S29"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_original_actions": [
+              {
+                "element_id": "pnt_240",
+                "evidence_refs": [
+                  "GATES.S28.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "parking_brake_handle",
+                "type": "overlay"
+              }
+            ],
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S29",
+            "final_evidence_consistency_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+              "completion_gate_already_satisfied:S28"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "ifei_up_button"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_170",
+                  "evidence_refs": [
+                    "GATES.S29.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ifei_up_button"
+                  ],
+                  "frame_id": "1779198850939_000262",
+                  "fused_missing_conditions": [
+                    "vars.parking_brake_released==true"
+                  ],
+                  "fused_step_id": "S28",
+                  "generation_mode": "model",
+                  "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 88,
+                  "target": "ifei_up_button",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779198850939_000262"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S29"
+              },
+              "explanations": [
+                "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+              ],
+              "message": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。",
+              "next": {
+                "step_id": "S29"
+              }
+            },
+            "frame_id": "1779198850939_000262",
+            "fused_missing_conditions": [
+              "vars.parking_brake_released==true"
+            ],
+            "fused_step_id": "S28",
+            "generation_mode": "model",
+            "generation_prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+            "generation_prompt_tokens_est": 5526,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S29",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S29",
+              "targets": [
+                "ifei_up_button"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "parking_brake_handle"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S28",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button",
+                    "ifei_down_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": [
+                    "GATES.S29.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_altimeter_bug_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S31",
+                  "supporting_evidence_refs": [
+                    "GATES.S31.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "standby_attitude_cage_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S32",
+                  "supporting_evidence_refs": [
+                    "GATES.S32.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.66,
+                "proposed_next_action_target_ids": [
+                  "ifei_up_button",
+                  "ifei_down_button"
+                ],
+                "role": "candidate",
+                "source": "gate_blocker",
+                "step_id": "S29",
+                "supporting_evidence_refs": [
+                  "GATES.S29.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 12677,
+                  "frame_count": 20,
+                  "latest_seq": 12696
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+                "source_observation_seq": 12696,
+                "source_observation_t_wall": 1779198850.8817885,
+                "telemetry_window_first_seq": 12677,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 12696,
+                "telemetry_window_latest_t_wall": 1779198850.8817885,
+                "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "overlay_step_id": "S29",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S29",
+                "targets": [
+                  "ifei_up_button"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ifei_up_button"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S28.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "parking_brake_handle"
+                ],
+                "status": "ok",
+                "step_id": "S28"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S28"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+                "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+                  "completion_gate_already_satisfied:S28"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S28"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779198850939_000262"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 88,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+              "completion_gate_already_satisfied:S28"
+            ],
+            "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S29"
+              },
+              "explanations": [
+                "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+              ],
+              "next": {
+                "step_id": "S29"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S29.completion",
+                    "target": "ifei_up_button",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ifei_up_button"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S28"
+              },
+              "explanations": [
+                "当前处于 S28 阶段。S20、S22 等后续步骤因前置条件（如加油探头、发射杆）未满足而被阻塞。请操作 parking_brake_handle 释放刹车。"
+              ],
+              "next": {
+                "step_id": "S28"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S28.completion",
+                    "target": "parking_brake_handle",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "parking_brake_handle"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4553,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S28"
+            },
+            "model_raw_explanations": [
+              "当前处于 S28 阶段。S20、S22 等后续步骤因前置条件（如加油探头、发射杆）未满足而被阻塞。请操作 parking_brake_handle 释放刹车。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S28"
+              },
+              "explanations": [
+                "当前处于 S28 阶段。S20、S22 等后续步骤因前置条件（如加油探头、发射杆）未满足而被阻塞。请操作 parking_brake_handle 释放刹车。"
+              ],
+              "next": {
+                "step_id": "S28"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S28.completion",
+                    "target": "parking_brake_handle",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "parking_brake_handle"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S28"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779198850939_000262"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779198850939_000262",
+            "next": {
+              "step_id": "S29"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5579,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.parking_brake_released",
+                "GATES.S20.completion",
+                "GATES.S22.completion",
+                "GATES.S25.completion",
+                "GATES.S28.completion",
+                "GATES.S28.precondition",
+                "GATES.S29.completion",
+                "GATES.S31.completion",
+                "GATES.S32.completion",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_1",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_12",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_115",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_0"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": null,
+              "prompt_chars": 22103,
+              "prompt_tokens_est": 5526,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "Appendix - Training Task Syllabus_1",
+                "fa18c_coldstart_quiz_12",
+                "DCS FA-18C Early Access Guide EN_115",
+                "Appendix - Training Task Syllabus_8",
+                "Appendix - Training Task Syllabus_0"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+            "prompt_tokens_est": 5526,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.parking_brake_released==true"
+            ],
+            "rejected_model_step_id": "S28",
+            "rejected_model_target": "parking_brake_handle",
+            "rejected_model_targets": [
+              "parking_brake_handle"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+            "request_prompt_tokens_est": 5526,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 117,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S28"
+              },
+              "next": {
+                "step_id": "S28"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+              "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+            },
+            "state_key": "8cbd05336d5be237c70f1f8472d66df82b72bdd40e0ed2aebd43aadbb2f2b60a",
+            "sync_delta_ms": 88,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779198850939_000262",
+              "frame_ids": [
+                "1779198850939_000262"
+              ],
+              "frame_stale": false,
+              "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+              "observation_seq": 12696,
+              "observation_t_wall_ms": 1779198850882,
+              "observation_t_wall_s": 1779198850.8817885,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779198850939,
+                  "channel": "composite_panel",
+                  "frame_id": "1779198850939_000262",
+                  "frame_seq": 262,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198850939_000262_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198850939_000262.png",
+                  "sync_delta_ms": 88,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 88,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779198850939,
+                "channel": "composite_panel",
+                "frame_id": "1779198850939_000262",
+                "frame_seq": 262,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198850939_000262_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198850939_000262.png",
+                "sync_delta_ms": 88,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779198850851,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S28"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198850939_000262"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779198850939_000262"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "b1d7aa16-d0a7-4ecb-bd5b-f676ab40cb83",
+          "status": "ok",
+          "timestamp": "2026-05-19T13:54:15.933829+00:00",
+          "version": "v1"
+        },
+        "related_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "vision_refs": [
+          "1779198850939_000262"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S28",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S28",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "parking_brake_handle"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 12677,
+            "frame_count": 20,
+            "latest_seq": 12696
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+          "source_observation_seq": 12696,
+          "source_observation_t_wall": 1779198850.8817885,
+          "telemetry_window_first_seq": 12677,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12696,
+          "telemetry_window_latest_t_wall": 1779198850.8817885,
+          "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_1",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "1. Scenario Definition",
+            "score": 24.02604652973456,
+            "section": "1. Scenario Definition",
+            "snippet_id": "Appendix - Training Task Syllabus_1"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_12",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q12. Sequence Mini-Task 2",
+            "score": 19.172607698908763,
+            "section": "Q12. Sequence Mini-Task 2",
+            "snippet_id": "fa18c_coldstart_quiz_12"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_115",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 116,
+            "score": 18.920021229840746,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_115"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_8",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "score": 16.916118048536976,
+            "section": "Phase P6 – Pre-Taxi Instruments & Final Checks (S20–S25)",
+            "snippet_id": "Appendix - Training Task Syllabus_8"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_0",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Task Syllabus: F/A-18C Cold Start to Taxi-Ready",
+            "score": 15.137895908381518,
+            "section": "Task Syllabus: F/A-18C Cold Start to Taxi-Ready",
+            "snippet_id": "Appendix - Training Task Syllabus_0"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.parking_brake_released==true"
+            ],
+            "overlay_step_id": "S28",
+            "role": "candidate_not_authoritative",
+            "step_id": "S28"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 12696,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 12677,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 12696,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 12696,
+            "latest_t_wall": 1779198850.8817885,
+            "stable_false_vars": [
+              "fcs_bit_switch_up"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "pitot_heat_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.656
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779198850939_000262",
+          "frame_ids": [
+            "1779198850939_000262"
+          ],
+          "frame_stale": false,
+          "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+          "observation_seq": 12696,
+          "observation_t_wall_ms": 1779198850882,
+          "observation_t_wall_s": 1779198850.8817885,
+          "status": "partial",
+          "sync_delta_ms": 88,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779198850851,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198850939_000262"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 12677,
+            "frame_count": 20,
+            "latest_seq": 12696
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+          "source_observation_seq": 12696,
+          "source_observation_t_wall": 1779198850.8817885,
+          "telemetry_window_first_seq": 12677,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12696,
+          "telemetry_window_latest_t_wall": 1779198850.8817885,
+          "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "frame_id": "1779198850939_000262",
+        "fused_missing_conditions": [
+          "vars.parking_brake_released==true"
+        ],
+        "fused_step_id": "S28",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "Appendix - Training Task Syllabus_1",
+          "fa18c_coldstart_quiz_12",
+          "DCS FA-18C Early Access Guide EN_115",
+          "Appendix - Training Task Syllabus_8",
+          "Appendix - Training Task Syllabus_0"
+        ],
+        "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+        "prompt_tokens_est": 5526,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "source_chunk_refs": [
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_12",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_115",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_8",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_0"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 88,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198850939_000262"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779198850939_000262"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+      "request_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+      "timestamp": "2026-05-19T13:54:11.379864+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_170",
+          "evidence_refs": [
+            "GATES.S29.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ifei_up_button"
+          ],
+          "frame_id": "1779198850939_000262",
+          "fused_missing_conditions": [
+            "vars.parking_brake_released==true"
+          ],
+          "fused_step_id": "S28",
+          "generation_mode": "model",
+          "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 88,
+          "target": "ifei_up_button",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+      ],
+      "in_reply_to": "8d30d919-108d-4068-8b58-a9467aecdb21",
+      "message": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。",
+      "metadata": {
+        "allowed_evidence_ref_count": 117,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "de55962e-e67d-4189-a62a-1fde41b5ebd5",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S29"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+          "source_observation_seq": 12696,
+          "source_observation_t_wall": 1779198850.8817885,
+          "telemetry_window_first_seq": 12677,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 12696,
+          "telemetry_window_latest_t_wall": 1779198850.8817885,
+          "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "overlay_step_id": "S29",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S29",
+          "targets": [
+            "ifei_up_button"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 117,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S29"
+          },
+          "next": {
+            "step_id": "S29"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_original_actions": [
+          {
+            "element_id": "pnt_240",
+            "evidence_refs": [
+              "GATES.S28.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "parking_brake_handle",
+            "type": "overlay"
+          }
+        ],
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S29",
+        "final_evidence_consistency_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+          "completion_gate_already_satisfied:S28"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "ifei_up_button"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_170",
+              "evidence_refs": [
+                "GATES.S29.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ifei_up_button"
+              ],
+              "frame_id": "1779198850939_000262",
+              "fused_missing_conditions": [
+                "vars.parking_brake_released==true"
+              ],
+              "fused_step_id": "S28",
+              "generation_mode": "model",
+              "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 88,
+              "target": "ifei_up_button",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198850939_000262"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S29"
+          },
+          "explanations": [
+            "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+          ],
+          "message": "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。",
+          "next": {
+            "step_id": "S29"
+          }
+        },
+        "frame_id": "1779198850939_000262",
+        "fused_missing_conditions": [
+          "vars.parking_brake_released==true"
+        ],
+        "fused_step_id": "S28",
+        "generation_mode": "model",
+        "generation_prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+        "generation_prompt_tokens_est": 5526,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S29",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S29",
+          "targets": [
+            "ifei_up_button"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "parking_brake_handle"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S28",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S29",
+              "supporting_evidence_refs": [
+                "GATES.S29.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_altimeter_bug_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S31",
+              "supporting_evidence_refs": [
+                "GATES.S31.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "standby_attitude_cage_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S32",
+              "supporting_evidence_refs": [
+                "GATES.S32.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.66,
+            "proposed_next_action_target_ids": [
+              "ifei_up_button",
+              "ifei_down_button"
+            ],
+            "role": "candidate",
+            "source": "gate_blocker",
+            "step_id": "S29",
+            "supporting_evidence_refs": [
+              "GATES.S29.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 12677,
+              "frame_count": 20,
+              "latest_seq": 12696
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+            "source_observation_seq": 12696,
+            "source_observation_t_wall": 1779198850.8817885,
+            "telemetry_window_first_seq": 12677,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 12696,
+            "telemetry_window_latest_t_wall": 1779198850.8817885,
+            "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "overlay_step_id": "S29",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S29",
+            "targets": [
+              "ifei_up_button"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ifei_up_button"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S28.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "parking_brake_handle"
+            ],
+            "status": "ok",
+            "step_id": "S28"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S28"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+            "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+              "completion_gate_already_satisfied:S28"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S28"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779198850939_000262"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 88,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+          "completion_gate_already_satisfied:S28"
+        ],
+        "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S29"
+          },
+          "explanations": [
+            "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+          ],
+          "next": {
+            "step_id": "S29"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S29.completion",
+                "target": "ifei_up_button",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ifei_up_button"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S28"
+          },
+          "explanations": [
+            "当前处于 S28 阶段。S20、S22 等后续步骤因前置条件（如加油探头、发射杆）未满足而被阻塞。请操作 parking_brake_handle 释放刹车。"
+          ],
+          "next": {
+            "step_id": "S28"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S28.completion",
+                "target": "parking_brake_handle",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "parking_brake_handle"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4553,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S28"
+        },
+        "model_raw_explanations": [
+          "当前处于 S28 阶段。S20、S22 等后续步骤因前置条件（如加油探头、发射杆）未满足而被阻塞。请操作 parking_brake_handle 释放刹车。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S28"
+          },
+          "explanations": [
+            "当前处于 S28 阶段。S20、S22 等后续步骤因前置条件（如加油探头、发射杆）未满足而被阻塞。请操作 parking_brake_handle 释放刹车。"
+          ],
+          "next": {
+            "step_id": "S28"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S28.completion",
+                "target": "parking_brake_handle",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "parking_brake_handle"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S28"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779198850939_000262"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779198850939_000262",
+        "next": {
+          "step_id": "S29"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5579,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.parking_brake_released",
+            "GATES.S20.completion",
+            "GATES.S22.completion",
+            "GATES.S25.completion",
+            "GATES.S28.completion",
+            "GATES.S28.precondition",
+            "GATES.S29.completion",
+            "GATES.S31.completion",
+            "GATES.S32.completion",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_1",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_12",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_115",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_8",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_0"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": null,
+          "prompt_chars": 22103,
+          "prompt_tokens_est": 5526,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "Appendix - Training Task Syllabus_1",
+            "fa18c_coldstart_quiz_12",
+            "DCS FA-18C Early Access Guide EN_115",
+            "Appendix - Training Task Syllabus_8",
+            "Appendix - Training Task Syllabus_0"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+        "prompt_tokens_est": 5526,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.parking_brake_released==true"
+        ],
+        "rejected_model_step_id": "S28",
+        "rejected_model_target": "parking_brake_handle",
+        "rejected_model_targets": [
+          "parking_brake_handle"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "3004f4a979a6966661528c69530b6fd4387f9e5b5c7ea19da75876bfb0559320",
+        "request_prompt_tokens_est": 5526,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 117,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S28"
+          },
+          "next": {
+            "step_id": "S28"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+          "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+        },
+        "state_key": "8cbd05336d5be237c70f1f8472d66df82b72bdd40e0ed2aebd43aadbb2f2b60a",
+        "sync_delta_ms": 88,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779198850939_000262",
+          "frame_ids": [
+            "1779198850939_000262"
+          ],
+          "frame_stale": false,
+          "observation_ref": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+          "observation_seq": 12696,
+          "observation_t_wall_ms": 1779198850882,
+          "observation_t_wall_s": 1779198850.8817885,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779198850939,
+              "channel": "composite_panel",
+              "frame_id": "1779198850939_000262",
+              "frame_seq": 262,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198850939_000262_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198850939_000262.png",
+              "sync_delta_ms": 88,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 88,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779198850939,
+            "channel": "composite_panel",
+            "frame_id": "1779198850939_000262",
+            "frame_seq": 262,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198850939_000262_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198850939_000262.png",
+            "sync_delta_ms": 88,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779198850851,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S28"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198850939_000262"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779198850939_000262"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "b1d7aa16-d0a7-4ecb-bd5b-f676ab40cb83",
+      "status": "ok",
+      "timestamp": "2026-05-19T13:54:15.933829+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S29",
+    "expected_overlay_target_ids": [
+      "ifei_up_button"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "parking_brake_handle"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S28",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "GATES.S29.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_altimeter_bug_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S31",
+        "supporting_evidence_refs": [
+          "GATES.S31.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "standby_attitude_cage_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S32",
+        "supporting_evidence_refs": [
+          "GATES.S32.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+      "overlay_step_id": "S29",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S29",
+      "targets": [
+        "ifei_up_button"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S28.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "parking_brake_handle"
+      ],
+      "status": "ok",
+      "step_id": "S28"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "parking_brake_handle"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S28",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S29",
+          "supporting_evidence_refs": [
+            "GATES.S29.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_altimeter_bug_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S31",
+          "supporting_evidence_refs": [
+            "GATES.S31.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "standby_attitude_cage_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S32",
+          "supporting_evidence_refs": [
+            "GATES.S32.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "GATES.S29.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 12677,
+          "frame_count": 20,
+          "latest_seq": 12696
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "final_decision_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "model_request_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "source_observation_id": "7a8833c2-8903-4ee2-b7dc-d41b50eb9faa",
+        "source_observation_seq": 12696,
+        "source_observation_t_wall": 1779198850.8817885,
+        "telemetry_window_first_seq": 12677,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 12696,
+        "telemetry_window_latest_t_wall": 1779198850.8817885,
+        "validator_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "overlay_step_id": "S29",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S29",
+        "targets": [
+          "ifei_up_button"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ifei_up_button"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S28.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "parking_brake_handle"
+        ],
+        "status": "ok",
+        "step_id": "S28"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S28"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "final_decision": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "model_request": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d",
+        "validator": "63647303775b7d523a83a8693b3824d7dfdd54eb8728f5e558fa75b38e87e88d"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+          "completion_gate_already_satisfied:S28"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S28"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779198850939_000262"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 88,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "missing_condition_satisfied_by_latest_telemetry:vars.parking_brake_released==true",
+        "completion_gate_already_satisfied:S28"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S28"
+    }
+  },
+  "help_cycle_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S29"
+      },
+      "explanations": [
+        "现在进入 S29。请用 IFEI UP/DOWN 按钮设置 BINGO fuel。"
+      ],
+      "next": {
+        "step_id": "S29"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S29.completion",
+            "target": "ifei_up_button",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "ifei_up_button"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S28"
+      },
+      "explanations": [
+        "当前处于 S28 阶段。S20、S22 等后续步骤因前置条件（如加油探头、发射杆）未满足而被阻塞。请操作 parking_brake_handle 释放刹车。"
+      ],
+      "next": {
+        "step_id": "S28"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S28.completion",
+            "target": "parking_brake_handle",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "parking_brake_handle"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "8d30d919-108d-4068-8b58-a9467aecdb21",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 14472,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_134129.jsonl"
+  }
+}

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -8208,8 +8208,14 @@ class LiveDcsTutorLoop:
             fallback_targets_list = [candidate_targets[0]]
         fallback_target = fallback_targets_list[0]
 
+        missing_condition_refs: list[str] = []
+        for condition in missing_conditions:
+            if not isinstance(condition, str):
+                continue
+            matched = _MISSING_CONDITION_VAR_RE.search(condition)
+            if matched is not None:
+                missing_condition_refs.append(f"VARS.{matched.group(1)}")
         candidate_refs: list[str] = []
-        gate_blockers = hint.get("gate_blockers")
         if isinstance(gate_blockers, (list, tuple)):
             for blocker in gate_blockers:
                 if not isinstance(blocker, Mapping):
@@ -8217,11 +8223,15 @@ class LiveDcsTutorLoop:
                 ref = blocker.get("ref")
                 if isinstance(ref, str) and ref:
                     candidate_refs.append(ref)
+        if overridden_inferred_step:
+            candidate_refs.extend(missing_condition_refs)
         candidate_refs.append(f"GATES.{inferred_step_id}.completion")
         candidate_refs.append(f"GATES.{inferred_step_id}.precondition")
         if overlay_step_id != inferred_step_id:
             candidate_refs.append(f"GATES.{overlay_step_id}.completion")
             candidate_refs.append(f"GATES.{overlay_step_id}.precondition")
+        if not overridden_inferred_step:
+            candidate_refs.extend(missing_condition_refs)
         gate_var_refs = step_fallback_profile.get("gate_var_refs")
         if isinstance(gate_var_refs, list):
             for ref in gate_var_refs:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11150,6 +11150,25 @@ def _fixture_request_and_model_response(fixture: dict[str, Any]) -> tuple[TutorR
     return request, response
 
 
+def _fixture_request_and_raw_model_response(fixture: dict[str, Any]) -> tuple[TutorRequest, TutorResponse]:
+    request, _ = _fixture_request_and_model_response(fixture)
+    help_response = fixture["model_io"].get("model_raw_help_response") or fixture["model_io"]["help_response"]
+    explanations = [item for item in help_response.get("explanations", []) if isinstance(item, str)]
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message=explanations[0] if explanations else None,
+        actions=[],
+        explanations=explanations,
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": help_response,
+        },
+    )
+    return request, response
+
+
 def _public_response_text(response: TutorResponse) -> str:
     final_public = response.metadata.get("final_public_response")
     if not isinstance(final_public, dict):
@@ -11438,6 +11457,47 @@ def test_live_help_fixture_314_s33_default_satisfied_uses_public_completion_mess
     assert "evidence" not in public_text.lower()
     assert "AUTO" in public_text
     assert "完成" in public_text
+
+
+def test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json"
+    )
+    request, response = _fixture_request_and_raw_model_response(fixture)
+    request.context = dict(request.context)
+    request.context["deterministic_step_hint"] = dict(request.context["deterministic_step_hint"])
+    request.context["deterministic_step_hint"]["gate_blockers"] = [
+        {
+            "ref": "GATES.S28.precondition",
+            "reason": "Old raw-step blocker must not be reused after repair.",
+        }
+    ]
+    request.context["gates"] = {
+        "S29.completion": {"status": "blocked", "reason": "BINGO fuel must be set on the IFEI."},
+        "S29.precondition": {"status": "allowed"},
+    }
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    _assert_live_fixture_expectations(fixture, repaired)
+    assert repaired.metadata["diagnosis"]["step_id"] == "S29"
+    assert repaired.metadata["next"]["step_id"] == "S29"
+    assert repaired.metadata["final_action_plan"]["step_id"] == "S29"
+    assert repaired.metadata["final_action_plan"]["overlay_step_id"] == "S29"
+    assert repaired.metadata["final_overlay_targets"] == ["ifei_up_button"]
+    assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "ifei_up_button"
+    assert repaired.actions[0]["evidence_refs"] == ["VARS.bingo_fuel_set"]
+    assert repaired.metadata["help_response"]["overlay"]["evidence"][0]["ref"] == "VARS.bingo_fuel_set"
+    assert repaired.metadata["harness_trace"]["model_decision"]["step_id"] == "S28"
+    assert repaired.metadata["harness_trace"]["model_decision"]["overlay_targets"] == ["parking_brake_handle"]
+    assert repaired.metadata["harness_trace"]["validator_result"]["rejected"] is True
+    assert repaired.metadata["harness_trace"]["repair_result"]["path"] == "final_evidence_consistency_validator"
+    public_text = _public_response_text(repaired)
+    assert "BINGO" in public_text
+    assert "S20" not in public_text
+    assert "S22" not in public_text
+    assert "parking_brake_handle" not in public_text
+    assert "最新证据" not in public_text
 
 
 def test_safe_fallback_overlay_syncs_message_after_completion_conflict_repair() -> None:


### PR DESCRIPTION
## Summary
- prefer repaired-step missing-condition VARS evidence during final consistency override fallback, before generated gate refs
- avoid reusing stale raw-step gate blockers after final consistency advances/repairs the step
- add 8d30d919 live fixture replay using raw S28 parking-brake model output repaired to S29 IFEI guidance

## Tests
- python -m pytest -q -s --basetemp=.tmp/pytest-315-latest-8d tests/test_live_dcs.py::test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance
- python -m pytest -q -s --basetemp=.tmp/pytest-315-latest-related tests/test_live_dcs.py::test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance tests/test_live_dcs.py::test_live_help_fixture_314_s33_default_satisfied_uses_public_completion_message tests/test_live_dcs.py::test_live_help_fixture_306_7ea8_hook_down_advances_to_s25_without_trace_mismatch tests/test_live_dcs.py::test_final_evidence_consistency_repair_uses_repaired_action_guidance tests/test_step_harness_specs.py::test_step_harness_spec_derives_early_telemetry_delta_and_gate_contract
- python3 tools/ci_guard.py

Full test suite intentionally not run per request.