### PR TITLE
Fix final consistency partial completion advance

### DIFF
--- a/artifacts/live_fixtures/c4d7c369-f151-4ef6-b528-409b16f1fe34.fixture.json
+++ b/artifacts/live_fixtures/c4d7c369-f151-4ef6-b528-409b16f1fe34.fixture.json
@@ -1,0 +1,166 @@
+{
+  "context": {
+    "observation_ref": "685a3d7f-d0d7-4ec5-a719-03f0a460b998",
+    "observations": [
+      {
+        "observation_id": "685a3d7f-d0d7-4ec5-a719-03f0a460b998",
+        "payload": {
+          "seq": 6214,
+          "t_wall": 1779209302.552865,
+          "recent_ui_targets": [],
+          "vars": {
+            "battery_on": true,
+            "power_available": true,
+            "hud_on": true,
+            "left_ddi_on": true,
+            "right_ddi_on": true,
+            "mpcd_on": true,
+            "comm1_freq_134_000": true,
+            "right_engine_nominal_start_params": true,
+            "engine_crank_left_complete": true,
+            "rpm_l": 26,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": false,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "throttle_l_not_off": false,
+            "ins_mode": 0,
+            "ins_mode_set": false,
+            "ins_mode_cv_or_gnd": false,
+            "ins_fast_align_complete": false,
+            "radar_mode_opr": false
+          }
+        }
+      }
+    ]
+  },
+  "cycle": {
+    "tutor_request": {
+      "request_id": "c4d7c369-f151-4ef6-b528-409b16f1fe34",
+      "message": "help",
+      "observation_ref": "685a3d7f-d0d7-4ec5-a719-03f0a460b998",
+      "context": {
+        "scenario_profile": "airfield",
+        "deterministic_step_hint": {
+          "inferred_step_id": "S11",
+          "overlay_step_id": "S11",
+          "observability": "observable",
+          "observability_status": "observable",
+          "requires_visual_confirmation": false,
+          "missing_conditions_count": 1,
+          "step_ui_targets": []
+        },
+        "state_harness": {
+          "conflicts": [],
+          "telemetry_evidence": {
+            "source_status": "nominal",
+            "confidence": "medium",
+            "observation_seq": 6214
+          },
+          "vision_evidence": {
+            "source_status": "vision_not_required",
+            "confidence": "low",
+            "seen_fact_ids": [],
+            "fresh_fact_ids": []
+          },
+          "deterministic_candidate": {
+            "step_id": "S11",
+            "overlay_step_id": "S11",
+            "missing_conditions": [
+              "vars.rpm_l>=25"
+            ],
+            "role": "candidate_not_authoritative"
+          },
+          "telemetry_window_digest": {
+            "frame_count": 20,
+            "first_seq": 6195,
+            "latest_seq": 6214,
+            "stable_true_vars": [
+              "battery_on",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "stable_false_vars": [],
+            "contradictions": [],
+            "changed_vars": [
+              {
+                "var": "rpm_l",
+                "first_value": 25,
+                "last_value": 26,
+                "transition_count": 1
+              }
+            ]
+          }
+        },
+        "evidence_packet_summary": {
+          "telemetry_status": "nominal",
+          "vision_status": "vision_not_required",
+          "blocked_gate_count": 7,
+          "recent_action_count": 0,
+          "conflicts": []
+        },
+        "vision_fact_summary": {
+          "status": "vision_not_required",
+          "seen_fact_ids": [],
+          "fresh_fact_ids": []
+        },
+        "vision_facts": [],
+        "overlay_target_allowlist": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "rag_topk": []
+      },
+      "metadata": {}
+    },
+    "tutor_response": {
+      "metadata": {
+        "vision": {
+          "status": "partial",
+          "vision_used": true,
+          "frame_ids": [
+            "1779209302604_000294"
+          ],
+          "sync_miss_reason": "missing_pre_trigger_frame"
+        },
+        "vision_fact_summary": {
+          "status": "vision_not_required",
+          "frame_ids": [
+            "1779209302604_000294"
+          ],
+          "fresh_fact_ids": [],
+          "seen_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "summary_text": "no_active_vision_facts"
+        },
+        "vision_facts": []
+      }
+    }
+  },
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "step_id": "S11",
+        "error_category": "OM"
+      },
+      "next": {
+        "step_id": "S11"
+      },
+      "overlay": {
+        "targets": [],
+        "evidence": []
+      },
+      "explanations": [
+        "当前处于 S11 步骤，需要将左油门杆从 OFF 推至 IDLE。由于无法高亮真实油门杆，请使用键盘热键：按住 Right Alt 并按 Home 将左油门推至 IDLE。"
+      ]
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S11",
+    "expected_overlay_target_ids": [],
+    "final_response_source": "model"
+  }
+}

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -6466,7 +6466,7 @@ class LiveDcsTutorLoop:
             "step_id": plan.step_id,
             "overlay_step_id": plan.overlay_step_id,
             "targets": list(plan.targets),
