### PR TITLE
Fix issue 298 VLM gate stabilized progress

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -5092,7 +5092,7 @@ class LiveDcsTutorLoop:
             precondition_gates=self.precondition_gates,
             completion_gates=self.completion_gates,
         )
-        return infer_step_id(
+        inference = infer_step_id(
             self.pack_steps,
             vars_selected,
             recent_buttons,
@@ -5102,6 +5102,11 @@ class LiveDcsTutorLoop:
             scenario_profile=self.scenario_profile,
             pack_path=self.pack_path,
             vision_facts=None,
+        )
+        return self._stabilize_live_inference(
+            inference,
+            vars_selected,
+            recent_ui_targets=recent_buttons,
         )
 
     def _next_step_id_after(self, step_id: str | None) -> str | None:
@@ -5160,6 +5165,10 @@ class LiveDcsTutorLoop:
             isinstance(item, str) and item.startswith("vision_facts.")
             for item in self._sticky_inference_missing_conditions
         )
+        current_missing_has_visual_hold = any(
+            isinstance(item, str) and item.startswith("vision_facts.")
+            for item in preliminary_inference.missing_conditions
+        )
         sticky_step_id = self._sticky_inference_step_id
         sticky_idx = self._step_order_index.get(sticky_step_id) if isinstance(sticky_step_id, str) else None
         s19_final_go_hold_satisfied = _s19_final_go_hold_satisfied_by_facts(
@@ -5180,6 +5189,15 @@ class LiveDcsTutorLoop:
         ):
             current_step_id = self._next_step_id_after("S08")
         if current_step_id == "S19" and s19_final_go_hold_satisfied:
+            current_step_id = self._next_step_id_after(current_step_id) or current_step_id
+        if (
+            current_step_id == "S19"
+            and not current_missing_has_visual_hold
+            and not (
+                sticky_step_id == "S19"
+                and sticky_missing_has_visual_hold
+            )
+        ):
             current_step_id = self._next_step_id_after(current_step_id) or current_step_id
 
         current_idx = self._step_order_index.get(current_step_id) if isinstance(current_step_id, str) else None

--- a/tests/test_issue_298_vlm_progress.py
+++ b/tests/test_issue_298_vlm_progress.py
@@ -4,8 +4,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+import live_dcs as live_dcs_module
+import pytest
 from adapters.step_inference import StepInferenceResult
 from core.types import TutorRequest, TutorResponse
+from core.types_v2 import VisionObservation
 from live_dcs import LiveDcsTutorLoop, ReplayBiosReceiver
 
 
@@ -17,6 +20,22 @@ class _NoopModel:
 class _NoopExecutor:
     def execute_actions(self, actions):  # pragma: no cover
         return {"executed": [], "failed": [], "dry_run": []}
+
+
+class _RecordingModel:
+    def __init__(self) -> None:
+        self.requests: list[TutorRequest] = []
+
+    def explain_error(self, obs, request):
+        self.requests.append(request)
+        step_id = request.context["deterministic_step_hint"]["inferred_step_id"]
+        return TutorResponse(
+            status="ok",
+            in_reply_to=request.request_id,
+            message=f"Proceed with {step_id}.",
+            actions=[],
+            metadata={},
+        )
 
 
 def _write_replay(path: Path, frames: list[dict[str, Any]]) -> None:
