### PR TITLE
Fix action text repair guidance

### DIFF
--- a/artifacts/live_fixtures/e96b29b7-b305-4444-beb3-60ddb0804b4b.fixture.json
+++ b/artifacts/live_fixtures/e96b29b7-b305-4444-beb3-60ddb0804b4b.fixture.json
@@ -1,0 +1,3246 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 1,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 2,
+        "contradiction_count": 0,
+        "first_seq": 7852,
+        "frame_count": 20,
+        "latest_seq": 7871
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+      "source_observation_seq": 7871,
+      "source_observation_t_wall": 1779209388.129013,
+      "telemetry_window_first_seq": 7852,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 7871,
+      "telemetry_window_latest_t_wall": 1779209388.129013,
+      "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+    },
+    "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:56452",
+          "raw_delta_count": 1,
+          "seq": 7871
+        },
+        "observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41343
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 7871,
+          "t_wall": 1779209388.129013,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": false,
+            "hook_handle_value": 1,
+            "hook_retracted": true,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 301,
+            "temp_r": 324,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T16:49:48.130006+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 2,
+      "contradiction_count": 0,
+      "first_seq": 7852,
+      "frame_count": 20,
+      "latest_seq": 7871
+    },
+    "vision": {
+      "frame_ids": [
+        "1779209388207_000298"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779209388207_000298",
+        "frame_ids": [
+          "1779209388207_000298"
+        ],
+        "frame_stale": false,
+        "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+        "observation_seq": 7871,
+        "observation_t_wall_ms": 1779209388129,
+        "observation_t_wall_s": 1779209388.129013,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779209388207,
+            "channel": "composite_panel",
+            "frame_id": "1779209388207_000298",
+            "frame_seq": 298,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209388207_000298_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209388207_000298.png",
+            "sync_delta_ms": 95,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 95,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779209388207,
+          "channel": "composite_panel",
+          "frame_id": "1779209388207_000298",
+          "frame_seq": 298,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209388207_000298_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209388207_000298.png",
+          "sync_delta_ms": 95,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779209388112,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779209388207_000298"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "kind": "tutor_request",
+        "lineno": 8505,
+        "metadata": {
+          "frame_id": "1779209388207_000298",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 95,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S12",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S12",
+              "recent_ui_targets": [
+                "ampcd_pb19"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 2,
+                "contradiction_count": 0,
+                "first_seq": 7852,
+                "frame_count": 20,
+                "latest_seq": 7871
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+              "source_observation_seq": 7871,
+              "source_observation_t_wall": 1779209388.129013,
+              "telemetry_window_first_seq": 7852,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 7871,
+              "telemetry_window_latest_t_wall": 1779209388.129013,
+              "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_error_coding_guide_5",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.3 Order Error (OR)",
+                "score": 20.594762638746236,
+                "section": "2.3 Order Error (OR)",
+                "snippet_id": "fa18c_error_coding_guide_5"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_6",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "score": 19.486667513299274,
+                "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "snippet_id": "Appendix - Training Task Syllabus_6"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 14.8142745576926,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_3",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 4,
+                "score": 14.77405908339654,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_3"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_93",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 94,
+                "score": 14.365182678255943,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_93"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.rpm_l_gte_60==true"
+                ],
+                "overlay_step_id": "S12",
+                "role": "candidate_not_authoritative",
+                "step_id": "S12"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 7871,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": false,
+                    "last_value": true,
+                    "latest_transition_age_s": 1.103,
+                    "transition_count": 1,
+                    "var": "ins_fast_align_complete"
+                  },
+                  {
+                    "first_value": false,
+                    "last_value": false,
+                    "latest_transition_age_s": 1.002,
+                    "transition_count": 2,
+                    "var": "ins_fast_align_pressed"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 7852,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 7871,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 7871,
+                "latest_t_wall": 1779209388.129013,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.28
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779209388207_000298",
+              "frame_ids": [
+                "1779209388207_000298"
+              ],
+              "frame_stale": false,
+              "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+              "observation_seq": 7871,
+              "observation_t_wall_ms": 1779209388129,
+              "observation_t_wall_s": 1779209388.129013,
+              "status": "partial",
+              "sync_delta_ms": 95,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779209388112,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779209388207_000298"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 2,
+                "contradiction_count": 0,
+                "first_seq": 7852,
+                "frame_count": 20,
+                "latest_seq": 7871
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+              "source_observation_seq": 7871,
+              "source_observation_t_wall": 1779209388.129013,
+              "telemetry_window_first_seq": 7852,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 7871,
+              "telemetry_window_latest_t_wall": 1779209388.129013,
+              "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "frame_id": "1779209388207_000298",
+            "fused_missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "fused_step_id": "S12",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_error_coding_guide_5",
+              "Appendix - Training Task Syllabus_6",
+              "fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN_3",
+              "DCS FA-18C Early Access Guide EN_93"
+            ],
+            "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+            "prompt_tokens_est": 5513,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "source_chunk_refs": [
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_5",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_3",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_93"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 95,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779209388207_000298"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779209388207_000298"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+          "request_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "timestamp": "2026-05-19T16:49:48.688877+00:00",
+          "version": "v1"
+        },
+        "related_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "vision_refs": [
+          "1779209388207_000298"
+        ]
+      },
+      {
+        "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "kind": "overlay_requested",
+        "lineno": 8506,
+        "metadata": {
+          "final_overlay_targets": [
+            "radar_mode_knob"
+          ],
+          "frame_id": "1779209388207_000298",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 95,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "4f08ccae-0a92-46ec-9866-b21f1e4710e0",
+          "final_overlay_targets": [
+            "radar_mode_knob"
+          ],
+          "frame_id": "1779209388207_000298",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 95,
+          "target": "pnt_201",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "kind": "overlay_requested",
+        "lineno": 8507,
+        "metadata": {
+          "final_overlay_targets": [
+            "radar_mode_knob"
+          ],
+          "frame_id": "1779209388207_000298",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 95,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "db7d9309-d63d-4a12-8e7a-a04d71120175",
+          "final_overlay_targets": [
+            "radar_mode_knob"
+          ],
+          "frame_id": "1779209388207_000298",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 95,
+          "target": "pnt_440",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "kind": "tutor_response",
+        "lineno": 8508,
+        "metadata": {
+          "final_overlay_targets": [
+            "radar_mode_knob"
+          ],
+          "frame_id": "1779209388207_000298",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 95,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_440",
+              "evidence_refs": [
+                "VARS.radar_mode_opr"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "radar_mode_knob"
+              ],
+              "frame_id": "1779209388207_000298",
+              "fused_missing_conditions": [
+                "vars.rpm_l_gte_60==true"
+              ],
+              "fused_step_id": "S12",
+              "generation_mode": "model",
+              "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 95,
+              "target": "radar_mode_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779209388207_000298"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "请先操作 radar_mode_knob。"
+          ],
+          "in_reply_to": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "message": "请先操作 radar_mode_knob。",
+          "metadata": {
+            "allowed_evidence_ref_count": 118,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "2ab517db-cf73-4e5e-a2ab-5261df283eba",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "请先操作 radar_mode_knob。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "ampcd_pb19"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S13"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+              "source_observation_seq": 7871,
+              "source_observation_t_wall": 1779209388.129013,
+              "telemetry_window_first_seq": 7852,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 7871,
+              "telemetry_window_latest_t_wall": 1779209388.129013,
+              "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "overlay_step_id": "S13",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S13",
+              "targets": [
+                "radar_mode_knob"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 118,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S13"
+              },
+              "next": {
+                "step_id": "S13"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_original_actions": [
+              {
+                "element_id": "pnt_201",
+                "evidence_refs": [
+                  "GATES.S12.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "ampcd_pb19",
+                "type": "overlay"
+              }
+            ],
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S13",
+            "final_evidence_consistency_precondition_reasons": [
+              "precondition_satisfied:vars.rpm_l_gte_60==true"
+            ],
+            "final_evidence_consistency_precondition_satisfied": true,
+            "final_evidence_consistency_reasons": [
+              "completion_gate_already_satisfied:S12"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "radar_mode_knob"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_440",
+                  "evidence_refs": [
+                    "VARS.radar_mode_opr"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "radar_mode_knob"
+                  ],
+                  "frame_id": "1779209388207_000298",
+                  "fused_missing_conditions": [
+                    "vars.rpm_l_gte_60==true"
+                  ],
+                  "fused_step_id": "S12",
+                  "generation_mode": "model",
+                  "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 95,
+                  "target": "radar_mode_knob",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779209388207_000298"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S13"
+              },
+              "explanations": [
+                "请先操作 radar_mode_knob。"
+              ],
+              "message": "请先操作 radar_mode_knob。",
+              "next": {
+                "step_id": "S13"
+              }
+            },
+            "frame_id": "1779209388207_000298",
+            "fused_missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "fused_step_id": "S12",
+            "generation_mode": "model",
+            "generation_prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+            "generation_prompt_tokens_est": 5513,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S13",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S13",
+              "targets": [
+                "radar_mode_knob"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "GATES.S13.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "obogs_control_switch",
+                    "obogs_flow_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S14",
+                  "supporting_evidence_refs": [
+                    "GATES.S14.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "fcs_reset_button",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S15",
+                  "supporting_evidence_refs": [
+                    "GATES.S15.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "flap_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S16",
+                  "supporting_evidence_refs": [
+                    "GATES.S16.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "takeoff_trim_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S17",
+                  "supporting_evidence_refs": [
+                    "GATES.S17.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.5,
+                  "proposed_next_action_target_ids": [
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "recent_action",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "RECENT_ACTIONS.ampcd_pb19"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.66,
+                "proposed_next_action_target_ids": [
+                  "radar_mode_knob"
+                ],
+                "role": "candidate",
+                "source": "gate_blocker",
+                "step_id": "S13",
+                "supporting_evidence_refs": [
+                  "GATES.S13.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 1,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 2,
+                  "contradiction_count": 0,
+                  "first_seq": 7852,
+                  "frame_count": 20,
+                  "latest_seq": 7871
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+                "source_observation_seq": 7871,
+                "source_observation_t_wall": 1779209388.129013,
+                "telemetry_window_first_seq": 7852,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 7871,
+                "telemetry_window_latest_t_wall": 1779209388.129013,
+                "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "overlay_step_id": "S13",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S13",
+                "targets": [
+                  "radar_mode_knob"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "radar_mode_knob"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S12.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "ampcd_pb19"
+                ],
+                "status": "ok",
+                "step_id": "S12"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S12"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+                "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "precondition_satisfied:vars.rpm_l_gte_60==true",
+                  "completion_gate_already_satisfied:S12"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S12"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779209388207_000298"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 95,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "precondition_satisfied:vars.rpm_l_gte_60==true",
+              "completion_gate_already_satisfied:S12"
+            ],
+            "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S13"
+              },
+              "explanations": [
+                "请先操作 radar_mode_knob。"
+              ],
+              "next": {
+                "step_id": "S13"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.radar_mode_opr",
+                    "target": "radar_mode_knob",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "radar_mode_knob"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "当前处于 S12 阶段。S13 因雷达旋钮未设为 OPR 而被阻塞。请左键点击 AMPCD PB19 以完成 S12 步骤。"
+              ],
+              "next": {
+                "step_id": "S12"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S12.completion",
+                    "target": "ampcd_pb19",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ampcd_pb19"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4651,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S12"
+            },
+            "model_raw_explanations": [
+              "当前处于 S12 阶段。S13 因雷达旋钮未设为 OPR 而被阻塞。请左键点击 AMPCD PB19 以完成 S12 步骤。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "当前处于 S12 阶段。S13 因雷达旋钮未设为 OPR 而被阻塞。请左键点击 AMPCD PB19 以完成 S12 步骤。"
+              ],
+              "next": {
+                "step_id": "S12"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S12.completion",
+                    "target": "ampcd_pb19",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ampcd_pb19"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S12"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779209388207_000298"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779209388207_000298",
+            "next": {
+              "step_id": "S13"
+            },
+            "observability_status": "observable",
+            "precondition_satisfied_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "prompt_budget_used": 5590,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.rpm_l_gte_60",
+                "GATES.S12.completion",
+                "GATES.S12.precondition",
+                "GATES.S13.completion",
+                "GATES.S14.completion",
+                "GATES.S14.precondition",
+                "GATES.S15.completion",
+                "GATES.S16.completion",
+                "GATES.S17.completion",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_5",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_3",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_93"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 23,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "ampcd_pb19",
+              "prompt_chars": 22051,
+              "prompt_tokens_est": 5513,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_error_coding_guide_5",
+                "Appendix - Training Task Syllabus_6",
+                "fa18c_startup_master_1",
+                "DCS FA-18C Early Access Guide EN_3",
+                "DCS FA-18C Early Access Guide EN_93"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+            "prompt_tokens_est": 5513,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "rejected_model_step_id": "S12",
+            "rejected_model_target": "ampcd_pb19",
+            "rejected_model_targets": [
+              "ampcd_pb19"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+            "request_prompt_tokens_est": 5513,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 118,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S12"
+              },
+              "next": {
+                "step_id": "S12"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+              "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+            },
+            "state_key": "50ac151bae05c7afe581cc1117a9b9556f290ef31a55802c2622f4cd40be2fb0",
+            "sync_delta_ms": 95,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779209388207_000298",
+              "frame_ids": [
+                "1779209388207_000298"
+              ],
+              "frame_stale": false,
+              "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+              "observation_seq": 7871,
+              "observation_t_wall_ms": 1779209388129,
+              "observation_t_wall_s": 1779209388.129013,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779209388207,
+                  "channel": "composite_panel",
+                  "frame_id": "1779209388207_000298",
+                  "frame_seq": 298,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209388207_000298_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209388207_000298.png",
+                  "sync_delta_ms": 95,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 95,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779209388207,
+                "channel": "composite_panel",
+                "frame_id": "1779209388207_000298",
+                "frame_seq": 298,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209388207_000298_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209388207_000298.png",
+                "sync_delta_ms": 95,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779209388112,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S12"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779209388207_000298"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779209388207_000298"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "9fa83343-17fe-4737-9512-8466529c3ccd",
+          "status": "ok",
+          "timestamp": "2026-05-19T16:49:53.341790+00:00",
+          "version": "v1"
+        },
+        "related_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "vision_refs": [
+          "1779209388207_000298"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S12",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S12",
+          "recent_ui_targets": [
+            "ampcd_pb19"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 2,
+            "contradiction_count": 0,
+            "first_seq": 7852,
+            "frame_count": 20,
+            "latest_seq": 7871
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+          "source_observation_seq": 7871,
+          "source_observation_t_wall": 1779209388.129013,
+          "telemetry_window_first_seq": 7852,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 7871,
+          "telemetry_window_latest_t_wall": 1779209388.129013,
+          "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_error_coding_guide_5",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.3 Order Error (OR)",
+            "score": 20.594762638746236,
+            "section": "2.3 Order Error (OR)",
+            "snippet_id": "fa18c_error_coding_guide_5"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_6",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "score": 19.486667513299274,
+            "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "snippet_id": "Appendix - Training Task Syllabus_6"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 14.8142745576926,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_3",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 4,
+            "score": 14.77405908339654,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_3"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_93",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 94,
+            "score": 14.365182678255943,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_93"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "overlay_step_id": "S12",
+            "role": "candidate_not_authoritative",
+            "step_id": "S12"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 7871,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": false,
+                "last_value": true,
+                "latest_transition_age_s": 1.103,
+                "transition_count": 1,
+                "var": "ins_fast_align_complete"
+              },
+              {
+                "first_value": false,
+                "last_value": false,
+                "latest_transition_age_s": 1.002,
+                "transition_count": 2,
+                "var": "ins_fast_align_pressed"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 7852,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 7871,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 7871,
+            "latest_t_wall": 1779209388.129013,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.28
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779209388207_000298",
+          "frame_ids": [
+            "1779209388207_000298"
+          ],
+          "frame_stale": false,
+          "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+          "observation_seq": 7871,
+          "observation_t_wall_ms": 1779209388129,
+          "observation_t_wall_s": 1779209388.129013,
+          "status": "partial",
+          "sync_delta_ms": 95,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779209388112,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779209388207_000298"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 2,
+            "contradiction_count": 0,
+            "first_seq": 7852,
+            "frame_count": 20,
+            "latest_seq": 7871
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+          "source_observation_seq": 7871,
+          "source_observation_t_wall": 1779209388.129013,
+          "telemetry_window_first_seq": 7852,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 7871,
+          "telemetry_window_latest_t_wall": 1779209388.129013,
+          "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "frame_id": "1779209388207_000298",
+        "fused_missing_conditions": [
+          "vars.rpm_l_gte_60==true"
+        ],
+        "fused_step_id": "S12",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_error_coding_guide_5",
+          "Appendix - Training Task Syllabus_6",
+          "fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN_3",
+          "DCS FA-18C Early Access Guide EN_93"
+        ],
+        "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+        "prompt_tokens_est": 5513,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "source_chunk_refs": [
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_5",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_3",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_93"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 95,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779209388207_000298"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779209388207_000298"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+      "request_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+      "timestamp": "2026-05-19T16:49:48.688877+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_440",
+          "evidence_refs": [
+            "VARS.radar_mode_opr"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "radar_mode_knob"
+          ],
+          "frame_id": "1779209388207_000298",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 95,
+          "target": "radar_mode_knob",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "请先操作 radar_mode_knob。"
+      ],
+      "in_reply_to": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+      "message": "请先操作 radar_mode_knob。",
+      "metadata": {
+        "allowed_evidence_ref_count": 118,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "2ab517db-cf73-4e5e-a2ab-5261df283eba",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "请先操作 radar_mode_knob。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "ampcd_pb19"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S13"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+          "source_observation_seq": 7871,
+          "source_observation_t_wall": 1779209388.129013,
+          "telemetry_window_first_seq": 7852,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 7871,
+          "telemetry_window_latest_t_wall": 1779209388.129013,
+          "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "overlay_step_id": "S13",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S13",
+          "targets": [
+            "radar_mode_knob"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 118,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S13"
+          },
+          "next": {
+            "step_id": "S13"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_original_actions": [
+          {
+            "element_id": "pnt_201",
+            "evidence_refs": [
+              "GATES.S12.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "ampcd_pb19",
+            "type": "overlay"
+          }
+        ],
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S13",
+        "final_evidence_consistency_precondition_reasons": [
+          "precondition_satisfied:vars.rpm_l_gte_60==true"
+        ],
+        "final_evidence_consistency_precondition_satisfied": true,
+        "final_evidence_consistency_reasons": [
+          "completion_gate_already_satisfied:S12"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "radar_mode_knob"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_440",
+              "evidence_refs": [
+                "VARS.radar_mode_opr"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "radar_mode_knob"
+              ],
+              "frame_id": "1779209388207_000298",
+              "fused_missing_conditions": [
+                "vars.rpm_l_gte_60==true"
+              ],
+              "fused_step_id": "S12",
+              "generation_mode": "model",
+              "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 95,
+              "target": "radar_mode_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779209388207_000298"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S13"
+          },
+          "explanations": [
+            "请先操作 radar_mode_knob。"
+          ],
+          "message": "请先操作 radar_mode_knob。",
+          "next": {
+            "step_id": "S13"
+          }
+        },
+        "frame_id": "1779209388207_000298",
+        "fused_missing_conditions": [
+          "vars.rpm_l_gte_60==true"
+        ],
+        "fused_step_id": "S12",
+        "generation_mode": "model",
+        "generation_prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+        "generation_prompt_tokens_est": 5513,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S13",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S13",
+          "targets": [
+            "radar_mode_knob"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S12",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "GATES.S13.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "obogs_control_switch",
+                "obogs_flow_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S14",
+              "supporting_evidence_refs": [
+                "GATES.S14.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "fcs_reset_button",
+                "left_mdi_pb18",
+                "left_mdi_pb15"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S15",
+              "supporting_evidence_refs": [
+                "GATES.S15.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "flap_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S16",
+              "supporting_evidence_refs": [
+                "GATES.S16.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "takeoff_trim_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S17",
+              "supporting_evidence_refs": [
+                "GATES.S17.completion"
+              ]
+            },
+            {
+              "confidence": 0.5,
+              "proposed_next_action_target_ids": [
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "recent_action",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "RECENT_ACTIONS.ampcd_pb19"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.66,
+            "proposed_next_action_target_ids": [
+              "radar_mode_knob"
+            ],
+            "role": "candidate",
+            "source": "gate_blocker",
+            "step_id": "S13",
+            "supporting_evidence_refs": [
+              "GATES.S13.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 1,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 2,
+              "contradiction_count": 0,
+              "first_seq": 7852,
+              "frame_count": 20,
+              "latest_seq": 7871
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+            "source_observation_seq": 7871,
+            "source_observation_t_wall": 1779209388.129013,
+            "telemetry_window_first_seq": 7852,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 7871,
+            "telemetry_window_latest_t_wall": 1779209388.129013,
+            "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "overlay_step_id": "S13",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S13",
+            "targets": [
+              "radar_mode_knob"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "radar_mode_knob"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S12.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "ampcd_pb19"
+            ],
+            "status": "ok",
+            "step_id": "S12"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S12"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+            "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "precondition_satisfied:vars.rpm_l_gte_60==true",
+              "completion_gate_already_satisfied:S12"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S12"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779209388207_000298"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 95,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "precondition_satisfied:vars.rpm_l_gte_60==true",
+          "completion_gate_already_satisfied:S12"
+        ],
+        "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S13"
+          },
+          "explanations": [
+            "请先操作 radar_mode_knob。"
+          ],
+          "next": {
+            "step_id": "S13"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.radar_mode_opr",
+                "target": "radar_mode_knob",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "radar_mode_knob"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "当前处于 S12 阶段。S13 因雷达旋钮未设为 OPR 而被阻塞。请左键点击 AMPCD PB19 以完成 S12 步骤。"
+          ],
+          "next": {
+            "step_id": "S12"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S12.completion",
+                "target": "ampcd_pb19",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ampcd_pb19"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4651,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S12"
+        },
+        "model_raw_explanations": [
+          "当前处于 S12 阶段。S13 因雷达旋钮未设为 OPR 而被阻塞。请左键点击 AMPCD PB19 以完成 S12 步骤。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "当前处于 S12 阶段。S13 因雷达旋钮未设为 OPR 而被阻塞。请左键点击 AMPCD PB19 以完成 S12 步骤。"
+          ],
+          "next": {
+            "step_id": "S12"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S12.completion",
+                "target": "ampcd_pb19",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ampcd_pb19"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S12"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779209388207_000298"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779209388207_000298",
+        "next": {
+          "step_id": "S13"
+        },
+        "observability_status": "observable",
+        "precondition_satisfied_conditions": [
+          "vars.rpm_l_gte_60==true"
+        ],
+        "prompt_budget_used": 5590,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.rpm_l_gte_60",
+            "GATES.S12.completion",
+            "GATES.S12.precondition",
+            "GATES.S13.completion",
+            "GATES.S14.completion",
+            "GATES.S14.precondition",
+            "GATES.S15.completion",
+            "GATES.S16.completion",
+            "GATES.S17.completion",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_5",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_3",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_93"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 23,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "ampcd_pb19",
+          "prompt_chars": 22051,
+          "prompt_tokens_est": 5513,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_error_coding_guide_5",
+            "Appendix - Training Task Syllabus_6",
+            "fa18c_startup_master_1",
+            "DCS FA-18C Early Access Guide EN_3",
+            "DCS FA-18C Early Access Guide EN_93"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+        "prompt_tokens_est": 5513,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.rpm_l_gte_60==true"
+        ],
+        "rejected_model_step_id": "S12",
+        "rejected_model_target": "ampcd_pb19",
+        "rejected_model_targets": [
+          "ampcd_pb19"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "02eaa8568e1c7aa31d26e664585bf3a99281fcfa6d2465b1b0ba974e759970cb",
+        "request_prompt_tokens_est": 5513,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 118,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S12"
+          },
+          "next": {
+            "step_id": "S12"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+          "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+        },
+        "state_key": "50ac151bae05c7afe581cc1117a9b9556f290ef31a55802c2622f4cd40be2fb0",
+        "sync_delta_ms": 95,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779209388207_000298",
+          "frame_ids": [
+            "1779209388207_000298"
+          ],
+          "frame_stale": false,
+          "observation_ref": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+          "observation_seq": 7871,
+          "observation_t_wall_ms": 1779209388129,
+          "observation_t_wall_s": 1779209388.129013,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779209388207,
+              "channel": "composite_panel",
+              "frame_id": "1779209388207_000298",
+              "frame_seq": 298,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209388207_000298_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209388207_000298.png",
+              "sync_delta_ms": 95,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 95,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779209388207,
+            "channel": "composite_panel",
+            "frame_id": "1779209388207_000298",
+            "frame_seq": 298,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209388207_000298_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209388207_000298.png",
+            "sync_delta_ms": 95,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779209388112,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S12"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779209388207_000298"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779209388207_000298"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "9fa83343-17fe-4737-9512-8466529c3ccd",
+      "status": "ok",
+      "timestamp": "2026-05-19T16:49:53.341790+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S13",
+    "expected_overlay_target_ids": [
+      "radar_mode_knob"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S12",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "obogs_control_switch",
+          "obogs_flow_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S14",
+        "supporting_evidence_refs": [
+          "GATES.S14.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "fcs_reset_button",
+          "left_mdi_pb18",
+          "left_mdi_pb15"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S15",
+        "supporting_evidence_refs": [
+          "GATES.S15.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "flap_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S16",
+        "supporting_evidence_refs": [
+          "GATES.S16.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "takeoff_trim_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S17",
+        "supporting_evidence_refs": [
+          "GATES.S17.completion"
+        ]
+      },
+      {
+        "confidence": 0.5,
+        "proposed_next_action_target_ids": [
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "recent_action",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "RECENT_ACTIONS.ampcd_pb19"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+      "overlay_step_id": "S13",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S13",
+      "targets": [
+        "radar_mode_knob"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S12.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "ampcd_pb19"
+      ],
+      "status": "ok",
+      "step_id": "S12"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S12",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "GATES.S13.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "obogs_control_switch",
+            "obogs_flow_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S14",
+          "supporting_evidence_refs": [
+            "GATES.S14.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "fcs_reset_button",
+            "left_mdi_pb18",
+            "left_mdi_pb15"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S15",
+          "supporting_evidence_refs": [
+            "GATES.S15.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "flap_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S16",
+          "supporting_evidence_refs": [
+            "GATES.S16.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "takeoff_trim_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S17",
+          "supporting_evidence_refs": [
+            "GATES.S17.completion"
+          ]
+        },
+        {
+          "confidence": 0.5,
+          "proposed_next_action_target_ids": [
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "recent_action",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "RECENT_ACTIONS.ampcd_pb19"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 1,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 2,
+          "contradiction_count": 0,
+          "first_seq": 7852,
+          "frame_count": 20,
+          "latest_seq": 7871
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "final_decision_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "model_request_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "source_observation_id": "2994217d-1455-4e41-b5d9-445af8f9cd48",
+        "source_observation_seq": 7871,
+        "source_observation_t_wall": 1779209388.129013,
+        "telemetry_window_first_seq": 7852,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 7871,
+        "telemetry_window_latest_t_wall": 1779209388.129013,
+        "validator_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "overlay_step_id": "S13",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S13",
+        "targets": [
+          "radar_mode_knob"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "radar_mode_knob"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S12.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "ampcd_pb19"
+        ],
+        "status": "ok",
+        "step_id": "S12"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S12"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "final_decision": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "model_request": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7",
+        "validator": "72af5d16d1bedbb0820e4fbbc2e7bf8ee79c0d9fe4be500f38c6d860a0513df7"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "precondition_satisfied:vars.rpm_l_gte_60==true",
+          "completion_gate_already_satisfied:S12"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S12"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779209388207_000298"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 95,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "precondition_satisfied:vars.rpm_l_gte_60==true",
+        "completion_gate_already_satisfied:S12"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S12"
+    }
+  },
+  "help_cycle_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S13"
+      },
+      "explanations": [
+        "请先操作 radar_mode_knob。"
+      ],
+      "next": {
+        "step_id": "S13"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.radar_mode_opr",
+            "target": "radar_mode_knob",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "radar_mode_knob"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S12"
+      },
+      "explanations": [
+        "当前处于 S12 阶段。S13 因雷达旋钮未设为 OPR 而被阻塞。请左键点击 AMPCD PB19 以完成 S12 步骤。"
+      ],
+      "next": {
+        "step_id": "S12"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S12.completion",
+            "target": "ampcd_pb19",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "ampcd_pb19"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "e96b29b7-b305-4444-beb3-60ddb0804b4b",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 13409,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_164221.jsonl"
+  }
+}

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -626,6 +626,15 @@ def _state_action_plan(
                 source="state_action_planner",
                 reasons=("s10_left_engine_left_click_guidance",),
             )
+    if step_id == "S13" and vars_map.get("radar_mode_opr") is not True:
+        if "radar_mode_knob" in allowed:
+            return _StateActionPlan(
+                targets=("radar_mode_knob",),
+                guidance="Set the radar knob to OPR with a right-click to the next detent.",
+                text_only=False,
+                source="state_action_planner",
+                reasons=("s13_radar_opr_right_click_guidance",),
+            )
     if step_id == "S31" and vars_map.get("radar_altimeter_bug_set") is not True:
         if "radar_altimeter_bug_knob" in allowed:
             return _StateActionPlan(

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -157,6 +157,93 @@ _S08_POWER_SEQUENCE: tuple[tuple[str, str, str], ...] = (
         "DDIs and AMPCD are powered. Increase HUD symbology brightness next.",
     ),
 )
+
+_TARGET_ACTION_GUIDANCE_BY_STEP: dict[tuple[str, str], dict[str, str]] = {
+    ("S18", "right_mdi_pb5"): {
+        "zh": "请在右 DDI BIT 页面左键按 PB5/FCS-MC，进入 FCS-MC BIT 页面。",
+        "en": "On the right DDI BIT page, left-click PB5/FCS-MC to enter the FCS-MC BIT page.",
+    },
+    ("S13", "radar_mode_knob"): {
+        "zh": "请将 RADAR knob 设到 OPR：右键点击到下一挡。",
+        "en": "Set the radar knob to OPR with a right-click to the next detent.",
+    },
+    ("S20", "refuel_probe_switch"): {
+        "zh": "请右键将受油管开关拨到 EXTEND，开始四落检查。",
+        "en": "Right-click the refueling probe switch to EXTEND for the four-down check.",
+    },
+    ("S21", "refuel_probe_switch"): {
+        "zh": "请收回受油管，确认受油管完全收好。",
+        "en": "Retract the refueling probe and confirm it is fully stowed.",
+    },
+}
+
+_TARGET_ACTION_GUIDANCE: dict[str, dict[str, str]] = {
+    "fcs_bit_switch": {
+        "zh": "请按住 FCS BIT 开关向上，并按右 DDI PB5 启动 FCS BIT。",
+        "en": "Hold the FCS BIT switch up and press right DDI PB5 to start the FCS BIT.",
+    },
+}
+
+_CJK_RE = re.compile(r"[\u3400-\u9fff]")
+
+
+def _ui_map_target_interaction_hint(
+    ui_map_path: str | Path | None,
+    target: str,
+    *,
+    lang: str,
+) -> str | None:
+    path = Path(ui_map_path) if ui_map_path is not None else _default_ui_map_path()
+    try:
+        ui_map = _load_yaml_mapping(path, "ui_map.yaml")
+    except Exception:
+        return None
+    cockpit_elements = ui_map.get("cockpit_elements")
+    if not isinstance(cockpit_elements, Mapping):
+        return None
+    entry = cockpit_elements.get(target)
+    if not isinstance(entry, Mapping):
+        return None
+    hint = entry.get("interaction_hint")
+    if not isinstance(hint, Mapping):
+        return None
+    key = "zh" if lang == "zh" else "en"
+    value = hint.get(key)
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _localized_target_action_guidance(
+    target: str | None,
+    *,
+    step_id: str | None,
+    lang: str,
+    ui_map_path: str | Path | None = None,
+) -> str | None:
+    if not isinstance(target, str) or not target:
+        return None
+    language = "zh" if lang == "zh" else "en"
+    ui_hint = _ui_map_target_interaction_hint(ui_map_path, target, lang=lang)
+    if isinstance(ui_hint, str) and ui_hint:
+        return ui_hint
+    if isinstance(step_id, str) and step_id:
+        entry = _TARGET_ACTION_GUIDANCE_BY_STEP.get((step_id, target))
+        if isinstance(entry, Mapping):
+            guidance = entry.get(language)
+            if isinstance(guidance, str) and guidance:
+                return guidance
+    entry = _TARGET_ACTION_GUIDANCE.get(target)
+    if not isinstance(entry, Mapping):
+        return None
+    guidance = entry.get(language)
+    return guidance if isinstance(guidance, str) and guidance else None
+
+
+def _prefix_step_incomplete_guidance(step_id: str | None, guidance: str, *, lang: str) -> str:
+    if not isinstance(step_id, str) or not step_id:
+        return guidance
+    if lang == "zh":
+        return f"当前 {step_id} 尚未完成。{guidance}"
+    return f"{step_id} is not complete yet. {guidance}"
 from core.types import Event, Observation, TutorRequest, TutorResponse
 from core.vision_facts import (
     VisionFactsConfigError,
@@ -5294,6 +5381,63 @@ class LiveDcsTutorLoop:
         if isinstance(raw_diagnosis, Mapping):
             response.metadata.setdefault("model_raw_diagnosis", dict(raw_diagnosis))
 
+    def _rewrite_public_target_id_action_text(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> bool:
+        targets = [
+            action.get("target")
+            for action in response.actions
+            if isinstance(action, Mapping) and isinstance(action.get("target"), str)
+        ]
+        if len(targets) != 1:
+            return False
+        target = targets[0]
+        context = request.context if isinstance(request.context, Mapping) else {}
+        hint = context.get("deterministic_step_hint")
+        step_id = None
+        for payload in (response.metadata.get("next"), response.metadata.get("diagnosis"), hint):
+            if isinstance(payload, Mapping):
+                candidate = payload.get("step_id") or payload.get("inferred_step_id")
+                if isinstance(candidate, str) and candidate:
+                    step_id = candidate
+                    break
+        guidance = _localized_target_action_guidance(
+            target,
+            step_id=step_id,
+            lang=self.lang,
+            ui_map_path=self.ui_map_path,
+        )
+        if not isinstance(guidance, str) or not guidance:
+            return False
+
+        text_parts = [response.message, *response.explanations]
+        has_target_id = any(isinstance(part, str) and target in part for part in text_parts)
+        has_language_leak = (
+            self.lang == "zh"
+            and any(isinstance(part, str) and part.strip() and _CJK_RE.search(part) is None for part in text_parts)
+        )
+        if not has_target_id and not has_language_leak:
+            return False
+
+        rewritten = _prefix_step_incomplete_guidance(step_id, guidance, lang=self.lang)
+        original_message = response.message
+        original_explanations = list(response.explanations)
+        response.message = rewritten
+        response.explanations = [rewritten]
+        response.metadata["target_action_text_rewritten"] = True
+        response.metadata["target_action_text_rewrite_target"] = target
+        if original_message != rewritten:
+            response.metadata["target_action_text_original_message"] = original_message
+        if original_explanations and original_explanations != [rewritten]:
+            response.metadata["target_action_text_original_explanations"] = original_explanations
+        if isinstance(response.metadata.get("help_response"), Mapping):
+            help_response = copy.deepcopy(dict(response.metadata["help_response"]))
+            help_response["explanations"] = [rewritten]
+            response.metadata["help_response"] = help_response
+        return True
+
     def _annotate_response_audit_metadata(self, response: TutorResponse) -> None:
         self._capture_model_raw_help_response(response)
         sanitized_message = sanitize_public_model_text(response.message, lang=self.lang)
@@ -5511,20 +5655,33 @@ class LiveDcsTutorLoop:
                     "You are still on S08. The left DDI is only showing the FCS button, "
                     "but it has not entered the FCS page yet; press Left DDI PB15 to enter the FCS page first."
                 )
+        elif isinstance(action_target, str) and action_target:
+            action_guidance = _localized_target_action_guidance(
+                action_target,
+                step_id=inferred_step_id,
+                lang=self.lang,
+                ui_map_path=self.ui_map_path,
+            )
+            if isinstance(action_guidance, str) and action_guidance:
+                rewritten = _prefix_step_incomplete_guidance(
+                    inferred_step_id,
+                    action_guidance,
+                    lang=self.lang,
+                )
+            elif self.lang == "zh":
+                rewritten = f"当前 {inferred_step_id} 尚未完成。请先操作 {action_target}，并确认该步骤条件已满足。"
+            else:
+                rewritten = (
+                    f"{inferred_step_id} is not complete yet. "
+                    f"Please operate {action_target} first and confirm that step is complete."
+                )
         elif self.lang == "zh":
             rewritten = f"当前 {inferred_step_id} 尚未完成，请先完成该步骤的未满足条件。"
-            if isinstance(action_target, str) and action_target:
-                rewritten = f"当前 {inferred_step_id} 尚未完成。请先操作 {action_target}，并确认该步骤条件已满足。"
         else:
             rewritten = (
                 f"{inferred_step_id} is not complete yet. "
                 "Please complete the unmet conditions for that step."
             )
-            if isinstance(action_target, str) and action_target:
-                rewritten = (
-                    f"{inferred_step_id} is not complete yet. "
-                    f"Please operate {action_target} first and confirm that step is complete."
-                )
 
         response.message = rewritten
         response.explanations = [rewritten]
@@ -6435,6 +6592,12 @@ class LiveDcsTutorLoop:
                 if self.lang == "zh"
                 else "You are on S10. Set the Engine Crank switch to LEFT/L with a left-click to start the left engine."
             )
+        elif "s13_radar_opr_right_click_guidance" in plan.reasons:
+            plan_guidance = (
+                "现在进入 S13。请将 RADAR knob 设到 OPR：右键点击到下一挡。"
+                if self.lang == "zh"
+                else "Continue to S13. Set the radar knob to OPR with a right-click to the next detent."
+            )
         elif "s31_radar_altimeter_mouse_wheel_guidance" in plan.reasons:
             plan_guidance = (
                 "现在进入 S31。请用鼠标滚轮调整雷达高度表告警高度旋钮：机场 200 ft，航母 40 ft。"
@@ -6447,6 +6610,15 @@ class LiveDcsTutorLoop:
                 if self.lang == "zh"
                 else "Continue to S32. Use the mouse wheel on the standby attitude cage knob to uncage the standby attitude indicator."
             )
+        if self.lang == "zh" and len(plan.targets) == 1:
+            localized_plan_guidance = _localized_target_action_guidance(
+                plan.targets[0],
+                step_id=plan.step_id,
+                lang=self.lang,
+                ui_map_path=self.ui_map_path,
+            )
+            if isinstance(localized_plan_guidance, str) and localized_plan_guidance:
+                plan_guidance = localized_plan_guidance
         if s18_visual_hint_used and (not isinstance(plan_guidance, str) or not plan_guidance):
             plan_guidance = s18_visual_hint_reason
         emergency_presentation_fallback = response.status == "error" or response.metadata.get("provider") == "fallback"
@@ -8381,6 +8553,15 @@ class LiveDcsTutorLoop:
             and _s08_power_condition_missing_for_target(fallback_target, missing_set, vars_map)
         ):
             fallback_guidance = _s08_power_guidance_for_target(fallback_target, self.lang)
+        elif len(fallback_targets_list) == 1 and (
+            localized_fallback_guidance := _localized_target_action_guidance(
+                fallback_target,
+                step_id=overlay_step_id,
+                lang=self.lang,
+                ui_map_path=self.ui_map_path,
+            )
+        ):
+            fallback_guidance = localized_fallback_guidance
         elif self.lang == "zh" and overlay_step_id in {"S22", "S23", "S24", "S25"}:
             fallback_guidance = {
                 "S22": "请放下 launch bar，确认 launch bar 已伸出。",
@@ -8395,6 +8576,10 @@ class LiveDcsTutorLoop:
                 "S24": "Lower the arresting hook handle and confirm the hook is down.",
                 "S25": "Raise the arresting hook handle and confirm the hook is up.",
             }[overlay_step_id]
+        elif self.lang == "zh" and overlay_step_id == "S13":
+            fallback_guidance = "现在进入 S13。请将 RADAR knob 设到 OPR：右键点击到下一挡。"
+        elif overlay_step_id == "S13":
+            fallback_guidance = "Continue to S13. Set the radar knob to OPR with a right-click to the next detent."
         elif self.lang == "zh" and overlay_step_id in {"S28", "S29", "S30", "S31", "S32"}:
             fallback_guidance = {
                 "S28": "现在进入 S28。请释放停车刹车手柄，准备滑行。",
@@ -8777,6 +8962,7 @@ class LiveDcsTutorLoop:
         if final_consistency_used:
             fallback_overlay_used = bool(response.actions)
             fallback_overlay_reason = final_consistency_reason
+        self._rewrite_public_target_id_action_text(response, request)
 
         if mapped_meta:
             mapping_failure_codes = classify_mapping_failure(mapped_meta)

--- a/packs/fa18c_startup/pack.yaml
+++ b/packs/fa18c_startup/pack.yaml
@@ -766,7 +766,7 @@ steps:
     ui_targets:
       - radar_mode_knob
     tutor_prompts:
-      - "After INS mode is set, rotate radar knob to OPR."
+      - "After INS mode is set, right-click the radar knob to the next detent and set it to OPR."
 
   - id: S14
     phase: P4

--- a/packs/fa18c_startup/ui_map.yaml
+++ b/packs/fa18c_startup/ui_map.yaml
@@ -109,6 +109,14 @@ cockpit_elements:
     dcs_id: "pnt_416"
     aliases: ["Lights Test Switch"]
     panel_area: "right_console_lighting"
+    interaction:
+      user_label: "LIGHTS TEST switch"
+      action_verb: "hold"
+      click_type: "left"
+      target_state: "TEST"
+    interaction_hint:
+      zh: "LIGHTS TEST：左键按住执行灯光测试。"
+      en: "LIGHTS TEST: left-click and hold to run the light test."
   left_mdi_brightness_selector:
     description: "Left MDI Brightness Selector Knob OFF/NIGHT/DAY"
     dcs_id: "pnt_51"
@@ -256,11 +264,26 @@ cockpit_elements:
     dcs_id: "pnt_349"
     aliases: ["FCS RESET Button"]
     panel_area: "left_console_flight_controls"
+    interaction:
+      user_label: "FCS RESET button"
+      action_verb: "press"
+      click_type: "left"
+    interaction_hint:
+      zh: "FCS RESET：左键按下按钮。"
+      en: "FCS RESET: left-click the button."
   fcs_bit_switch:
     description: "FCS BIT switch on right wall"
     dcs_id: "pnt_470"
     aliases: ["FCS BIT Switch"]
     panel_area: "right_console_flight_controls"
+    interaction:
+      user_label: "FCS BIT switch"
+      action_verb: "hold"
+      click_type: "right"
+      target_state: "UP"
+    interaction_hint:
+      zh: "FCS BIT：右键向上按住。"
+      en: "FCS BIT: right-click and hold the switch up."
   ufc_comm1_channel_selector_rotate:
     description: "UFC COMM 1 channel selector rotate"
     dcs_id: "pnt_124"
@@ -331,13 +354,21 @@ cockpit_elements:
       click_type: "right"
       detent_direction: "counter_clockwise"
     interaction_hint:
-      zh: "RADAR：右键到下一挡。"
-      en: "RADAR: right-click to the next detent."
+      zh: "RADAR：右键到下一挡，设到 OPR。"
+      en: "RADAR: right-click to the next detent and set OPR."
   obogs_control_switch:
     description: "OBOGS control switch"
     dcs_id: "pnt_365"
     aliases: ["OBOGS Control Switch"]
     panel_area: "left_console_oxygen"
+    interaction:
+      user_label: "OBOGS control switch"
+      action_verb: "set"
+      click_type: "right"
+      target_state: "ON"
+    interaction_hint:
+      zh: "OBOGS control：右键拨到 ON。"
+      en: "OBOGS control: right-click the switch to ON."
   obogs_flow_knob:
     description: "OBOGS flow knob"
     dcs_id: "pnt_366"
@@ -353,6 +384,13 @@ cockpit_elements:
     dcs_id: "pnt_346"
     aliases: ["T/O TRIM Button"]
     panel_area: "left_console_flight_controls"
+    interaction:
+      user_label: "T/O TRIM button"
+      action_verb: "press"
+      click_type: "left"
+    interaction_hint:
+      zh: "T/O TRIM：左键按下按钮完成起飞配平。"
+      en: "T/O TRIM: left-click the button to set takeoff trim."
   refuel_probe_switch:
     description: "Probe control switch EXTEND/RETRACT/EMERG EXTD"
     dcs_id: "pnt_341"
@@ -379,6 +417,14 @@ cockpit_elements:
     dcs_id: "pnt_409"
     aliases: ["Pitot Heater Switch"]
     panel_area: "right_console_anti_ice"
+    interaction:
+      user_label: "PITOT HEAT switch"
+      action_verb: "set"
+      click_type: "right"
+      target_state: "ON"
+    interaction_hint:
+      zh: "PITOT HEAT：右键拨到 ON。"
+      en: "PITOT HEAT: right-click the switch to ON."
   parking_brake_handle:
     description: "Emergency/parking brake handle"
     dcs_id: "pnt_240"

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -931,6 +931,13 @@ def test_plan_harness_action_owns_known_control_interaction_guidance() -> None:
             "s10_left_engine_left_click_guidance",
         ),
         (
+            "S13",
+            "radar_mode_knob",
+            {"radar_mode_opr": False},
+            ("radar", "OPR", "right-click"),
+            "s13_radar_opr_right_click_guidance",
+        ),
+        (
             "S31",
             "radar_altimeter_bug_knob",
             {"radar_altimeter_bug_set": False},

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -10487,6 +10487,64 @@ def test_completion_conflict_does_not_clear_s20_overlay_when_text_says_s19_compl
         loop.close()
 
 
+def test_completion_conflict_s13_radar_uses_opr_guidance(tmp_path: Path) -> None:
+    replay_path = tmp_path / "bios_s13_radar_completion_conflict.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0, apu_switch=0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path),
+        model=FailingModel(),
+        action_executor=RecordingExecutor(),
+        cooldown_s=0,
+        lang="zh",
+    )
+    try:
+        request = TutorRequest(
+            actor="learner",
+            intent="help",
+            message="help",
+            context={
+                "deterministic_step_hint": {
+                    "inferred_step_id": "S13",
+                    "missing_conditions": ["vars.radar_mode_opr==true"],
+                }
+            },
+        )
+        response = TutorResponse(
+            status="ok",
+            message="S13 已完成，继续下一步。",
+            actions=[
+                {
+                    "type": "overlay",
+                    "intent": "highlight",
+                    "target": "radar_mode_knob",
+                    "element_id": "pnt_440",
+                }
+            ],
+            explanations=["S13 已完成，继续下一步。"],
+            metadata={
+                "help_response": {
+                    "diagnosis": {"step_id": "S13", "error_category": "OM"},
+                    "next": {"step_id": "S13"},
+                    "overlay": {"targets": ["radar_mode_knob"], "evidence": []},
+                    "explanations": ["S13 已完成，继续下一步。"],
+                },
+                "next": {"step_id": "S13"},
+                "diagnosis": {"step_id": "S13", "error_category": "OM"},
+            },
+        )
+
+        rewritten = loop._rewrite_conflicting_step_completion_response(response, request)
+    finally:
+        loop.close()
+
+    assert rewritten is True
+    assert response.metadata["completion_conflict_rewritten"] is True
+    assert "radar_mode_knob" not in response.message
+    assert "RADAR" in response.message
+    assert "OPR" in response.message
+    assert "右键" in response.message
+
+
 def test_live_loop_short_circuits_terminal_state_without_calling_model(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -11537,6 +11595,24 @@ def test_live_help_fixture_314_s10_left_engine_uses_left_click_guidance() -> Non
     assert "R 位置" not in public_text
     assert "右键" not in public_text
     assert "right-click" not in public_text
+
+
+def test_live_help_fixture_314_s13_radar_opr_uses_detent_guidance() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/e96b29b7-b305-4444-beb3-60ddb0804b4b.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S13"
+    assert repaired.metadata["next"]["step_id"] == "S13"
+    assert repaired.metadata["final_overlay_targets"] == ["radar_mode_knob"]
+    public_text = _public_response_text(repaired)
+    assert "radar_mode_knob" not in public_text
+    assert "RADAR" in public_text or "Radar" in public_text
+    assert "OPR" in public_text
+    assert "右键" in public_text or "right-click" in public_text
 
 
 def test_live_help_fixture_314_s31_radar_altimeter_uses_mouse_wheel_guidance() -> None:
@@ -12773,7 +12849,7 @@ def test_live_help_fixture_299_s17_keeps_takeoff_trim_overlay() -> None:
             "overlay_target_allowlist": ["takeoff_trim_button"],
         },
     )
-    raw_message = "当前处于 S17 步骤，请按下 TAKEOFF TRIM 按钮以完成该步骤。"
+    raw_message = "请先操作 takeoff_trim_button。"
     response = TutorResponse(
         status="ok",
         in_reply_to=request.request_id,
@@ -12807,7 +12883,9 @@ def test_live_help_fixture_299_s17_keeps_takeoff_trim_overlay() -> None:
 
     assert [action["target"] for action in repaired.actions] == ["takeoff_trim_button"]
     assert repaired.metadata.get("completion_conflict_rewritten") is not True
-    assert "takeoff_trim_button" in repaired.message
+    assert "takeoff_trim_button" not in repaired.message
+    assert "T/O TRIM" in repaired.message
+    assert "按下" in repaired.message
     assert repaired.explanations == [repaired.message]
     assert repaired.metadata["next"]["step_id"] == "S17"
     assert repaired.metadata["diagnosis"]["step_id"] == "S17"
@@ -12816,6 +12894,79 @@ def test_live_help_fixture_299_s17_keeps_takeoff_trim_overlay() -> None:
     assert repaired.metadata["final_public_response"]["message"] == repaired.message
     assert repaired.metadata["final_public_response"]["explanations"] == [repaired.message]
     assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "takeoff_trim_button"
+
+
+@pytest.mark.parametrize(
+    ("step_id", "target", "missing_condition", "expected_tokens"),
+    [
+        ("S07", "lights_test_button", "vars.lights_test_complete==true", ("LIGHTS TEST", "左键", "按住")),
+        ("S14", "obogs_control_switch", "vars.obogs_switch_on==true", ("OBOGS", "右键", "ON")),
+        ("S15", "fcs_reset_button", "vars.fcs_reset_complete==true", ("FCS RESET", "左键", "按下")),
+        ("S26", "pitot_heater_switch", "vars.pitot_heat_on==true", ("PITOT HEAT", "右键", "ON")),
+    ],
+)
+def test_live_help_rewrites_generic_target_id_action_text_for_known_controls(
+    step_id: str,
+    target: str,
+    missing_condition: str,
+    expected_tokens: tuple[str, ...],
+) -> None:
+    request = TutorRequest(
+        request_id=f"generic-{step_id}-{target}",
+        message="help",
+        context={
+            "gates": {
+                f"{step_id}.completion": {
+                    "status": "blocked",
+                    "reason_code": f"{step_id.lower()}_requires_{target}",
+                }
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": step_id,
+                "overlay_step_id": step_id,
+                "missing_conditions": [missing_condition],
+                "step_ui_targets": [target],
+                "action_hint": {"target": target},
+            },
+            "overlay_target_allowlist": [target],
+        },
+    )
+    raw_message = f"请先操作 {target}。"
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message=raw_message,
+        actions=[],
+        explanations=[raw_message],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": step_id, "error_category": "OM"},
+                "next": {"step_id": step_id},
+                "overlay": {
+                    "targets": [target],
+                    "evidence": [
+                        {
+                            "target": target,
+                            "type": "gate",
+                            "ref": f"GATES.{step_id}.completion",
+                            "quote": "Step completion is blocked.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": [raw_message],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+    public_text = _public_response_text(repaired)
+
+    assert [action["target"] for action in repaired.actions] == [target]
+    assert target not in public_text
+    assert all(token in public_text for token in expected_tokens)
 
 
 def test_completion_claim_parser_distinguishes_guidance_from_completion_claim() -> None:


### PR DESCRIPTION
## Summary
- add S13 radar OPR action planning and fixture coverage for latest issue #314 live smoke
- make repair/fallback public text use user-facing interaction guidance instead of generic target ids
- add interaction hints for representative controls such as T/O TRIM, OBOGS, FCS RESET, PITOT HEAT, and LIGHTS TEST

## Tests
- python -m pytest -q tests/test_live_dcs.py::test_live_help_fixture_299_s17_keeps_takeoff_trim_overlay tests/test_live_dcs.py::test_live_help_rewrites_generic_target_id_action_text_for_known_controls tests/test_live_dcs.py::test_completion_conflict_s13_radar_uses_opr_guidance tests/test_live_dcs.py::test_live_help_fixture_314_s13_radar_opr_uses_detent_guidance tests/test_harness_validation.py::test_plan_harness_action_owns_known_control_interaction_guidance
- python -m pytest -q tests/test_live_dcs.py -k '314_s13_radar_opr or completion_conflict_s13 or generic_target_id_action_text or takeoff_trim_overlay or final_public_guidance or final_evidence_consistency or s13'
- python -m pytest -q tests/test_harness_validation.py tests/test_pack_ui_targets_valid.py tests/test_step_harness_specs.py -k 'known_control_interaction or s13 or interaction or ui_targets'
- python -m pytest -q tests/test_pack_ui_targets_valid.py tests/test_step_harness_specs.py
- python -m pytest -q tests/test_harness_validation.py
- git diff --check

Related to #314