-            "text_only": plan.text_only,
+            "text_only": plan.text_only or not bool(plan.targets),
             "source": final_action_plan_source,
         }
         if s08_visual_hint_used:
@@ -6861,6 +6861,9 @@ class LiveDcsTutorLoop:
                 precondition_only.append(condition)
         return completion_only, precondition_only
 
+    def _completion_gate_condition_count(self, step_id: str | None) -> int:
+        return len(self._gate_missing_condition_keys_for_step(step_id, "completion"))
+
     def _record_final_evidence_precondition_metadata(
         self,
         response: TutorResponse,
@@ -6911,6 +6914,60 @@ class LiveDcsTutorLoop:
             else []
         )
         merged_reasons.extend(precondition_reasons)
+        response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
+
+    def _record_final_evidence_partial_completion_metadata(
+        self,
+        response: TutorResponse,
+        *,
+        completion_missing_conditions: Sequence[str],
+        latest_vars: Mapping[str, Any],
+        evidence_packet: Any,
+    ) -> None:
+        if not completion_missing_conditions:
+            return
+        partial_result = validate_final_evidence_consistency(
+            accepted_step_id=None,
+            accepted_overlay_targets=[],
+            accepted_missing_conditions=completion_missing_conditions,
+            latest_vars=latest_vars,
+            evidence_packet=evidence_packet,
+        )
+        satisfied = [
+            item for item in partial_result.rejected_missing_conditions
+            if isinstance(item, str) and item
+        ]
+        if not satisfied:
+            return
+        response.metadata["final_evidence_consistency_partial_completion_satisfied"] = True
+        existing_conditions = response.metadata.get("partial_completion_satisfied_conditions")
+        merged_conditions = (
+            [item for item in existing_conditions if isinstance(item, str) and item]
+            if isinstance(existing_conditions, list)
+            else []
+        )
+        merged_conditions.extend(satisfied)
+        response.metadata["partial_completion_satisfied_conditions"] = _dedupe_strings(merged_conditions)
+        partial_reasons = [
+            f"partial_completion_satisfied_not_complete:{condition}" for condition in satisfied
+        ]
+        existing_partial_reasons = response.metadata.get("final_evidence_consistency_partial_completion_reasons")
+        merged_partial_reasons = (
+            [item for item in existing_partial_reasons if isinstance(item, str) and item]
+            if isinstance(existing_partial_reasons, list)
+            else []
+        )
+        merged_partial_reasons.extend(partial_reasons)
+        response.metadata["final_evidence_consistency_partial_completion_reasons"] = _dedupe_strings(
+            merged_partial_reasons
+        )
+        existing_reasons = response.metadata.get("harness_validation_reasons")
+        merged_reasons = (
+            [item for item in existing_reasons if isinstance(item, str) and item]
+            if isinstance(existing_reasons, list)
+            else []
+        )
+        merged_reasons.extend(partial_reasons)
         response.metadata["harness_validation_reasons"] = _dedupe_strings(merged_reasons)
 
     def _apply_final_evidence_consistency_metadata(
@@ -6972,6 +7029,23 @@ class LiveDcsTutorLoop:
             latest_vars=vars_map,
             evidence_packet=evidence_packet,
         )
+        completion_condition_count = self._completion_gate_condition_count(accepted_step_id)
+        if completion_condition_count > 1:
+            completion_gate_result = validate_final_evidence_consistency(
+                accepted_step_id=accepted_step_id,
+                accepted_overlay_targets=targets,
+                accepted_missing_conditions=[],
+                latest_vars=vars_map,
+                evidence_packet=evidence_packet,
+            )
+            if completion_gate_result.accepted:
+                self._record_final_evidence_partial_completion_metadata(
+                    response,
+                    completion_missing_conditions=completion_missing_conditions,
+                    latest_vars=vars_map,
+                    evidence_packet=evidence_packet,
+                )
+            completion_missing_conditions = []
         result = validate_final_evidence_consistency(
             accepted_step_id=accepted_step_id,
             accepted_overlay_targets=targets,
@@ -7019,6 +7093,8 @@ class LiveDcsTutorLoop:
         if latched_reason is not None:
             return f"evidence_conflict:{latched_reason}"
         completion_missing_conditions, _ = self._split_completion_missing_conditions(step_id, missing_conditions)
+        if self._completion_gate_condition_count(step_id) > 1:
+            completion_missing_conditions = []
         if not completion_missing_conditions and not include_completion_gate:
             return None
         evidence_context = self._context_with_full_pack_gates(context)

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11366,6 +11366,44 @@ def test_live_help_fixture_312_s11_completion_advances_to_s12() -> None:
     assert "RPM >= 25" not in public_text
 
 
+def test_live_help_fixture_311_keeps_s11_when_completion_is_partial() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/c4d7c369-f151-4ef6-b528-409b16f1fe34.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+    vars_map = request.context["vars"]
+    assert vars_map["rpm_l"] == 26
+    assert vars_map["rpm_l_gte_25"] is True
+    assert vars_map["left_engine_idle_ready"] is False
+    assert vars_map["throttle_l_not_off"] is False
+    response.metadata["diagnosis"] = {"step_id": "S11", "error_category": "OM"}
+    response.metadata["next"] = {"step_id": "S11"}
+
+    repaired = _validate_compact_live_help_response(
+        request=request,
+        response=response,
+        vision_selection=_fixture_vision_selection(fixture),
+        vision_fact_context=_fixture_vision_fact_context(fixture),
+    )
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S11"
+    assert repaired.metadata["next"]["step_id"] == "S11"
+    assert repaired.metadata["final_public_response"]["next"]["step_id"] == "S11"
+    assert repaired.metadata["final_overlay_targets"] == []
+    assert repaired.actions == []
+    assert repaired.metadata.get("final_evidence_consistency_repair_applied") is not True
+    assert repaired.metadata.get("rejected_missing_conditions", []) == []
+    assert repaired.metadata["final_evidence_consistency_partial_completion_satisfied"] is True
+    assert repaired.metadata["partial_completion_satisfied_conditions"] == ["vars.rpm_l>=25"]
+    assert repaired.metadata["final_action_plan"]["step_id"] == "S11"
+    assert repaired.metadata["final_action_plan"]["targets"] == []
+    assert repaired.metadata["final_action_plan"]["text_only"] is True
+    public_text = _public_response_text(repaired)
+    assert "Right Alt" in public_text
+    assert "S12" not in public_text
+    assert "ins_mode_knob" not in public_text
+
+
 def test_final_evidence_split_uses_current_step_completion_predicates_only() -> None:
     loop = LiveDcsTutorLoop(
         source=_DelayedObservationSource(Observation()),


### PR DESCRIPTION
## Summary
- Keep S11 active when only one predicate from its multi-condition completion gate is satisfied
- Record partial completion metadata instead of advancing to S12
- Add c4d7c369 replay fixture and targeted regression coverage

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-issue311-partial-related tests/test_live_dcs.py::test_live_help_fixture_311_replays_real_s09_comm1_complete_fixture tests/test_live_dcs.py::test_live_help_fixture_311_replays_real_s10_left_engine_complete_fixture tests/test_live_dcs.py::test_live_help_fixture_311_keeps_s12_when_only_precondition_is_satisfied tests/test_live_dcs.py::test_live_help_fixture_312_s11_completion_advances_to_s12 tests/test_live_dcs.py::test_live_help_fixture_311_keeps_s11_when_completion_is_partial tests/test_live_dcs.py::test_final_evidence_split_uses_current_step_completion_predicates_only tests/test_live_dcs.py::test_final_evidence_validator_rechecks_repaired_fallback_step tests/test_live_dcs.py::test_safe_fallback_overlay_rejects_missing_condition_satisfied_by_latest_telemetry

Fixes #311