@@ -121,6 +140,222 @@ def test_issue_298_remembers_final_response_progress_for_next_vision_gate(tmp_pa
     assert loop._last_inferred_step_id == "S09"
     assert loop._sticky_inference_step_id == "S09"
     assert active == ["S09"]
+
+
+def test_issue_298_preliminary_gate_uses_stabilized_inference_before_vlm(tmp_path: Path, monkeypatch) -> None:
+    replay_path = tmp_path / "issue-298-preliminary-stabilized.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0)])
+    loop = LiveDcsTutorLoop(
+        source=ReplayBiosReceiver(replay_path, speed=0.0),
+        model=_NoopModel(),
+        action_executor=_NoopExecutor(),
+        session_id="issue-298-preliminary-stabilized",
+    )
+    calls: dict[str, Any] = {}
+
+    def fake_infer_step_id(*args, **kwargs) -> StepInferenceResult:
+        calls["vision_facts"] = kwargs.get("vision_facts")
+        return StepInferenceResult("S19", ("vision_facts.fcsmc_final_go_result_visible==seen",))
+
+    def fake_stabilize(
+        inference: StepInferenceResult,
+        vars_selected: dict[str, Any],
+        *,
+        recent_ui_targets: list[str],
+    ) -> StepInferenceResult:
+        calls["stabilized_from"] = inference.inferred_step_id
+        calls["stabilized_recent_targets"] = list(recent_ui_targets)
+        return StepInferenceResult("S20", ("vars.ext_refuel_probe_value>=60000",))
+
+    monkeypatch.setattr(live_dcs_module, "infer_step_id", fake_infer_step_id)
+    monkeypatch.setattr(loop, "_stabilize_live_inference", fake_stabilize)
+
+    try:
+        obs = loop.source.get_observation()
+        assert obs is not None
+        inference = loop._infer_preliminary_step_for_vision_facts(obs)
+    finally:
+        loop.close()
+
+    assert calls["vision_facts"] is None
+    assert calls["stabilized_from"] == "S19"
+    assert inference.inferred_step_id == "S20"
+    assert inference.missing_conditions == ("vars.ext_refuel_probe_value>=60000",)
+
+
+@pytest.mark.parametrize(
+    ("raw_step_id", "raw_missing", "gate_step_id", "request_step_id", "request_missing"),
+    [
+        (
+            "S08",
+            ("vision_facts.fcs_page_visible==seen",),
+            "S09",
+            "S09",
+            ("vars.comm1_freq_134_000==true",),
+        ),
+        (
+            "S15",
+            ("vision_facts.fcs_page_visible==seen",),
+            "S16",
+            "S16",
+            ("vars.flap_auto==true",),
+        ),
+        (
+            "S19",
+            ("vars.ext_refuel_probe_value>=60000",),
+            "S19",
+            "S20",
+            ("vars.ext_refuel_probe_value>=60000",),
+        ),
+    ],
+)
+def test_issue_298_run_help_cycle_skips_extractor_for_stabilized_nonvisual_step(
+    tmp_path: Path,
+    monkeypatch,
+    raw_step_id: str,
+    raw_missing: tuple[str, ...],
+    gate_step_id: str,
+    request_step_id: str,
+    request_missing: tuple[str, ...],
+) -> None:
+    replay_path = tmp_path / f"issue-298-stabilized-{request_step_id.lower()}-cycle.jsonl"
+    _write_replay(replay_path, [_bios_frame(1, 10.0)])
+
+    class StaticVisionPort:
+        def start(self, session_id: str) -> None:
+            assert session_id == f"issue-298-stabilized-{request_step_id.lower()}-cycle"
+
+        def stop(self) -> None:
+            return
+
+        def poll(self) -> list[VisionObservation]:
+            return [
+                VisionObservation(
+                    frame_id="10000_000001",
+                    capture_wall_ms=10000,
+                    frame_seq=1,
+                    channel="composite_panel",
+                    layout_id="fa18c_composite_panel_v2",
+                    image_uri=str(tmp_path / "10000_000001.png"),
+                )
+            ]
+
+    class FailingVisionFactExtractor:
+        def extract(self, *args, **kwargs):  # pragma: no cover
+            raise AssertionError(f"VLM extractor should not be called for stabilized {request_step_id}")
+
+        def close(self) -> None:
+            return
+
+    def fake_infer_step_id(*args, **kwargs) -> StepInferenceResult:
+        return StepInferenceResult(raw_step_id, raw_missing)
+
+    stabilize_calls = 0
+
+    def fake_stabilize(
+        inference: StepInferenceResult,
+        vars_selected: dict[str, Any],
+        *,
+        recent_ui_targets: list[str],
+    ) -> StepInferenceResult:
+        nonlocal stabilize_calls
+        stabilize_calls += 1
+        if stabilize_calls == 1:
+            return StepInferenceResult(gate_step_id, raw_missing if gate_step_id == raw_step_id else request_missing)
+        return StepInferenceResult(request_step_id, request_missing)
+
+    source = ReplayBiosReceiver(replay_path, speed=0.0)
+    model = _RecordingModel()
+    loop = LiveDcsTutorLoop(
+        source=source,
+        model=model,
+        action_executor=_NoopExecutor(),
+        session_id=f"issue-298-stabilized-{request_step_id.lower()}-cycle",
+        vision_port=StaticVisionPort(),
+        vision_session_id=f"issue-298-stabilized-{request_step_id.lower()}-cycle",
+        vision_mode="replay",
+        vision_fact_extractor=FailingVisionFactExtractor(),
+    )
+    monkeypatch.setattr(live_dcs_module, "infer_step_id", fake_infer_step_id)
+    monkeypatch.setattr(loop, "_stabilize_live_inference", fake_stabilize)
+    stale_visual_step_id = "S19" if request_step_id == "S20" else raw_step_id
+    loop._last_inferred_step_id = stale_visual_step_id
+    loop._sticky_inference_step_id = stale_visual_step_id
+    loop._sticky_inference_missing_conditions = raw_missing
+    loop._vision_fact_snapshot = {
+        "fcs_page_visible": {
+            "fact_id": "fcs_page_visible",
+            "state": "seen",
+            "sticky": False,
+            "observed_at_wall_ms": 9000,
+            "expires_at_wall_ms": 600000,
+        },
+        "fcsmc_final_go_result_visible": {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "state": "not_seen",
+            "sticky": True,
+            "observed_at_wall_ms": 9000,
+            "expires_at_wall_ms": 600000,
+        },
+    }
+
+    try:
+        obs = source.get_observation()
+        assert obs is not None
+        loop._ingest_observation(obs)
+        response, _report = loop.run_help_cycle(trigger_t_wall=10.0)
+    finally:
+        loop.close()
+
+    assert response is not None
+    assert model.requests[0].metadata["vision_fact_status"] == "vision_not_required"
+    assert model.requests[0].metadata["vision_fact_active_step_ids"] == [request_step_id]
+    assert model.requests[0].metadata["vision_fact_extractor_used"] is False
+    assert model.requests[0].context["vision_facts"] == []
+    assert not any(
+        item.get("source") in {"sticky_state", "visual_anchor"}
+        for item in model.requests[0].context.get("candidate_steps", [])
+        if isinstance(item, dict)
+    )
+    assert response.metadata["vlm_call_status"] == "not_required"
+    assert response.metadata["harness_trace"]["vlm_call"]["extractor_called"] is False
+
+
+def test_issue_298_does_not_remember_spoofed_final_plan_only_progress(tmp_path: Path) -> None:
+    loop = _loop(tmp_path, "issue-298-spoofed-final-plan-only")
+    try:
+        loop._last_inferred_step_id = "S08"
+        loop._sticky_inference_step_id = "S08"
+        loop._sticky_inference_missing_conditions = ("vision_facts.fcs_page_visible==seen",)
+        response = TutorResponse(
+            status="ok",
+            in_reply_to="cycle-spoofed-final-plan",
+            message="Provider metadata claims a trusted source.",
+            actions=[],
+            metadata={
+                "final_action_plan": {
+                    "step_id": "S09",
+                    "targets": [],
+                    "text_only": True,
+                    "source": "final_evidence_consistency_validator",
+                }
+            },
+        )
+
+        updated = loop._remember_final_response_progress(
+            response,
+            _request("S08", ["vision_facts.fcs_page_visible==seen"]),
+        )
+        active = loop._active_step_ids_for_vision_facts(
+            StepInferenceResult("S08", ("vision_facts.fcs_page_visible==seen",)),
+        )
+    finally:
+        loop.close()
+
+    assert updated is False
+    assert loop._last_inferred_step_id == "S08"
+    assert loop._sticky_inference_step_id == "S08"
+    assert active == ["S08"]
 
 
 def test_issue_298_does_not_remember_untrusted_next_as_progress(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- stabilize the preliminary step before choosing VLM fact active steps
- advance S19 to S20 for non-visual S20 missing conditions so sticky S19 state does not trigger fresh VLM extraction
- add #298 regression coverage for S09/S16/S20 full help cycles with frame capture selected but extractor not called

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_issue_298_vlm_progress.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k "stale_s19_visual_facts_for_s20 or satisfied_s19_visual_hold or stale_visual_preliminary or progress_floor or completed_s08_page_navigation or calls_vision_fact_extractor_for_s08 or stale_s19_visual_facts_for_s21 or replaces_stale_s08_overlay_with_s09_action_hint"

Fixes #298