### PR TITLE
Fix issue 312 fixture regression matrix coverage

### DIFF
--- a/artifacts/live_fixtures/0758602b-05c0-4ff6-9938-22b7e226f7c0.fixture.json
+++ b/artifacts/live_fixtures/0758602b-05c0-4ff6-9938-22b7e226f7c0.fixture.json
@@ -1,0 +1,2967 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 3,
+        "contradiction_count": 0,
+        "first_seq": 5842,
+        "frame_count": 20,
+        "latest_seq": 5861
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+      "source_observation_seq": 5861,
+      "source_observation_t_wall": 1779198438.51196,
+      "telemetry_window_first_seq": 5842,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 5861,
+      "telemetry_window_latest_t_wall": 1779198438.51196,
+      "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+    },
+    "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 4,
+          "delta_dropped_count": 1,
+          "from_addr": "192.168.0.105:64396",
+          "raw_delta_count": 4,
+          "seq": 5861
+        },
+        "observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "IFEI_TEMP_L",
+              "EXT_NOZZLE_POS_L",
+              "HYD_IND_LEFT"
+            ],
+            "delta_count": 3,
+            "dropped_stats": {
+              "dropped_by_reason": {
+                "blacklist": 1
+              },
+              "dropped_total": 1
+            },
+            "raw_delta_count": 4,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "IFEI_TEMP_L",
+                "ui_targets": [],
+                "value": "202"
+              },
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "EXT_NOZZLE_POS_L",
+                "ui_targets": [],
+                "value": 8244
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_LEFT",
+                "ui_targets": [],
+                "value": 37983
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 5861,
+          "t_wall": 1779198438.51196,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": true,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 200,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 12.57953765163653,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 30,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 27,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": false,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 202,
+            "temp_r": 322,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T13:47:18.511960+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 3,
+      "contradiction_count": 0,
+      "first_seq": 5842,
+      "frame_count": 20,
+      "latest_seq": 5861
+    },
+    "vision": {
+      "frame_ids": [
+        "1779198438576_000236"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779198438576_000236",
+        "frame_ids": [
+          "1779198438576_000236"
+        ],
+        "frame_stale": false,
+        "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+        "observation_seq": 5861,
+        "observation_t_wall_ms": 1779198438512,
+        "observation_t_wall_s": 1779198438.51196,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779198438576,
+            "channel": "composite_panel",
+            "frame_id": "1779198438576_000236",
+            "frame_seq": 236,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198438576_000236_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198438576_000236.png",
+            "sync_delta_ms": 94,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 94,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779198438576,
+          "channel": "composite_panel",
+          "frame_id": "1779198438576_000236",
+          "frame_seq": 236,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198438576_000236_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198438576_000236.png",
+          "sync_delta_ms": 94,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779198438482,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779198438576_000236"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "kind": "tutor_request",
+        "lineno": 6415,
+        "metadata": {
+          "frame_id": "1779198438576_000236",
+          "fused_missing_conditions": [
+            "vars.rpm_l>=25"
+          ],
+          "fused_step_id": "S11",
+          "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 94,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 1,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S11",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S11",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": []
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 3,
+                "contradiction_count": 0,
+                "first_seq": 5842,
+                "frame_count": 20,
+                "latest_seq": 5861
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+              "source_observation_seq": 5861,
+              "source_observation_t_wall": 1779198438.51196,
+              "telemetry_window_first_seq": 5842,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 5861,
+              "telemetry_window_latest_t_wall": 1779198438.51196,
+              "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_6",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "score": 20.149308173666007,
+                "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "snippet_id": "Appendix - Training Task Syllabus_6"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_5",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.3 Order Error (OR)",
+                "score": 17.59202981966743,
+                "section": "2.3 Order Error (OR)",
+                "snippet_id": "fa18c_error_coding_guide_5"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 15.070360048916584,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_2",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q2. Right Engine Throttle Timing",
+                "score": 14.701555674199204,
+                "section": "Q2. Right Engine Throttle Timing",
+                "snippet_id": "fa18c_coldstart_quiz_2"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_93",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 94,
+                "score": 14.547861262179229,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_93"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.rpm_l>=25"
+                ],
+                "overlay_step_id": "S11",
+                "role": "candidate_not_authoritative",
+                "step_id": "S11"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 5861,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": 5.593957427328908,
+                    "last_value": 12.57953765163653,
+                    "latest_transition_age_s": 0.0,
+                    "transition_count": 19,
+                    "var": "noz_l"
+                  },
+                  {
+                    "first_value": 26,
+                    "last_value": 27,
+                    "latest_transition_age_s": 0.322,
+                    "transition_count": 1,
+                    "var": "rpm_l"
+                  },
+                  {
+                    "first_value": 161,
+                    "last_value": 202,
+                    "latest_transition_age_s": 0.0,
+                    "transition_count": 19,
+                    "var": "temp_l"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 5842,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 5861,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 5861,
+                "latest_t_wall": 1779198438.51196,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.678
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779198438576_000236",
+              "frame_ids": [
+                "1779198438576_000236"
+              ],
+              "frame_stale": false,
+              "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+              "observation_seq": 5861,
+              "observation_t_wall_ms": 1779198438512,
+              "observation_t_wall_s": 1779198438.51196,
+              "status": "partial",
+              "sync_delta_ms": 94,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779198438482,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198438576_000236"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 3,
+                "contradiction_count": 0,
+                "first_seq": 5842,
+                "frame_count": 20,
+                "latest_seq": 5861
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+              "source_observation_seq": 5861,
+              "source_observation_t_wall": 1779198438.51196,
+              "telemetry_window_first_seq": 5842,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 5861,
+              "telemetry_window_latest_t_wall": 1779198438.51196,
+              "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "frame_id": "1779198438576_000236",
+            "fused_missing_conditions": [
+              "vars.rpm_l>=25"
+            ],
+            "fused_step_id": "S11",
+            "grounding_cache_hit": true,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "Appendix - Training Task Syllabus_6",
+              "fa18c_error_coding_guide_5",
+              "fa18c_startup_master_1",
+              "fa18c_coldstart_quiz_2",
+              "DCS FA-18C Early Access Guide EN_93"
+            ],
+            "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+            "prompt_tokens_est": 5622,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "source_chunk_refs": [
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_5",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_2",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_93"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 94,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198438576_000236"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779198438576_000236"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+          "request_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "timestamp": "2026-05-19T13:47:19.094541+00:00",
+          "version": "v1"
+        },
+        "related_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "vision_refs": [
+          "1779198438576_000236"
+        ]
+      },
+      {
+        "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "kind": "overlay_requested",
+        "lineno": 6416,
+        "metadata": {
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779198438576_000236",
+          "fused_missing_conditions": [
+            "vars.rpm_l>=25"
+          ],
+          "fused_step_id": "S11",
+          "generation_mode": "model",
+          "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 94,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "813c80d6-0174-4df2-a93f-362ba2fd2129",
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779198438576_000236",
+          "fused_missing_conditions": [
+            "vars.rpm_l>=25"
+          ],
+          "fused_step_id": "S11",
+          "generation_mode": "model",
+          "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 94,
+          "target": "pnt_377",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "kind": "overlay_requested",
+        "lineno": 6417,
+        "metadata": {
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779198438576_000236",
+          "fused_missing_conditions": [
+            "vars.rpm_l>=25"
+          ],
+          "fused_step_id": "S11",
+          "generation_mode": "model",
+          "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 94,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "82deecda-81a5-45be-bbdf-5f9161a51110",
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779198438576_000236",
+          "fused_missing_conditions": [
+            "vars.rpm_l>=25"
+          ],
+          "fused_step_id": "S11",
+          "generation_mode": "model",
+          "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 94,
+          "target": "pnt_443",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "kind": "tutor_response",
+        "lineno": 6418,
+        "metadata": {
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779198438576_000236",
+          "fused_missing_conditions": [
+            "vars.rpm_l>=25"
+          ],
+          "fused_step_id": "S11",
+          "generation_mode": "model",
+          "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 94,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_443",
+              "evidence_refs": [
+                "GATES.S12.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ins_mode_knob"
+              ],
+              "frame_id": "1779198438576_000236",
+              "fused_missing_conditions": [
+                "vars.rpm_l>=25"
+              ],
+              "fused_step_id": "S11",
+              "generation_mode": "model",
+              "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 94,
+              "target": "ins_mode_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198438576_000236"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "请先操作 ins_mode_knob。"
+          ],
+          "in_reply_to": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "message": "请先操作 ins_mode_knob。",
+          "metadata": {
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "a9e4e28d-4cac-4da5-b64f-0bf6a3104410",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "请先操作 ins_mode_knob。"
+            },
+            "delta_dropped_count": 1,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S12"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+              "source_observation_seq": 5861,
+              "source_observation_t_wall": 1779198438.51196,
+              "telemetry_window_first_seq": 5842,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 5861,
+              "telemetry_window_latest_t_wall": 1779198438.51196,
+              "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "overlay_step_id": "S12",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S12",
+              "targets": [
+                "ins_mode_knob"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 119,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S12"
+              },
+              "next": {
+                "step_id": "S12"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S12",
+            "final_evidence_consistency_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+              "completion_gate_already_satisfied:S11"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "ins_mode_knob"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_443",
+                  "evidence_refs": [
+                    "GATES.S12.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ins_mode_knob"
+                  ],
+                  "frame_id": "1779198438576_000236",
+                  "fused_missing_conditions": [
+                    "vars.rpm_l>=25"
+                  ],
+                  "fused_step_id": "S11",
+                  "generation_mode": "model",
+                  "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 94,
+                  "target": "ins_mode_knob",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779198438576_000236"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "请先操作 ins_mode_knob。"
+              ],
+              "message": "请先操作 ins_mode_knob。",
+              "next": {
+                "step_id": "S12"
+              }
+            },
+            "frame_id": "1779198438576_000236",
+            "fused_missing_conditions": [
+              "vars.rpm_l>=25"
+            ],
+            "fused_step_id": "S11",
+            "generation_mode": "model",
+            "generation_prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+            "generation_prompt_tokens_est": 5622,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S12",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S12",
+              "targets": [
+                "ins_mode_knob"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S11",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "GATES.S13.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "obogs_control_switch",
+                    "obogs_flow_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S14",
+                  "supporting_evidence_refs": [
+                    "GATES.S14.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.66,
+                "proposed_next_action_target_ids": [
+                  "ins_mode_knob",
+                  "ampcd_pb19"
+                ],
+                "role": "candidate",
+                "source": "gate_blocker",
+                "step_id": "S12",
+                "supporting_evidence_refs": [
+                  "GATES.S12.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 3,
+                  "contradiction_count": 0,
+                  "first_seq": 5842,
+                  "frame_count": 20,
+                  "latest_seq": 5861
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+                "source_observation_seq": 5861,
+                "source_observation_t_wall": 1779198438.51196,
+                "telemetry_window_first_seq": 5842,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 5861,
+                "telemetry_window_latest_t_wall": 1779198438.51196,
+                "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "overlay_step_id": "S12",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S12",
+                "targets": [
+                  "ins_mode_knob"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ins_mode_knob"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [],
+                "generation_mode": "model",
+                "overlay_targets": [],
+                "status": "ok",
+                "step_id": "S11"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S11"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+                "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+                  "completion_gate_already_satisfied:S11"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S11"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779198438576_000236"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 94,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+              "completion_gate_already_satisfied:S11"
+            ],
+            "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "请先操作 ins_mode_knob。"
+              ],
+              "next": {
+                "step_id": "S12"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S12.completion",
+                    "target": "ins_mode_knob",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ins_mode_knob"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S11"
+              },
+              "explanations": [
+                "S11 尚未完成，当前缺少左发动机 RPM >= 25% 的条件。请将左油门杆从 OFF 推至 IDLE（使用热键 Right Alt+Home）。"
+              ],
+              "next": {
+                "step_id": "S11"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 3030,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S11"
+            },
+            "model_raw_explanations": [
+              "S11 尚未完成，当前缺少左发动机 RPM >= 25% 的条件。请将左油门杆从 OFF 推至 IDLE（使用热键 Right Alt+Home）。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S11"
+              },
+              "explanations": [
+                "S11 尚未完成，当前缺少左发动机 RPM >= 25% 的条件。请将左油门杆从 OFF 推至 IDLE（使用热键 Right Alt+Home）。"
+              ],
+              "next": {
+                "step_id": "S11"
+              },
+              "overlay": {
+                "evidence": [],
+                "targets": []
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S11"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779198438576_000236"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779198438576_000236",
+            "next": {
+              "step_id": "S12"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5604,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "GATES.S11.completion",
+                "GATES.S11.precondition",
+                "GATES.S12.completion",
+                "GATES.S12.precondition",
+                "GATES.S13.completion",
+                "GATES.S13.precondition",
+                "GATES.S14.completion",
+                "GATES.S14.precondition",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_5",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_2",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_93"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 13,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": null,
+              "prompt_chars": 22486,
+              "prompt_tokens_est": 5622,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "Appendix - Training Task Syllabus_6",
+                "fa18c_error_coding_guide_5",
+                "fa18c_startup_master_1",
+                "fa18c_coldstart_quiz_2",
+                "DCS FA-18C Early Access Guide EN_93"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_overlay_enum"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+            "prompt_tokens_est": 5622,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.rpm_l>=25"
+            ],
+            "rejected_model_step_id": "S11",
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+            "request_prompt_tokens_est": 5622,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S11"
+              },
+              "next": {
+                "step_id": "S11"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+              "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+            },
+            "state_key": "273ea4ac411b3776f5c72dd68452a50eb5efd75151b54dfeca18cf087ee3e612",
+            "sync_delta_ms": 94,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779198438576_000236",
+              "frame_ids": [
+                "1779198438576_000236"
+              ],
+              "frame_stale": false,
+              "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+              "observation_seq": 5861,
+              "observation_t_wall_ms": 1779198438512,
+              "observation_t_wall_s": 1779198438.51196,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779198438576,
+                  "channel": "composite_panel",
+                  "frame_id": "1779198438576_000236",
+                  "frame_seq": 236,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198438576_000236_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198438576_000236.png",
+                  "sync_delta_ms": 94,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 94,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779198438576,
+                "channel": "composite_panel",
+                "frame_id": "1779198438576_000236",
+                "frame_seq": 236,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198438576_000236_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198438576_000236.png",
+                "sync_delta_ms": 94,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779198438482,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S11"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779198438576_000236"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779198438576_000236"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "0121de0a-721b-433a-b5a9-f46da5b85025",
+          "status": "ok",
+          "timestamp": "2026-05-19T13:47:22.126350+00:00",
+          "version": "v1"
+        },
+        "related_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "vision_refs": [
+          "1779198438576_000236"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 1,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S11",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S11",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": []
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 3,
+            "contradiction_count": 0,
+            "first_seq": 5842,
+            "frame_count": 20,
+            "latest_seq": 5861
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+          "source_observation_seq": 5861,
+          "source_observation_t_wall": 1779198438.51196,
+          "telemetry_window_first_seq": 5842,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 5861,
+          "telemetry_window_latest_t_wall": 1779198438.51196,
+          "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_6",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "score": 20.149308173666007,
+            "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "snippet_id": "Appendix - Training Task Syllabus_6"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_5",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.3 Order Error (OR)",
+            "score": 17.59202981966743,
+            "section": "2.3 Order Error (OR)",
+            "snippet_id": "fa18c_error_coding_guide_5"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 15.070360048916584,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_2",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q2. Right Engine Throttle Timing",
+            "score": 14.701555674199204,
+            "section": "Q2. Right Engine Throttle Timing",
+            "snippet_id": "fa18c_coldstart_quiz_2"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_93",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 94,
+            "score": 14.547861262179229,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_93"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.rpm_l>=25"
+            ],
+            "overlay_step_id": "S11",
+            "role": "candidate_not_authoritative",
+            "step_id": "S11"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 5861,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": 5.593957427328908,
+                "last_value": 12.57953765163653,
+                "latest_transition_age_s": 0.0,
+                "transition_count": 19,
+                "var": "noz_l"
+              },
+              {
+                "first_value": 26,
+                "last_value": 27,
+                "latest_transition_age_s": 0.322,
+                "transition_count": 1,
+                "var": "rpm_l"
+              },
+              {
+                "first_value": 161,
+                "last_value": 202,
+                "latest_transition_age_s": 0.0,
+                "transition_count": 19,
+                "var": "temp_l"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 5842,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 5861,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 5861,
+            "latest_t_wall": 1779198438.51196,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.678
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779198438576_000236",
+          "frame_ids": [
+            "1779198438576_000236"
+          ],
+          "frame_stale": false,
+          "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+          "observation_seq": 5861,
+          "observation_t_wall_ms": 1779198438512,
+          "observation_t_wall_s": 1779198438.51196,
+          "status": "partial",
+          "sync_delta_ms": 94,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779198438482,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198438576_000236"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 3,
+            "contradiction_count": 0,
+            "first_seq": 5842,
+            "frame_count": 20,
+            "latest_seq": 5861
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+          "source_observation_seq": 5861,
+          "source_observation_t_wall": 1779198438.51196,
+          "telemetry_window_first_seq": 5842,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 5861,
+          "telemetry_window_latest_t_wall": 1779198438.51196,
+          "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "frame_id": "1779198438576_000236",
+        "fused_missing_conditions": [
+          "vars.rpm_l>=25"
+        ],
+        "fused_step_id": "S11",
+        "grounding_cache_hit": true,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "Appendix - Training Task Syllabus_6",
+          "fa18c_error_coding_guide_5",
+          "fa18c_startup_master_1",
+          "fa18c_coldstart_quiz_2",
+          "DCS FA-18C Early Access Guide EN_93"
+        ],
+        "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+        "prompt_tokens_est": 5622,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "source_chunk_refs": [
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_5",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_2",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_93"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 94,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198438576_000236"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779198438576_000236"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+      "request_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+      "timestamp": "2026-05-19T13:47:19.094541+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_443",
+          "evidence_refs": [
+            "GATES.S12.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779198438576_000236",
+          "fused_missing_conditions": [
+            "vars.rpm_l>=25"
+          ],
+          "fused_step_id": "S11",
+          "generation_mode": "model",
+          "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 94,
+          "target": "ins_mode_knob",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "请先操作 ins_mode_knob。"
+      ],
+      "in_reply_to": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+      "message": "请先操作 ins_mode_knob。",
+      "metadata": {
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "a9e4e28d-4cac-4da5-b64f-0bf6a3104410",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "请先操作 ins_mode_knob。"
+        },
+        "delta_dropped_count": 1,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S12"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+          "source_observation_seq": 5861,
+          "source_observation_t_wall": 1779198438.51196,
+          "telemetry_window_first_seq": 5842,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 5861,
+          "telemetry_window_latest_t_wall": 1779198438.51196,
+          "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "overlay_step_id": "S12",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S12",
+          "targets": [
+            "ins_mode_knob"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 119,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S12"
+          },
+          "next": {
+            "step_id": "S12"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S12",
+        "final_evidence_consistency_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+          "completion_gate_already_satisfied:S11"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "ins_mode_knob"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_443",
+              "evidence_refs": [
+                "GATES.S12.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ins_mode_knob"
+              ],
+              "frame_id": "1779198438576_000236",
+              "fused_missing_conditions": [
+                "vars.rpm_l>=25"
+              ],
+              "fused_step_id": "S11",
+              "generation_mode": "model",
+              "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 94,
+              "target": "ins_mode_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779198438576_000236"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "请先操作 ins_mode_knob。"
+          ],
+          "message": "请先操作 ins_mode_knob。",
+          "next": {
+            "step_id": "S12"
+          }
+        },
+        "frame_id": "1779198438576_000236",
+        "fused_missing_conditions": [
+          "vars.rpm_l>=25"
+        ],
+        "fused_step_id": "S11",
+        "generation_mode": "model",
+        "generation_prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+        "generation_prompt_tokens_est": 5622,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S12",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S12",
+          "targets": [
+            "ins_mode_knob"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S11",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "GATES.S13.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "obogs_control_switch",
+                "obogs_flow_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S14",
+              "supporting_evidence_refs": [
+                "GATES.S14.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.66,
+            "proposed_next_action_target_ids": [
+              "ins_mode_knob",
+              "ampcd_pb19"
+            ],
+            "role": "candidate",
+            "source": "gate_blocker",
+            "step_id": "S12",
+            "supporting_evidence_refs": [
+              "GATES.S12.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 3,
+              "contradiction_count": 0,
+              "first_seq": 5842,
+              "frame_count": 20,
+              "latest_seq": 5861
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+            "source_observation_seq": 5861,
+            "source_observation_t_wall": 1779198438.51196,
+            "telemetry_window_first_seq": 5842,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 5861,
+            "telemetry_window_latest_t_wall": 1779198438.51196,
+            "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "overlay_step_id": "S12",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S12",
+            "targets": [
+              "ins_mode_knob"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [],
+            "generation_mode": "model",
+            "overlay_targets": [],
+            "status": "ok",
+            "step_id": "S11"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S11"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+            "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+              "completion_gate_already_satisfied:S11"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S11"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779198438576_000236"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 94,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+          "completion_gate_already_satisfied:S11"
+        ],
+        "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "请先操作 ins_mode_knob。"
+          ],
+          "next": {
+            "step_id": "S12"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S12.completion",
+                "target": "ins_mode_knob",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ins_mode_knob"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S11"
+          },
+          "explanations": [
+            "S11 尚未完成，当前缺少左发动机 RPM >= 25% 的条件。请将左油门杆从 OFF 推至 IDLE（使用热键 Right Alt+Home）。"
+          ],
+          "next": {
+            "step_id": "S11"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 3030,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S11"
+        },
+        "model_raw_explanations": [
+          "S11 尚未完成，当前缺少左发动机 RPM >= 25% 的条件。请将左油门杆从 OFF 推至 IDLE（使用热键 Right Alt+Home）。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S11"
+          },
+          "explanations": [
+            "S11 尚未完成，当前缺少左发动机 RPM >= 25% 的条件。请将左油门杆从 OFF 推至 IDLE（使用热键 Right Alt+Home）。"
+          ],
+          "next": {
+            "step_id": "S11"
+          },
+          "overlay": {
+            "evidence": [],
+            "targets": []
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S11"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779198438576_000236"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779198438576_000236",
+        "next": {
+          "step_id": "S12"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5604,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "GATES.S11.completion",
+            "GATES.S11.precondition",
+            "GATES.S12.completion",
+            "GATES.S12.precondition",
+            "GATES.S13.completion",
+            "GATES.S13.precondition",
+            "GATES.S14.completion",
+            "GATES.S14.precondition",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_5",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_2",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_93"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 13,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": null,
+          "prompt_chars": 22486,
+          "prompt_tokens_est": 5622,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "Appendix - Training Task Syllabus_6",
+            "fa18c_error_coding_guide_5",
+            "fa18c_startup_master_1",
+            "fa18c_coldstart_quiz_2",
+            "DCS FA-18C Early Access Guide EN_93"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_overlay_enum"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+        "prompt_tokens_est": 5622,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.rpm_l>=25"
+        ],
+        "rejected_model_step_id": "S11",
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "99c82562e487bd4b58324bb9a8b2ac514f1e8c54221f4986f1c6d52935881e16",
+        "request_prompt_tokens_est": 5622,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S11"
+          },
+          "next": {
+            "step_id": "S11"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+          "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+        },
+        "state_key": "273ea4ac411b3776f5c72dd68452a50eb5efd75151b54dfeca18cf087ee3e612",
+        "sync_delta_ms": 94,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779198438576_000236",
+          "frame_ids": [
+            "1779198438576_000236"
+          ],
+          "frame_stale": false,
+          "observation_ref": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+          "observation_seq": 5861,
+          "observation_t_wall_ms": 1779198438512,
+          "observation_t_wall_s": 1779198438.51196,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779198438576,
+              "channel": "composite_panel",
+              "frame_id": "1779198438576_000236",
+              "frame_seq": 236,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198438576_000236_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198438576_000236.png",
+              "sync_delta_ms": 94,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 94,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779198438576,
+            "channel": "composite_panel",
+            "frame_id": "1779198438576_000236",
+            "frame_seq": 236,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779198438576_000236_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779198438576_000236.png",
+            "sync_delta_ms": 94,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779198438482,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S11"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779198438576_000236"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779198438576_000236"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "0121de0a-721b-433a-b5a9-f46da5b85025",
+      "status": "ok",
+      "timestamp": "2026-05-19T13:47:22.126350+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S12",
+    "expected_overlay_target_ids": [
+      "ins_mode_knob"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S11",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "obogs_control_switch",
+          "obogs_flow_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S14",
+        "supporting_evidence_refs": [
+          "GATES.S14.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+      "overlay_step_id": "S12",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S12",
+      "targets": [
+        "ins_mode_knob"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [],
+      "generation_mode": "model",
+      "overlay_targets": [],
+      "status": "ok",
+      "step_id": "S11"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S11",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "GATES.S13.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "obogs_control_switch",
+            "obogs_flow_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S14",
+          "supporting_evidence_refs": [
+            "GATES.S14.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 3,
+          "contradiction_count": 0,
+          "first_seq": 5842,
+          "frame_count": 20,
+          "latest_seq": 5861
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "final_decision_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "model_request_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "source_observation_id": "28e8ec46-5105-42d6-93df-c1fd44633de1",
+        "source_observation_seq": 5861,
+        "source_observation_t_wall": 1779198438.51196,
+        "telemetry_window_first_seq": 5842,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 5861,
+        "telemetry_window_latest_t_wall": 1779198438.51196,
+        "validator_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "overlay_step_id": "S12",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S12",
+        "targets": [
+          "ins_mode_knob"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ins_mode_knob"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [],
+        "generation_mode": "model",
+        "overlay_targets": [],
+        "status": "ok",
+        "step_id": "S11"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S11"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "final_decision": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "model_request": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e",
+        "validator": "2833c0cc0cd57cca188b3d7fd47ac43e4b24c91590473ebf7cd257987317ab4e"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+          "completion_gate_already_satisfied:S11"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S11"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779198438576_000236"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 94,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "missing_condition_satisfied_by_latest_telemetry:vars.rpm_l>=25",
+        "completion_gate_already_satisfied:S11"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S11"
+    }
+  },
+  "help_cycle_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S12"
+      },
+      "explanations": [
+        "请先操作 ins_mode_knob。"
+      ],
+      "next": {
+        "step_id": "S12"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S12.completion",
+            "target": "ins_mode_knob",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "ins_mode_knob"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S11"
+      },
+      "explanations": [
+        "S11 尚未完成，当前缺少左发动机 RPM >= 25% 的条件。请将左油门杆从 OFF 推至 IDLE（使用热键 Right Alt+Home）。"
+      ],
+      "next": {
+        "step_id": "S11"
+      },
+      "overlay": {
+        "evidence": [],
+        "targets": []
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "0758602b-05c0-4ff6-9938-22b7e226f7c0",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 14472,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_134129.jsonl"
+  }
+}

--- a/replay_eval/fa18c_startup_v04/suite.yaml
+++ b/replay_eval/fa18c_startup_v04/suite.yaml
@@ -48,6 +48,106 @@ coverage:
     fixture: artifacts/live_fixtures/c3c775ce-7a4d-4e7f-a841-3a022528138e.fixture.json
     test_id: tests/test_live_dcs.py::test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture
     reason: Latest telemetry with engine_crank_left_complete=true must advance past S10.
+  - step_id: S12
+    state_category: completion_already_true
+    source: live_fixture_regression
+    issue: 312
+    regression_class: final_consistency_no_over_advance
+    fixture: artifacts/live_fixtures/c2a80099-8375-42a1-89eb-b09544b474e2.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_311_keeps_s12_when_only_precondition_is_satisfied
+    reason: S12 must not advance to S13 when only the S12 precondition/previous engine gate is satisfied.
+  - step_id: S11
+    state_category: completion_already_true
+    source: live_fixture_regression
+    issue: 312
+    regression_class: completion_based_advancement
+    fixture: artifacts/live_fixtures/0758602b-05c0-4ff6-9938-22b7e226f7c0.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_312_s11_completion_advances_to_s12
+    reason: S11 RPM completion should be repaired forward to S12 / ins_mode_knob.
+  - step_id: S10
+    state_category: wrong_target_prevention
+    source: live_fixture_regression
+    issue: 312
+    regression_class: interaction_text_semantics
+    text_intent: left_engine_left_click_not_right_click
+    fixture: artifacts/live_fixtures/3de0e688-8bc4-4df1-b062-72f3134bc775.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_314_s10_left_engine_uses_left_click_guidance
+    reason: S10 left-engine guidance must say LEFT / left-click, not R / right-click.
+  - step_id: S08
+    state_category: wrong_target_prevention
+    source: live_fixture_regression
+    issue: 312
+    regression_class: visual_substate_not_collapsed
+    fixture: artifacts/live_fixtures/e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_314_keeps_s08_supt_bit_root_visual_recovery
+    reason: S08 SUPT/BIT-root sub-state must remain at PB15 instead of collapsing into display-power completion.
+  - step_id: S09
+    state_category: wrong_target_prevention
+    source: live_fixture_regression
+    issue: 312
+    regression_class: staged_ufc_comm_selector_first
+    fixture: artifacts/live_fixtures/ce8512ef-901a-4f08-a339-af10893b744f.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_314_s09_requires_comm1_pull_before_numeric_sequence
+    reason: S09 staged UFC entry must target COMM1 selector before numeric keys.
+  - step_id: S21
+    state_category: moving_settling_control
+    source: live_fixture_regression
+    issue: 312
+    regression_class: four_down_probe_transition_latch
+    fixture: artifacts/live_fixtures/20c79783-092e-4128-ad47-5fa7d3774ed7.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_306_20c_retracted_probe_latch_advances_to_s22
+    reason: Probe transition/latch evidence must advance to the next four-down step when the retraction is complete.
+  - step_id: S21
+    state_category: moving_settling_control
+    source: live_fixture_regression
+    issue: 312
+    regression_class: four_down_probe_wait_guidance
+    fixture: artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json
+    test_id: tests/test_live_dcs.py::test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting
+    reason: Moving/settling probe evidence must produce wait guidance instead of repeated wrong-target prompts.
+  - step_id: S25
+    state_category: moving_settling_control
+    source: live_fixture_regression
+    issue: 312
+    regression_class: hook_lever_polarity
+    fixture: artifacts/live_fixtures/7ea8bf09-dfe7-4e7b-a23f-6407af510e2a.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_306_7ea8_hook_down_advances_to_s25_without_trace_mismatch
+    reason: HOOK_LEVER polarity must distinguish hook-down completion from hook-up retraction guidance.
+  - step_id: S31
+    state_category: wrong_target_prevention
+    source: live_fixture_regression
+    issue: 312
+    regression_class: wheel_interaction_radar_altimeter
+    text_intent: mouse_wheel_radar_altimeter_bug
+    fixture: artifacts/live_fixtures/5a7d5df7-2f08-4321-9a4a-6858131b4e6e.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_314_s31_radar_altimeter_uses_mouse_wheel_guidance
+    reason: S31 radar altitude bug guidance must preserve wheel interaction semantics.
+  - step_id: S32
+    state_category: wrong_target_prevention
+    source: live_fixture_regression
+    issue: 312
+    regression_class: wheel_interaction_standby_attitude
+    text_intent: mouse_wheel_standby_attitude_cage
+    fixture: artifacts/live_fixtures/ffb5e69b-664b-47d8-9150-57d7cd75d233.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_314_s32_standby_attitude_uses_mouse_wheel_guidance
+    reason: S32 standby attitude cage guidance must preserve wheel interaction semantics.
+  - step_id: S33
+    state_category: completion_already_true
+    source: live_fixture_regression
+    issue: 312
+    regression_class: public_completion_message
+    text_intent: public_completion_no_internal_evidence
+    fixture: artifacts/live_fixtures/7bea22f8-a4d1-4744-917b-f7ddc957f709.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_314_s33_default_satisfied_uses_public_completion_message
+    reason: S33 already-satisfied repair must show user-facing completion guidance rather than internal validator wording.
+  - step_id: S29
+    state_category: wrong_target_prevention
+    source: live_fixture_regression
+    issue: 312
+    regression_class: raw_wrong_final_repaired
+    fixture: artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance
+    reason: Matrix must expose raw S28 / parking-brake decision separately from final repaired S29 / IFEI action.
 cases:
   - case_id: noop_2min
     input: cases/noop_2min/dcs_bios_raw.jsonl

--- a/simtutor/replay_eval.py
+++ b/simtutor/replay_eval.py
@@ -151,6 +151,8 @@ def _normalize_coverage_tags(
                 issue=_ensure_optional_positive_issue(item.get("issue"), field_name=f"{item_field}.issue"),
                 fixture=_extract_optional_text(item.get("fixture")),
                 test_id=_extract_optional_text(item.get("test_id")),
+                regression_class=_extract_optional_text(item.get("regression_class")),
+                text_intent=_extract_optional_text(item.get("text_intent")),
                 reason=_extract_optional_text(item.get("reason")),
             )
         )
@@ -189,6 +191,8 @@ class ReplayEvalCoverageTag:
     issue: int | None = None
     fixture: str | None = None
     test_id: str | None = None
+    regression_class: str | None = None
+    text_intent: str | None = None
     reason: str | None = None
 
 
@@ -763,7 +767,102 @@ def _build_summary(case_results: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _coverage_source_dict(tag: ReplayEvalCoverageTag | Mapping[str, Any]) -> dict[str, Any]:
+def _as_mapping(raw: Any) -> Mapping[str, Any]:
+    return raw if isinstance(raw, Mapping) else {}
+
+
+def _string_list(raw: Any) -> list[str]:
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [item for item in raw if isinstance(item, str) and item]
+
+
+def _resolve_fixture_path(*, suite_dir: Path | None, raw_path: str) -> Path:
+    candidate = Path(raw_path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    if suite_dir is not None:
+        suite_candidate = suite_dir / candidate
+        if suite_candidate.exists():
+            return suite_candidate
+    return _repo_root() / candidate
+
+
+def _extract_live_fixture_assertions(fixture_path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"coverage fixture could not be loaded: {fixture_path}") from exc
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"coverage fixture root is not a mapping: {fixture_path}")
+
+    expectations = _as_mapping(raw.get("expectations"))
+    harness = _as_mapping(raw.get("harness"))
+    trace = _as_mapping(harness.get("trace"))
+    model_decision = _as_mapping(trace.get("model_decision") or harness.get("model_decision"))
+    validator_result = _as_mapping(trace.get("validator_result") or harness.get("validator_result"))
+    repair_result = _as_mapping(trace.get("repair_result") or harness.get("repair_result"))
+    final_plan = _as_mapping(trace.get("final_action_plan") or harness.get("final_action_plan"))
+    vlm_call = _as_mapping(trace.get("vlm_call"))
+
+    raw_model_step_id = _extract_optional_text(model_decision.get("step_id"))
+    final_step_id = (
+        _extract_optional_text(final_plan.get("step_id"))
+        or _extract_optional_text(expectations.get("expected_final_step_id"))
+    )
+    final_targets = _string_list(final_plan.get("targets")) or _string_list(
+        expectations.get("expected_overlay_target_ids")
+    )
+    extractor_used = _extract_optional_bool(vlm_call.get("extractor_used"))
+    extractor_called = _extract_optional_bool(vlm_call.get("extractor_called"))
+    frame_capture_selected = _extract_optional_bool(vlm_call.get("frame_capture_selected"))
+
+    assertions: dict[str, Any] = {}
+    if raw_model_step_id is not None:
+        assertions["raw_model_step_id"] = raw_model_step_id
+        assertions["raw_model_targets"] = _string_list(model_decision.get("overlay_targets"))
+    if validator_result:
+        rejected = _extract_optional_bool(validator_result.get("rejected"))
+        if rejected is not None:
+            assertions["validator_rejected"] = rejected
+    if repair_result:
+        repair_applied = _extract_optional_bool(repair_result.get("applied"))
+        if repair_applied is not None:
+            assertions["repair_applied"] = repair_applied
+    final_action_plan_source = _extract_optional_text(final_plan.get("source"))
+    if final_action_plan_source is not None:
+        assertions["final_action_plan_source"] = final_action_plan_source
+    message_category = _extract_optional_text(trace.get("message_category"))
+    if message_category is not None:
+        assertions["message_category"] = message_category
+    if final_step_id is not None:
+        assertions["final_step_id"] = final_step_id
+    if final_targets:
+        assertions["final_targets"] = final_targets
+    vlm_call_status = _extract_optional_text(vlm_call.get("status")) or _extract_optional_text(
+        expectations.get("vlm_call_status")
+    )
+    if vlm_call_status is not None:
+        assertions["vlm_call_status"] = vlm_call_status
+    vision_fact_extractor_used = extractor_used if extractor_used is not None else extractor_called
+    if vision_fact_extractor_used is not None:
+        assertions["vision_fact_extractor_used"] = vision_fact_extractor_used
+    if extractor_called is not None:
+        assertions["vision_fact_extractor_called"] = extractor_called
+    if frame_capture_selected is not None:
+        assertions["frame_capture_selected"] = frame_capture_selected
+    if frame_capture_selected is not None and (extractor_used is not None or extractor_called is not None):
+        assertions["frame_capture_only"] = bool(
+            frame_capture_selected and not bool(extractor_used) and not bool(extractor_called)
+        )
+    return assertions
+
+
+def _coverage_source_dict(
+    tag: ReplayEvalCoverageTag | Mapping[str, Any],
+    *,
+    suite_dir: Path | None = None,
+) -> dict[str, Any]:
     if isinstance(tag, ReplayEvalCoverageTag):
         raw: dict[str, Any] = {
             "source": tag.source,
@@ -771,11 +870,18 @@ def _coverage_source_dict(tag: ReplayEvalCoverageTag | Mapping[str, Any]) -> dic
             "issue": tag.issue,
             "fixture": tag.fixture,
             "test_id": tag.test_id,
+            "regression_class": tag.regression_class,
+            "text_intent": tag.text_intent,
             "reason": tag.reason,
         }
     else:
         raw = dict(tag)
-    return {key: value for key, value in raw.items() if value is not None}
+    source = {key: value for key, value in raw.items() if value is not None}
+    fixture = source.get("fixture")
+    if isinstance(fixture, str) and fixture:
+        fixture_path = _resolve_fixture_path(suite_dir=suite_dir, raw_path=fixture)
+        source["fixture_assertions"] = _extract_live_fixture_assertions(fixture_path)
+    return source
 
 
 def _new_coverage_cell(*, status: str = "missing", reason: str | None = None) -> dict[str, Any]:
@@ -808,12 +914,13 @@ def _add_regression_reference(
     step_id: str,
     state_category: str,
     source: Mapping[str, Any],
+    allow_not_applicable: bool = False,
 ) -> None:
     row = steps.get(step_id)
     if row is None or state_category not in row:
         return
     cell = row[state_category]
-    if cell["status"] == "not_applicable":
+    if cell["status"] == "not_applicable" and not allow_not_applicable:
         return
     if cell["status"] not in {"covered", "contract_only"}:
         cell["status"] = "regression_reference"
@@ -903,7 +1010,7 @@ def _build_case_only_coverage_matrix(
     step_ids = sorted(
         {
             tag.step_id
-            for tag in _all_suite_coverage_tags(suite, case_results=case_results)
+            for tag in (*_all_suite_coverage_tags(suite, case_results=case_results), *suite.coverage_tags)
             if isinstance(tag.step_id, str) and tag.step_id
         },
         key=lambda step_id: (int(step_id[1:]) if step_id.startswith("S") and step_id[1:].isdigit() else 10_000, step_id),
@@ -920,14 +1027,15 @@ def _build_case_only_coverage_matrix(
             steps,
             step_id=tag.step_id,
             state_category=tag.state_category,
-            source=_coverage_source_dict(tag),
+            source=_coverage_source_dict(tag, suite_dir=suite.suite_path.parent),
         )
     for tag in suite.coverage_tags:
         _add_regression_reference(
             steps,
             step_id=tag.step_id,
             state_category=tag.state_category,
-            source=_coverage_source_dict(tag),
+            source=_coverage_source_dict(tag, suite_dir=suite.suite_path.parent),
+            allow_not_applicable=True,
         )
     covered_count = sum(
         1
@@ -1003,7 +1111,7 @@ def build_harness_coverage_matrix(
         has_recent_action_facts = any(spec.recent_action_facts for spec in specs_for_step)
         has_allowed_overlay_targets = any(spec.allowed_overlay_targets for spec in specs_for_step)
         visual_step = any(spec.requires_visual_confirmation or spec.vision_facts for spec in specs_for_step)
-        has_moving_settling_control = step_id in {"S20", "S21"}
+        has_moving_settling_control = step_id in {"S20", "S21", "S24", "S25"}
         _mark_coverage_contract(
             steps,
             step_id=step_id,
@@ -1066,8 +1174,8 @@ def build_harness_coverage_matrix(
                 step_id=step_id,
                 state_category="moving_settling_control",
                 source={
-                    "source": "refuel_probe_motion_contract",
-                    "reason": "step can be in motion/settling while the refuel probe moves toward its threshold",
+                    "source": "four_down_control_motion_contract",
+                    "reason": "step can be in transition/settling while a four-down control moves toward its threshold",
                 },
             )
         else:
@@ -1158,14 +1266,14 @@ def build_harness_coverage_matrix(
             steps,
             step_id=tag.step_id,
             state_category=tag.state_category,
-            source=_coverage_source_dict(tag),
+            source=_coverage_source_dict(tag, suite_dir=suite.suite_path.parent),
         )
     for tag in suite.coverage_tags:
         _add_regression_reference(
             steps,
             step_id=tag.step_id,
             state_category=tag.state_category,
-            source=_coverage_source_dict(tag),
+            source=_coverage_source_dict(tag, suite_dir=suite.suite_path.parent),
         )
 
     missing_cells = [

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11066,7 +11066,35 @@ def _validate_compact_live_help_response(
     request: TutorRequest,
     response: TutorResponse,
     vision_status: str = "vision_not_required",
+    vision_selection: HelpCycleVisionSelection | None = None,
+    vision_fact_context: dict[str, Any] | None = None,
 ) -> TutorResponse:
+    if vision_selection is None:
+        vision_selection = HelpCycleVisionSelection(
+            status=vision_status,
+            observation_ref=None,
+            observation_seq=None,
+            observation_t_wall_s=None,
+            observation_t_wall_ms=None,
+            trigger_wall_ms=None,
+            sync_window_ms=None,
+            vision_used=False,
+            frame_id=None,
+            sync_status=None,
+            sync_delta_ms=None,
+            frame_stale=False,
+            frame_ids=[],
+            selected_frames=[],
+            pre_trigger_frame=None,
+            trigger_frame=None,
+            sync_miss_reason=None,
+        )
+    if vision_fact_context is None:
+        vision_fact_context = {
+            "status": vision_status,
+            "vision_fact_summary": {"status": vision_status},
+            "vision_facts": [],
+        }
     loop = LiveDcsTutorLoop(
         source=_DelayedObservationSource(Observation()),
         model=RecordingModel(),
@@ -11082,30 +11110,8 @@ def _validate_compact_live_help_response(
             prompt_meta={},
             state_key=f"state-{request.request_id}",
             help_cycle_id=request.request_id,
-            vision_selection=HelpCycleVisionSelection(
-                status=vision_status,
-                observation_ref=None,
-                observation_seq=None,
-                observation_t_wall_s=None,
-                observation_t_wall_ms=None,
-                trigger_wall_ms=None,
-                sync_window_ms=None,
-                vision_used=False,
-                frame_id=None,
-                sync_status=None,
-                sync_delta_ms=None,
-                frame_stale=False,
-                frame_ids=[],
-                selected_frames=[],
-                pre_trigger_frame=None,
-                trigger_frame=None,
-                sync_miss_reason=None,
-            ),
-            vision_fact_context={
-                "status": vision_status,
-                "vision_fact_summary": {"status": vision_status},
-                "vision_facts": [],
-            },
+            vision_selection=vision_selection,
+            vision_fact_context=vision_fact_context,
             vision_fact_active_step_ids=[],
             terminal_state_short_circuited=False,
         )
@@ -11116,6 +11122,53 @@ def _validate_compact_live_help_response(
 
 def _load_live_help_fixture(path: str) -> dict[str, Any]:
     return json.loads((Path(__file__).resolve().parents[1] / path).read_text(encoding="utf-8"))
+
+
+def _fixture_vision_selection(fixture: dict[str, Any]) -> HelpCycleVisionSelection:
+    metadata = fixture["cycle"]["tutor_response"].get("metadata", {})
+    vision = metadata.get("vision", {})
+    return HelpCycleVisionSelection(
+        status=vision.get("status"),
+        observation_ref=vision.get("observation_ref"),
+        observation_seq=vision.get("observation_seq"),
+        observation_t_wall_s=vision.get("observation_t_wall_s"),
+        observation_t_wall_ms=vision.get("observation_t_wall_ms"),
+        trigger_wall_ms=vision.get("trigger_wall_ms"),
+        sync_window_ms=vision.get("sync_window_ms"),
+        vision_used=bool(vision.get("vision_used")),
+        frame_id=vision.get("frame_id"),
+        sync_status=vision.get("sync_status"),
+        sync_delta_ms=vision.get("sync_delta_ms"),
+        frame_stale=vision.get("frame_stale"),
+        frame_ids=[item for item in vision.get("frame_ids", []) if isinstance(item, str)],
+        selected_frames=[
+            dict(item) for item in vision.get("selected_frames", []) if isinstance(item, dict)
+        ],
+        pre_trigger_frame=(
+            dict(vision["pre_trigger_frame"]) if isinstance(vision.get("pre_trigger_frame"), dict) else None
+        ),
+        trigger_frame=(
+            dict(vision["trigger_frame"]) if isinstance(vision.get("trigger_frame"), dict) else None
+        ),
+        sync_miss_reason=vision.get("sync_miss_reason"),
+    )
+
+
+def _fixture_vision_fact_context(fixture: dict[str, Any]) -> dict[str, Any]:
+    metadata = fixture["cycle"]["tutor_response"].get("metadata", {})
+    vlm_call = fixture.get("harness", {}).get("trace", {}).get("vlm_call", {})
+    status = vlm_call.get("vision_fact_status") or metadata.get("vision_fact_status") or "vision_not_required"
+    return {
+        "status": status,
+        "vision_fact_summary": metadata.get("vision_fact_summary") or {"status": status},
+        "vision_facts": metadata.get("vision_facts") or [],
+        "metadata": {
+            "extractor_used": bool(vlm_call.get("extractor_used")),
+            "cached_fact_count": vlm_call.get("cached_fact_count", 0),
+            "sticky_fact_count": vlm_call.get("sticky_fact_count", 0),
+            "ignored_fact_count": vlm_call.get("ignored_fact_count", 0),
+        },
+    }
 
 
 def _fixture_request_and_model_response(fixture: dict[str, Any]) -> tuple[TutorRequest, TutorResponse]:
@@ -11276,6 +11329,41 @@ def test_live_help_fixture_311_keeps_s12_when_only_precondition_is_satisfied() -
         "harness_validation_reasons",
         [],
     )
+
+
+def test_live_help_fixture_312_s11_completion_advances_to_s12() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/0758602b-05c0-4ff6-9938-22b7e226f7c0.fixture.json"
+    )
+    request, response = _fixture_request_and_raw_model_response(fixture)
+    vars_map = request.context["vars"]
+    assert vars_map["rpm_l"] == 27
+    assert vars_map["rpm_l_gte_25"] is True
+
+    repaired = _validate_compact_live_help_response(
+        request=request,
+        response=response,
+        vision_selection=_fixture_vision_selection(fixture),
+        vision_fact_context=_fixture_vision_fact_context(fixture),
+    )
+
+    _assert_live_fixture_expectations(fixture, repaired)
+    assert repaired.metadata["diagnosis"]["step_id"] == "S12"
+    assert repaired.metadata["next"]["step_id"] == "S12"
+    assert repaired.metadata["validator_rejected"] is True
+    assert repaired.metadata["repair_applied"] is True
+    assert repaired.metadata["final_action_plan"]["source"] == "final_evidence_consistency_validator"
+    assert repaired.metadata["final_overlay_targets"] == ["ins_mode_knob"]
+    assert repaired.metadata["harness_trace"]["model_decision"]["step_id"] == "S11"
+    assert repaired.metadata["harness_trace"]["model_decision"]["overlay_targets"] == []
+    assert repaired.metadata["harness_trace"]["final_action_plan"]["step_id"] == "S12"
+    assert repaired.metadata["vision_frame_capture_selected"] is True
+    assert repaired.metadata["vision_fact_extractor_used"] is False
+    assert repaired.metadata["harness_trace"]["vlm_call"]["frame_capture_selected"] is True
+    assert repaired.metadata["harness_trace"]["vlm_call"]["extractor_used"] is False
+    public_text = _public_response_text(repaired)
+    assert "ins_mode_knob" in public_text
+    assert "RPM >= 25" not in public_text
 
 
 def test_final_evidence_split_uses_current_step_completion_predicates_only() -> None:

--- a/tests/test_replay_eval.py
+++ b/tests/test_replay_eval.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,55 @@ from simtutor.replay_eval import (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SUITE_PATH = REPO_ROOT / "replay_eval" / "fa18c_startup_v04" / "suite.yaml"
+
+
+LATEST_ISSUE_312_FIXTURES = {
+    "artifacts/live_fixtures/c2a80099-8375-42a1-89eb-b09544b474e2.fixture.json":
+        "final_consistency_no_over_advance",
+    "artifacts/live_fixtures/0758602b-05c0-4ff6-9938-22b7e226f7c0.fixture.json":
+        "completion_based_advancement",
+    "artifacts/live_fixtures/3de0e688-8bc4-4df1-b062-72f3134bc775.fixture.json":
+        "interaction_text_semantics",
+    "artifacts/live_fixtures/e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad.fixture.json":
+        "visual_substate_not_collapsed",
+    "artifacts/live_fixtures/ce8512ef-901a-4f08-a339-af10893b744f.fixture.json":
+        "staged_ufc_comm_selector_first",
+    "artifacts/live_fixtures/20c79783-092e-4128-ad47-5fa7d3774ed7.fixture.json":
+        "four_down_probe_transition_latch",
+    "artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json":
+        "four_down_probe_wait_guidance",
+    "artifacts/live_fixtures/7ea8bf09-dfe7-4e7b-a23f-6407af510e2a.fixture.json":
+        "hook_lever_polarity",
+    "artifacts/live_fixtures/5a7d5df7-2f08-4321-9a4a-6858131b4e6e.fixture.json":
+        "wheel_interaction_radar_altimeter",
+    "artifacts/live_fixtures/ffb5e69b-664b-47d8-9150-57d7cd75d233.fixture.json":
+        "wheel_interaction_standby_attitude",
+    "artifacts/live_fixtures/7bea22f8-a4d1-4744-917b-f7ddc957f709.fixture.json":
+        "public_completion_message",
+    "artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json":
+        "raw_wrong_final_repaired",
+}
+
+TEXT_INTENT_REGRESSION_CLASSES = {
+    "interaction_text_semantics",
+    "wheel_interaction_radar_altimeter",
+    "wheel_interaction_standby_attitude",
+    "public_completion_message",
+}
+
+
+def _coverage_sources_by_fixture(matrix: dict[str, object]) -> dict[str, dict[str, object]]:
+    sources: dict[str, dict[str, object]] = {}
+    steps = matrix["steps"]
+    assert isinstance(steps, dict)
+    for row in steps.values():
+        assert isinstance(row, dict)
+        for cell in row.values():
+            assert isinstance(cell, dict)
+            for source in cell.get("sources", []):
+                if isinstance(source, dict) and isinstance(source.get("fixture"), str):
+                    sources[source["fixture"]] = source
+    return sources
 
 
 def test_load_replay_eval_suite_exposes_expected_cases() -> None:
@@ -128,6 +178,89 @@ def test_replay_eval_report_includes_issue_312_fixture_regression_sources(tmp_pa
         source.get("issue") == 306
         for source in matrix["steps"]["S21"]["moving_settling_control"]["sources"]
     )
+
+
+def test_replay_eval_report_records_latest_issue_312_fixture_regression_classes(
+    tmp_path: Path,
+) -> None:
+    suite = load_replay_eval_suite(SUITE_PATH)
+
+    report = run_replay_eval_suite(suite, output_dir=tmp_path / "issue312-latest")
+    sources_by_fixture = _coverage_sources_by_fixture(report["coverage_matrix"])
+
+    assert set(sources_by_fixture) >= set(LATEST_ISSUE_312_FIXTURES)
+    for fixture, regression_class in LATEST_ISSUE_312_FIXTURES.items():
+        assert (REPO_ROOT / fixture).exists(), fixture
+        source = sources_by_fixture[fixture]
+        assert source["issue"] == 312
+        assert source["source"] == "live_fixture_regression"
+        assert source["regression_class"] == regression_class
+        assert isinstance(source.get("fixture_assertions"), dict), fixture
+        assert "error" not in source["fixture_assertions"]
+        if regression_class in TEXT_INTENT_REGRESSION_CLASSES:
+            assert isinstance(source.get("text_intent"), str), fixture
+
+    s075 = sources_by_fixture[
+        "artifacts/live_fixtures/0758602b-05c0-4ff6-9938-22b7e226f7c0.fixture.json"
+    ]["fixture_assertions"]
+    assert s075["raw_model_step_id"] == "S11"
+    assert s075["raw_model_targets"] == []
+    assert s075["validator_rejected"] is True
+    assert s075["repair_applied"] is True
+    assert s075["final_action_plan_source"] == "final_evidence_consistency_validator"
+    assert s075["message_category"] == "harness_validator_repair"
+    assert s075["final_step_id"] == "S12"
+    assert s075["final_targets"] == ["ins_mode_knob"]
+    assert s075["vlm_call_status"] == "not_required"
+    assert s075["vision_fact_extractor_used"] is False
+    assert s075["frame_capture_selected"] is True
+    assert s075["frame_capture_only"] is True
+
+    s8d30 = sources_by_fixture[
+        "artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json"
+    ]["fixture_assertions"]
+    assert s8d30["raw_model_step_id"] == "S28"
+    assert s8d30["raw_model_targets"] == ["parking_brake_handle"]
+    assert s8d30["final_step_id"] == "S29"
+    assert s8d30["final_targets"] == ["ifei_up_button"]
+    assert s8d30["validator_rejected"] is True
+    assert s8d30["repair_applied"] is True
+    assert s8d30["final_action_plan_source"] == "final_evidence_consistency_validator"
+    assert s8d30["message_category"] == "harness_validator_repair"
+
+    s99b = sources_by_fixture[
+        "artifacts/live_fixtures/99b112ae-ea07-4f5f-a561-71e99fdc2581.fixture.json"
+    ]["fixture_assertions"]
+    assert s99b["vlm_call_status"] == "called"
+    assert s99b["vision_fact_extractor_used"] is True
+    assert s99b["frame_capture_selected"] is True
+    assert s99b["frame_capture_only"] is False
+
+    s3de = sources_by_fixture[
+        "artifacts/live_fixtures/3de0e688-8bc4-4df1-b062-72f3134bc775.fixture.json"
+    ]
+    assert s3de["text_intent"] == "left_engine_left_click_not_right_click"
+
+    s5a = sources_by_fixture[
+        "artifacts/live_fixtures/5a7d5df7-2f08-4321-9a4a-6858131b4e6e.fixture.json"
+    ]
+    assert s5a["text_intent"] == "mouse_wheel_radar_altimeter_bug"
+
+    s7bea = sources_by_fixture[
+        "artifacts/live_fixtures/7bea22f8-a4d1-4744-917b-f7ddc957f709.fixture.json"
+    ]
+    assert s7bea["text_intent"] == "public_completion_no_internal_evidence"
+
+
+def test_harness_coverage_matrix_keeps_suite_regressions_without_pack_specs(tmp_path: Path) -> None:
+    suite = load_replay_eval_suite(SUITE_PATH)
+    suite_without_pack = replace(suite, pack_path=tmp_path / "missing-pack.yaml")
+
+    matrix = build_harness_coverage_matrix(suite_without_pack)
+    sources_by_fixture = _coverage_sources_by_fixture(matrix)
+
+    assert matrix["steps"]["S25"]["moving_settling_control"]["status"] == "regression_reference"
+    assert set(sources_by_fixture) >= set(LATEST_ISSUE_312_FIXTURES)
 
 
 def test_run_replay_eval_suite_is_stable_across_repeated_runs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add the latest #312 live fixture regression references to the FA-18C replay coverage suite, including the 0758602b S11->S12 fixture extracted from the 20260519 live smoke log.
- Enrich replay coverage sources with fixture-derived raw model step/targets, validator rejection, repair status, final action plan source, VLM call status, extractor/frame-capture distinction, and expected text-intent labels for interaction regressions.
- Add replay-eval and live fixture tests for the new regression matrix fields, pack-missing fallback coverage, and the 075 S11 completion repair with frame capture but no VLM extractor call.

## Tests
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_replay_eval.py tests/test_live_dcs.py::test_live_help_fixture_311_keeps_s12_when_only_precondition_is_satisfied tests/test_live_dcs.py::test_live_help_fixture_312_s11_completion_advances_to_s12 tests/test_live_dcs.py::test_live_help_fixture_314_keeps_s08_supt_bit_root_visual_recovery tests/test_live_dcs.py::test_live_help_fixture_314_s09_requires_comm1_pull_before_numeric_sequence tests/test_live_dcs.py::test_live_help_fixture_314_s10_left_engine_uses_left_click_guidance tests/test_live_dcs.py::test_live_help_fixture_314_s31_radar_altimeter_uses_mouse_wheel_guidance tests/test_live_dcs.py::test_live_help_fixture_314_s32_standby_attitude_uses_mouse_wheel_guidance tests/test_live_dcs.py::test_live_help_fixture_314_s33_default_satisfied_uses_public_completion_message tests/test_live_dcs.py::test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance tests/test_live_dcs.py::test_live_help_fixture_306_20c_retracted_probe_latch_advances_to_s22 tests/test_live_dcs.py::test_procedural_guidance_waits_without_highlight_for_s21_probe_retracting tests/test_live_dcs.py::test_live_help_fixture_306_7ea8_hook_down_advances_to_s25_without_trace_mismatch
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #312