### PR TITLE
Add issue 312 latest coverage addendum

### DIFF
--- a/artifacts/live_fixtures/614024be-1420-4188-91e9-f044acff9291.fixture.json
+++ b/artifacts/live_fixtures/614024be-1420-4188-91e9-f044acff9291.fixture.json
@@ -1,0 +1,3275 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 8,
+      "telemetry_missing_source_count": 28,
+      "telemetry_status": "low_confidence_bootstrap",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 1,
+        "frame_count": 1,
+        "latest_seq": 1
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+      "source_observation_seq": 1,
+      "source_observation_t_wall": 1779209004.800106,
+      "telemetry_window_first_seq": 1,
+      "telemetry_window_frame_count": 1,
+      "telemetry_window_latest_seq": 1,
+      "telemetry_window_latest_t_wall": 1779209004.800106,
+      "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+    },
+    "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 502,
+          "delta_dropped_count": 13,
+          "from_addr": "192.168.0.105:56452",
+          "raw_delta_count": 502,
+          "seq": 1
+        },
+        "observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "LEFT_DDI_BRT_CTL",
+              "LEFT_DDI_CONT_CTL",
+              "LEFT_DDI_PB_14",
+              "LEFT_DDI_PB_15",
+              "LEFT_DDI_PB_16",
+              "LEFT_DDI_PB_17",
+              "LEFT_DDI_PB_18",
+              "LEFT_DDI_PB_19"
+            ],
+            "delta_count": 489,
+            "dropped_stats": {
+              "dropped_by_reason": {
+                "blacklist": 13
+              },
+              "dropped_total": 13
+            },
+            "raw_delta_count": 502,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 111,
+                "key": "FIRE_TEST_SW",
+                "ui_targets": [
+                  "fire_test_switch"
+                ],
+                "value": 1
+              },
+              {
+                "count": 1,
+                "importance": 111,
+                "key": "APU_CONTROL_SW",
+                "ui_targets": [
+                  "apu_switch"
+                ],
+                "value": 0
+              },
+              {
+                "count": 1,
+                "importance": 111,
+                "key": "ENGINE_CRANK_SW",
+                "ui_targets": [
+                  "eng_crank_switch"
+                ],
+                "value": 1
+              },
+              {
+                "count": 1,
+                "importance": 111,
+                "key": "BATTERY_SW",
+                "ui_targets": [
+                  "battery_switch"
+                ],
+                "value": 1
+              },
+              {
+                "count": 1,
+                "importance": 111,
+                "key": "L_GEN_SW",
+                "ui_targets": [
+                  "generator_left_switch"
+                ],
+                "value": 1
+              },
+              {
+                "count": 1,
+                "importance": 111,
+                "key": "R_GEN_SW",
+                "ui_targets": [
+                  "generator_right_switch"
+                ],
+                "value": 1
+              },
+              {
+                "count": 1,
+                "importance": 111,
+                "key": "BLEED_AIR_KNOB",
+                "ui_targets": [
+                  "bleed_air_knob"
+                ],
+                "value": 2
+              },
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "IFEI_FF_L",
+                "ui_targets": [],
+                "value": "   "
+              },
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "IFEI_FF_R",
+                "ui_targets": [],
+                "value": "   "
+              },
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "IFEI_OIL_PRESS_L",
+                "ui_targets": [],
+                "value": "   "
+              },
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "IFEI_OIL_PRESS_R",
+                "ui_targets": [],
+                "value": "   "
+              },
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "IFEI_RPM_L",
+                "ui_targets": [],
+                "value": "   "
+              }
+            ],
+            "truncated": true
+          },
+          "recent_ui_targets": [
+            "left_mdi_brightness_control",
+            "left_mdi_contrast_control",
+            "left_mdi_pb15",
+            "left_mdi_pb18",
+            "ufc_comm1_channel_selector_pull",
+            "ufc_comm2_channel_selector_pull",
+            "ufc_key_0",
+            "ufc_key_1"
+          ],
+          "seq": 1,
+          "t_wall": 1779209004.800106,
+          "vars": {
+            "annunciator_panel_activity": false,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": false,
+            "attitude_source_auto": true,
+            "battery_on": false,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": false,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 0,
+            "comm1_freq_134_000": false,
+            "comm1_freq_value": 30500,
+            "comm2_channel_numeric": 0,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": false,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": false,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": null,
+            "ff_r": null,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": false,
+            "hook_handle_value": 1,
+            "hook_retracted": true,
+            "hud_on": false,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": false,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": false,
+            "mpcd_on": false,
+            "noz_l": 0.0,
+            "noz_r": 0.0,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": null,
+            "oil_r": null,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": false,
+            "right_engine_nominal_start_params": false,
+            "rpm_l": null,
+            "rpm_l_gte_25": false,
+            "rpm_l_gte_60": false,
+            "rpm_r": null,
+            "rpm_r_gte_25": false,
+            "rpm_r_gte_60": false,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": null,
+            "temp_r": null,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "bingo_fuel_set",
+              "ff_l",
+              "ff_l_in_range",
+              "ff_r",
+              "ff_r_in_range",
+              "ins_fast_align_pressed",
+              "left_engine_idle_ready",
+              "left_engine_nominal_start_params",
+              "oil_l",
+              "oil_l_in_range",
+              "oil_r",
+              "oil_r_in_range",
+              "rpm_l",
+              "rpm_l_gte_25",
+              "rpm_l_gte_60",
+              "rpm_l_in_range",
+              "rpm_r",
+              "rpm_r_gte_25",
+              "rpm_r_gte_60",
+              "rpm_r_in_range",
+              "temp_l",
+              "temp_l_in_range",
+              "temp_r",
+              "temp_r_in_range",
+              "throttle_r_idle_complete",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T16:43:24.800105+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 1,
+      "frame_count": 1,
+      "latest_seq": 1
+    },
+    "vision": {
+      "frame_ids": [
+        "1779209004872_000276"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779209004872_000276",
+        "frame_ids": [
+          "1779209004872_000276"
+        ],
+        "frame_stale": false,
+        "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+        "observation_seq": 1,
+        "observation_t_wall_ms": 1779209004800,
+        "observation_t_wall_s": 1779209004.800106,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779209004872,
+            "channel": "composite_panel",
+            "frame_id": "1779209004872_000276",
+            "frame_seq": 276,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209004872_000276_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209004872_000276.png",
+            "sync_delta_ms": 86,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 86,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779209004872,
+          "channel": "composite_panel",
+          "frame_id": "1779209004872_000276",
+          "frame_seq": 276,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209004872_000276_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209004872_000276.png",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779209004786,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779209004872_000276"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+        "kind": "tutor_request",
+        "lineno": 523,
+        "metadata": {
+          "frame_id": "1779209004872_000276",
+          "fused_missing_conditions": [
+            "vars.battery_on==true"
+          ],
+          "fused_step_id": "S01",
+          "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 0,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 0,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209004872_000276"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 13,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S01",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S01",
+              "recent_ui_targets": [
+                "left_mdi_brightness_control",
+                "left_mdi_contrast_control",
+                "left_mdi_pb15",
+                "left_mdi_pb18",
+                "ufc_comm1_channel_selector_pull",
+                "ufc_comm2_channel_selector_pull",
+                "ufc_key_0",
+                "ufc_key_1"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "battery_switch",
+                "generator_left_switch",
+                "generator_right_switch"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 8,
+              "telemetry_missing_source_count": 28,
+              "telemetry_status": "low_confidence_bootstrap",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 1,
+                "frame_count": 1,
+                "latest_seq": 1
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+              "source_observation_seq": 1,
+              "source_observation_t_wall": 1779209004.800106,
+              "telemetry_window_first_seq": 1,
+              "telemetry_window_frame_count": 1,
+              "telemetry_window_latest_seq": 1,
+              "telemetry_window_latest_t_wall": 1779209004.800106,
+              "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_153",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 154,
+                "score": 48.65353017746378,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_153"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_38",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 39,
+                "score": 42.218890149785025,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_38"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 39.47359427534396,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_49",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 50,
+                "score": 37.23990347014751,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_49"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_142",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 143,
+                "score": 35.682364601561275,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_142"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.battery_on==true"
+                ],
+                "overlay_step_id": "S01",
+                "role": "candidate_not_authoritative",
+                "step_id": "S01"
+              },
+              "telemetry_evidence": {
+                "confidence": "low",
+                "early_vars": {
+                  "battery_on": false,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 1,
+                "source_status": "low_confidence_bootstrap",
+                "vars_source_missing_count": 28
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 1,
+                "frame_count": 1,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 1,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 1,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 1,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 1,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 1,
+                "latest_t_wall": 1779209004.800106,
+                "stable_false_vars": [
+                  "battery_on",
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "pitot_heat_on",
+                  "right_ddi_on"
+                ],
+                "stable_true_vars": [
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "power_available"
+                ],
+                "unknown_or_missing_vars": [
+                  "bingo_fuel_set",
+                  "ff_l",
+                  "ff_l_in_range",
+                  "ff_r",
+                  "ff_r_in_range",
+                  "ins_fast_align_pressed",
+                  "left_engine_idle_ready",
+                  "left_engine_nominal_start_params",
+                  "oil_l",
+                  "oil_l_in_range",
+                  "oil_r",
+                  "oil_r_in_range",
+                  "rpm_l",
+                  "rpm_l_gte_25",
+                  "rpm_l_gte_60",
+                  "rpm_l_in_range"
+                ],
+                "window_duration_s": null
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779209004872_000276",
+              "frame_ids": [
+                "1779209004872_000276"
+              ],
+              "frame_stale": false,
+              "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+              "observation_seq": 1,
+              "observation_t_wall_ms": 1779209004800,
+              "observation_t_wall_s": 1779209004.800106,
+              "status": "partial",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779209004786,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779209004872_000276"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 8,
+              "telemetry_missing_source_count": 28,
+              "telemetry_status": "low_confidence_bootstrap",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 1,
+                "frame_count": 1,
+                "latest_seq": 1
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+              "source_observation_seq": 1,
+              "source_observation_t_wall": 1779209004.800106,
+              "telemetry_window_first_seq": 1,
+              "telemetry_window_frame_count": 1,
+              "telemetry_window_latest_seq": 1,
+              "telemetry_window_latest_t_wall": 1779209004.800106,
+              "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "frame_id": "1779209004872_000276",
+            "fused_missing_conditions": [
+              "vars.battery_on==true"
+            ],
+            "fused_step_id": "S01",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "DCS FA-18C Early Access Guide EN_153",
+              "DCS FA-18C Early Access Guide EN_38",
+              "fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN_49",
+              "DCS FA-18C Early Access Guide EN_142"
+            ],
+            "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+            "prompt_tokens_est": 5536,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "source_chunk_refs": [
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_153",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_38",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_49",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_142"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "low_confidence_bootstrap",
+            "sync_delta_ms": 86,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779209004872_000276"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779209004872_000276"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+          "request_id": "614024be-1420-4188-91e9-f044acff9291",
+          "timestamp": "2026-05-19T16:43:25.119026+00:00",
+          "version": "v1"
+        },
+        "related_id": "614024be-1420-4188-91e9-f044acff9291",
+        "vision_refs": [
+          "1779209004872_000276"
+        ]
+      },
+      {
+        "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+        "kind": "overlay_requested",
+        "lineno": 524,
+        "metadata": {
+          "final_overlay_targets": [
+            "battery_switch"
+          ],
+          "frame_id": "1779209004872_000276",
+          "fused_missing_conditions": [
+            "vars.battery_on==true"
+          ],
+          "fused_step_id": "S01",
+          "generation_mode": "model",
+          "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "fallback_overlay",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 0,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 0,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209004872_000276"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "458973ca-b2ae-4a6a-b122-6393bb780058",
+          "final_overlay_targets": [
+            "battery_switch"
+          ],
+          "frame_id": "1779209004872_000276",
+          "fused_missing_conditions": [
+            "vars.battery_on==true"
+          ],
+          "fused_step_id": "S01",
+          "generation_mode": "model",
+          "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "fallback_overlay",
+          "schema_version": "v2",
+          "sync_delta_ms": 86,
+          "target": "pnt_404",
+          "vision_fact_cached_count": 0,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 0,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209004872_000276"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+        "kind": "tutor_response",
+        "lineno": 525,
+        "metadata": {
+          "final_overlay_targets": [
+            "battery_switch"
+          ],
+          "frame_id": "1779209004872_000276",
+          "fused_missing_conditions": [
+            "vars.battery_on==true"
+          ],
+          "fused_step_id": "S01",
+          "generation_mode": "model",
+          "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "fallback_overlay",
+          "sync_delta_ms": 86,
+          "vision_fact_cached_count": 0,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 0,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209004872_000276"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_404",
+              "evidence_refs": [
+                "GATES.S01.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "battery_switch"
+              ],
+              "frame_id": "1779209004872_000276",
+              "fused_missing_conditions": [
+                "vars.battery_on==true"
+              ],
+              "fused_step_id": "S01",
+              "generation_mode": "model",
+              "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "fallback_overlay",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 86,
+              "target": "battery_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 0,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 0,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779209004872_000276"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "请先操作 battery_switch。"
+          ],
+          "in_reply_to": "614024be-1420-4188-91e9-f044acff9291",
+          "message": "请先操作 battery_switch。",
+          "metadata": {
+            "allowed_evidence_ref_count": 153,
+            "bootstrap_low_confidence_guardrail_applied": true,
+            "bootstrap_low_confidence_guardrail_step_id": "S01",
+            "bootstrap_low_confidence_original_actions": [
+              {
+                "element_id": "pnt_404",
+                "evidence_refs": [
+                  "GATES.S01.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "battery_switch",
+                "type": "overlay"
+              }
+            ],
+            "bootstrap_low_confidence_original_explanations": [
+              "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+            ],
+            "bootstrap_low_confidence_original_message": "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。",
+            "bootstrap_low_confidence_vars_source_missing_count": 28,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "8293aea1-8131-4b7b-ae05-5530e4129c29",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "请先操作 battery_switch。"
+            },
+            "delta_dropped_count": 13,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S01",
+              "missing_conditions": [
+                "vars.battery_on==true"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "left_mdi_brightness_control",
+                "left_mdi_contrast_control",
+                "left_mdi_pb15",
+                "left_mdi_pb18",
+                "ufc_comm1_channel_selector_pull",
+                "ufc_comm2_channel_selector_pull",
+                "ufc_key_0",
+                "ufc_key_1"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "battery_switch",
+                "generator_left_switch",
+                "generator_right_switch"
+              ],
+              "superseded_by_snapshot": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S01"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+              "source_observation_seq": 1,
+              "source_observation_t_wall": 1779209004.800106,
+              "telemetry_window_first_seq": 1,
+              "telemetry_window_frame_count": 1,
+              "telemetry_window_latest_seq": 1,
+              "telemetry_window_latest_t_wall": 1779209004.800106,
+              "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "fallback_overlay_reason": "model",
+            "fallback_overlay_used": true,
+            "final_action_plan": {
+              "evidence_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "overlay_step_id": "S01",
+              "source": "model",
+              "step_id": "S01",
+              "targets": [
+                "battery_switch"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "model",
+            "final_overlay_targets": [
+              "battery_switch"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_404",
+                  "evidence_refs": [
+                    "GATES.S01.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "battery_switch"
+                  ],
+                  "frame_id": "1779209004872_000276",
+                  "fused_missing_conditions": [
+                    "vars.battery_on==true"
+                  ],
+                  "fused_step_id": "S01",
+                  "generation_mode": "model",
+                  "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "fallback_overlay",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 86,
+                  "target": "battery_switch",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 0,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 0,
+                  "vision_fact_sticky_count": 0,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779209004872_000276"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S01"
+              },
+              "explanations": [
+                "请先操作 battery_switch。"
+              ],
+              "message": "请先操作 battery_switch。",
+              "next": {
+                "step_id": "S01"
+              }
+            },
+            "frame_id": "1779209004872_000276",
+            "fused_missing_conditions": [
+              "vars.battery_on==true"
+            ],
+            "fused_step_id": "S01",
+            "generation_mode": "model",
+            "generation_prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+            "generation_prompt_tokens_est": 5536,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S01",
+              "source": "model",
+              "step_id": "S01",
+              "targets": [
+                "battery_switch"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "battery_switch",
+                    "generator_left_switch",
+                    "generator_right_switch"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S01",
+                  "supporting_evidence_refs": [
+                    "GATES.S01.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "battery_switch",
+                    "generator_left_switch",
+                    "generator_right_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S01",
+                  "supporting_evidence_refs": [
+                    "GATES.S01.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "apu_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S03",
+                  "supporting_evidence_refs": [
+                    "GATES.S03.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S04",
+                  "supporting_evidence_refs": [
+                    "GATES.S04.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S05",
+                  "supporting_evidence_refs": [
+                    "GATES.S05.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "bleed_air_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S06",
+                  "supporting_evidence_refs": [
+                    "GATES.S06.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.5,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_pb15",
+                    "left_mdi_pb18"
+                  ],
+                  "role": "candidate",
+                  "source": "recent_action",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": [
+                    "RECENT_ACTIONS.left_mdi_pb15",
+                    "RECENT_ACTIONS.left_mdi_pb18"
+                  ]
+                },
+                {
+                  "confidence": 0.5,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_0",
+                    "ufc_key_1"
+                  ],
+                  "role": "candidate",
+                  "source": "recent_action",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+                    "RECENT_ACTIONS.ufc_key_0",
+                    "RECENT_ACTIONS.ufc_key_1"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "battery_switch",
+                  "generator_left_switch",
+                  "generator_right_switch"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S01",
+                "supporting_evidence_refs": [
+                  "GATES.S01.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 8,
+                "telemetry_missing_source_count": 28,
+                "telemetry_status": "low_confidence_bootstrap",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 1,
+                  "frame_count": 1,
+                  "latest_seq": 1
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+                "source_observation_seq": 1,
+                "source_observation_t_wall": 1779209004.800106,
+                "telemetry_window_first_seq": 1,
+                "telemetry_window_frame_count": 1,
+                "telemetry_window_latest_seq": 1,
+                "telemetry_window_latest_t_wall": 1779209004.800106,
+                "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "overlay_step_id": "S01",
+                "source": "model",
+                "step_id": "S01",
+                "targets": [
+                  "battery_switch"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "battery_switch"
+              ],
+              "message_category": "fallback_overlay",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S01.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "battery_switch"
+                ],
+                "status": "ok",
+                "step_id": "S01"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "model"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+                "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "model",
+                "fallback_overlay_used": true,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 0,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779209004872_000276"
+                ],
+                "ignored_fact_count": 0,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 0,
+                "sync_delta_ms": 86,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [],
+            "harness_validator_fallback_reason": "deterministic_step:S01",
+            "harness_validator_mapping": {
+              "allowed_evidence_ref_count": 153,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S01"
+              },
+              "next": {
+                "step_id": "S01"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S01"
+              },
+              "explanations": [
+                "请先操作 battery_switch。"
+              ],
+              "next": {
+                "step_id": "S01"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S01.completion",
+                    "target": "battery_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "battery_switch"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S01"
+              },
+              "explanations": [
+                "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+              ],
+              "next": {
+                "step_id": "S01"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S01.completion",
+                    "target": "battery_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "battery_switch"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 3978,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "fallback_overlay",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S01"
+            },
+            "model_raw_explanations": [
+              "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S01"
+              },
+              "explanations": [
+                "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+              ],
+              "next": {
+                "step_id": "S01"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S01.completion",
+                    "target": "battery_switch",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "battery_switch"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S01"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779209004872_000276"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779209004872_000276",
+            "next": {
+              "step_id": "S01"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 5474,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.battery_on",
+                "GATES.S01.completion",
+                "GATES.S01.precondition",
+                "GATES.S03.completion",
+                "GATES.S04.completion",
+                "GATES.S04.precondition",
+                "GATES.S05.completion",
+                "GATES.S05.precondition",
+                "GATES.S06.completion",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_153",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_38",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_49",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_142"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 18,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "battery_switch",
+              "prompt_chars": 22142,
+              "prompt_tokens_est": 5536,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "DCS FA-18C Early Access Guide EN_153",
+                "DCS FA-18C Early Access Guide EN_38",
+                "fa18c_startup_master_1",
+                "DCS FA-18C Early Access Guide EN_49",
+                "DCS FA-18C Early Access Guide EN_142"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "low_confidence_bootstrap",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+            "prompt_tokens_est": 5536,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+            "request_prompt_tokens_est": 5536,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 153,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S01"
+              },
+              "next": {
+                "step_id": "S01"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+              "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+            },
+            "state_key": "099ae84f26d22ee7bd95fccfdb0868baf0903b1bb5c49364bd0333a9db2cc0a3",
+            "sync_delta_ms": 86,
+            "validator_rejected": false,
+            "vision": {
+              "frame_id": "1779209004872_000276",
+              "frame_ids": [
+                "1779209004872_000276"
+              ],
+              "frame_stale": false,
+              "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+              "observation_seq": 1,
+              "observation_t_wall_ms": 1779209004800,
+              "observation_t_wall_s": 1779209004.800106,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779209004872,
+                  "channel": "composite_panel",
+                  "frame_id": "1779209004872_000276",
+                  "frame_seq": 276,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209004872_000276_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209004872_000276.png",
+                  "sync_delta_ms": 86,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779209004872,
+                "channel": "composite_panel",
+                "frame_id": "1779209004872_000276",
+                "frame_seq": 276,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209004872_000276_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209004872_000276.png",
+                "sync_delta_ms": 86,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779209004786,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S01"
+            ],
+            "vision_fact_cached_count": 0,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 0,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779209004872_000276"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779209004872_000276"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "98de9798-7b38-41e2-8618-bf9390cc1471",
+          "status": "ok",
+          "timestamp": "2026-05-19T16:43:29.098996+00:00",
+          "version": "v1"
+        },
+        "related_id": "614024be-1420-4188-91e9-f044acff9291",
+        "vision_refs": [
+          "1779209004872_000276"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 13,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S01",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S01",
+          "recent_ui_targets": [
+            "left_mdi_brightness_control",
+            "left_mdi_contrast_control",
+            "left_mdi_pb15",
+            "left_mdi_pb18",
+            "ufc_comm1_channel_selector_pull",
+            "ufc_comm2_channel_selector_pull",
+            "ufc_key_0",
+            "ufc_key_1"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "battery_switch",
+            "generator_left_switch",
+            "generator_right_switch"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 8,
+          "telemetry_missing_source_count": 28,
+          "telemetry_status": "low_confidence_bootstrap",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 1,
+            "frame_count": 1,
+            "latest_seq": 1
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+          "source_observation_seq": 1,
+          "source_observation_t_wall": 1779209004.800106,
+          "telemetry_window_first_seq": 1,
+          "telemetry_window_frame_count": 1,
+          "telemetry_window_latest_seq": 1,
+          "telemetry_window_latest_t_wall": 1779209004.800106,
+          "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_153",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 154,
+            "score": 48.65353017746378,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_153"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_38",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 39,
+            "score": 42.218890149785025,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_38"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 39.47359427534396,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_49",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 50,
+            "score": 37.23990347014751,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_49"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_142",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 143,
+            "score": 35.682364601561275,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_142"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.battery_on==true"
+            ],
+            "overlay_step_id": "S01",
+            "role": "candidate_not_authoritative",
+            "step_id": "S01"
+          },
+          "telemetry_evidence": {
+            "confidence": "low",
+            "early_vars": {
+              "battery_on": false,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 1,
+            "source_status": "low_confidence_bootstrap",
+            "vars_source_missing_count": 28
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 1,
+            "frame_count": 1,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 1,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 1,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 1,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 1,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 1,
+            "latest_t_wall": 1779209004.800106,
+            "stable_false_vars": [
+              "battery_on",
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "pitot_heat_on",
+              "right_ddi_on"
+            ],
+            "stable_true_vars": [
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "power_available"
+            ],
+            "unknown_or_missing_vars": [
+              "bingo_fuel_set",
+              "ff_l",
+              "ff_l_in_range",
+              "ff_r",
+              "ff_r_in_range",
+              "ins_fast_align_pressed",
+              "left_engine_idle_ready",
+              "left_engine_nominal_start_params",
+              "oil_l",
+              "oil_l_in_range",
+              "oil_r",
+              "oil_r_in_range",
+              "rpm_l",
+              "rpm_l_gte_25",
+              "rpm_l_gte_60",
+              "rpm_l_in_range"
+            ],
+            "window_duration_s": null
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779209004872_000276",
+          "frame_ids": [
+            "1779209004872_000276"
+          ],
+          "frame_stale": false,
+          "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+          "observation_seq": 1,
+          "observation_t_wall_ms": 1779209004800,
+          "observation_t_wall_s": 1779209004.800106,
+          "status": "partial",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779209004786,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779209004872_000276"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 8,
+          "telemetry_missing_source_count": 28,
+          "telemetry_status": "low_confidence_bootstrap",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 1,
+            "frame_count": 1,
+            "latest_seq": 1
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+          "source_observation_seq": 1,
+          "source_observation_t_wall": 1779209004.800106,
+          "telemetry_window_first_seq": 1,
+          "telemetry_window_frame_count": 1,
+          "telemetry_window_latest_seq": 1,
+          "telemetry_window_latest_t_wall": 1779209004.800106,
+          "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "frame_id": "1779209004872_000276",
+        "fused_missing_conditions": [
+          "vars.battery_on==true"
+        ],
+        "fused_step_id": "S01",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "DCS FA-18C Early Access Guide EN_153",
+          "DCS FA-18C Early Access Guide EN_38",
+          "fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN_49",
+          "DCS FA-18C Early Access Guide EN_142"
+        ],
+        "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+        "prompt_tokens_est": 5536,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "source_chunk_refs": [
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_153",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_38",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_49",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_142"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "low_confidence_bootstrap",
+        "sync_delta_ms": 86,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779209004872_000276"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779209004872_000276"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+      "request_id": "614024be-1420-4188-91e9-f044acff9291",
+      "timestamp": "2026-05-19T16:43:25.119026+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_404",
+          "evidence_refs": [
+            "GATES.S01.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "battery_switch"
+          ],
+          "frame_id": "1779209004872_000276",
+          "fused_missing_conditions": [
+            "vars.battery_on==true"
+          ],
+          "fused_step_id": "S01",
+          "generation_mode": "model",
+          "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "fallback_overlay",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 86,
+          "target": "battery_switch",
+          "type": "overlay",
+          "vision_fact_cached_count": 0,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 0,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779209004872_000276"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "请先操作 battery_switch。"
+      ],
+      "in_reply_to": "614024be-1420-4188-91e9-f044acff9291",
+      "message": "请先操作 battery_switch。",
+      "metadata": {
+        "allowed_evidence_ref_count": 153,
+        "bootstrap_low_confidence_guardrail_applied": true,
+        "bootstrap_low_confidence_guardrail_step_id": "S01",
+        "bootstrap_low_confidence_original_actions": [
+          {
+            "element_id": "pnt_404",
+            "evidence_refs": [
+              "GATES.S01.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "battery_switch",
+            "type": "overlay"
+          }
+        ],
+        "bootstrap_low_confidence_original_explanations": [
+          "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+        ],
+        "bootstrap_low_confidence_original_message": "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。",
+        "bootstrap_low_confidence_vars_source_missing_count": 28,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "8293aea1-8131-4b7b-ae05-5530e4129c29",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "请先操作 battery_switch。"
+        },
+        "delta_dropped_count": 13,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S01",
+          "missing_conditions": [
+            "vars.battery_on==true"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "left_mdi_brightness_control",
+            "left_mdi_contrast_control",
+            "left_mdi_pb15",
+            "left_mdi_pb18",
+            "ufc_comm1_channel_selector_pull",
+            "ufc_comm2_channel_selector_pull",
+            "ufc_key_0",
+            "ufc_key_1"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "battery_switch",
+            "generator_left_switch",
+            "generator_right_switch"
+          ],
+          "superseded_by_snapshot": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S01"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+          "source_observation_seq": 1,
+          "source_observation_t_wall": 1779209004.800106,
+          "telemetry_window_first_seq": 1,
+          "telemetry_window_frame_count": 1,
+          "telemetry_window_latest_seq": 1,
+          "telemetry_window_latest_t_wall": 1779209004.800106,
+          "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "fallback_overlay_reason": "model",
+        "fallback_overlay_used": true,
+        "final_action_plan": {
+          "evidence_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "overlay_step_id": "S01",
+          "source": "model",
+          "step_id": "S01",
+          "targets": [
+            "battery_switch"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "model",
+        "final_overlay_targets": [
+          "battery_switch"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_404",
+              "evidence_refs": [
+                "GATES.S01.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "battery_switch"
+              ],
+              "frame_id": "1779209004872_000276",
+              "fused_missing_conditions": [
+                "vars.battery_on==true"
+              ],
+              "fused_step_id": "S01",
+              "generation_mode": "model",
+              "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "fallback_overlay",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 86,
+              "target": "battery_switch",
+              "type": "overlay",
+              "vision_fact_cached_count": 0,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 0,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779209004872_000276"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S01"
+          },
+          "explanations": [
+            "请先操作 battery_switch。"
+          ],
+          "message": "请先操作 battery_switch。",
+          "next": {
+            "step_id": "S01"
+          }
+        },
+        "frame_id": "1779209004872_000276",
+        "fused_missing_conditions": [
+          "vars.battery_on==true"
+        ],
+        "fused_step_id": "S01",
+        "generation_mode": "model",
+        "generation_prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+        "generation_prompt_tokens_est": 5536,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S01",
+          "source": "model",
+          "step_id": "S01",
+          "targets": [
+            "battery_switch"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "battery_switch",
+                "generator_left_switch",
+                "generator_right_switch"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S01",
+              "supporting_evidence_refs": [
+                "GATES.S01.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "battery_switch",
+                "generator_left_switch",
+                "generator_right_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S01",
+              "supporting_evidence_refs": [
+                "GATES.S01.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "apu_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S03",
+              "supporting_evidence_refs": [
+                "GATES.S03.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S04",
+              "supporting_evidence_refs": [
+                "GATES.S04.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S05",
+              "supporting_evidence_refs": [
+                "GATES.S05.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "bleed_air_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S06",
+              "supporting_evidence_refs": [
+                "GATES.S06.completion"
+              ]
+            },
+            {
+              "confidence": 0.5,
+              "proposed_next_action_target_ids": [
+                "left_mdi_pb15",
+                "left_mdi_pb18"
+              ],
+              "role": "candidate",
+              "source": "recent_action",
+              "step_id": "S08",
+              "supporting_evidence_refs": [
+                "RECENT_ACTIONS.left_mdi_pb15",
+                "RECENT_ACTIONS.left_mdi_pb18"
+              ]
+            },
+            {
+              "confidence": 0.5,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_0",
+                "ufc_key_1"
+              ],
+              "role": "candidate",
+              "source": "recent_action",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+                "RECENT_ACTIONS.ufc_key_0",
+                "RECENT_ACTIONS.ufc_key_1"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "battery_switch",
+              "generator_left_switch",
+              "generator_right_switch"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S01",
+            "supporting_evidence_refs": [
+              "GATES.S01.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 8,
+            "telemetry_missing_source_count": 28,
+            "telemetry_status": "low_confidence_bootstrap",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 1,
+              "frame_count": 1,
+              "latest_seq": 1
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+            "source_observation_seq": 1,
+            "source_observation_t_wall": 1779209004.800106,
+            "telemetry_window_first_seq": 1,
+            "telemetry_window_frame_count": 1,
+            "telemetry_window_latest_seq": 1,
+            "telemetry_window_latest_t_wall": 1779209004.800106,
+            "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "overlay_step_id": "S01",
+            "source": "model",
+            "step_id": "S01",
+            "targets": [
+              "battery_switch"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "battery_switch"
+          ],
+          "message_category": "fallback_overlay",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S01.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "battery_switch"
+            ],
+            "status": "ok",
+            "step_id": "S01"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "model"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+            "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "model",
+            "fallback_overlay_used": true,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 0,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779209004872_000276"
+            ],
+            "ignored_fact_count": 0,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 0,
+            "sync_delta_ms": 86,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [],
+        "harness_validator_fallback_reason": "deterministic_step:S01",
+        "harness_validator_mapping": {
+          "allowed_evidence_ref_count": 153,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S01"
+          },
+          "next": {
+            "step_id": "S01"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S01"
+          },
+          "explanations": [
+            "请先操作 battery_switch。"
+          ],
+          "next": {
+            "step_id": "S01"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S01.completion",
+                "target": "battery_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "battery_switch"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S01"
+          },
+          "explanations": [
+            "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+          ],
+          "next": {
+            "step_id": "S01"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S01.completion",
+                "target": "battery_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "battery_switch"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 3978,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "fallback_overlay",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S01"
+        },
+        "model_raw_explanations": [
+          "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S01"
+          },
+          "explanations": [
+            "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+          ],
+          "next": {
+            "step_id": "S01"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S01.completion",
+                "target": "battery_switch",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "battery_switch"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S01"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779209004872_000276"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779209004872_000276",
+        "next": {
+          "step_id": "S01"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 5474,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.battery_on",
+            "GATES.S01.completion",
+            "GATES.S01.precondition",
+            "GATES.S03.completion",
+            "GATES.S04.completion",
+            "GATES.S04.precondition",
+            "GATES.S05.completion",
+            "GATES.S05.precondition",
+            "GATES.S06.completion",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_153",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_38",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_49",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_142"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 18,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "battery_switch",
+          "prompt_chars": 22142,
+          "prompt_tokens_est": 5536,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "DCS FA-18C Early Access Guide EN_153",
+            "DCS FA-18C Early Access Guide EN_38",
+            "fa18c_startup_master_1",
+            "DCS FA-18C Early Access Guide EN_49",
+            "DCS FA-18C Early Access Guide EN_142"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "low_confidence_bootstrap",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+        "prompt_tokens_est": 5536,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "ddd9aba13dc750d1afcffa188dd33a3a1ab91e3a415b64ca4a824c2ff7865dbe",
+        "request_prompt_tokens_est": 5536,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 153,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S01"
+          },
+          "next": {
+            "step_id": "S01"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+          "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+        },
+        "state_key": "099ae84f26d22ee7bd95fccfdb0868baf0903b1bb5c49364bd0333a9db2cc0a3",
+        "sync_delta_ms": 86,
+        "validator_rejected": false,
+        "vision": {
+          "frame_id": "1779209004872_000276",
+          "frame_ids": [
+            "1779209004872_000276"
+          ],
+          "frame_stale": false,
+          "observation_ref": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+          "observation_seq": 1,
+          "observation_t_wall_ms": 1779209004800,
+          "observation_t_wall_s": 1779209004.800106,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779209004872,
+              "channel": "composite_panel",
+              "frame_id": "1779209004872_000276",
+              "frame_seq": 276,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209004872_000276_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209004872_000276.png",
+              "sync_delta_ms": 86,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 86,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779209004872,
+            "channel": "composite_panel",
+            "frame_id": "1779209004872_000276",
+            "frame_seq": 276,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779209004872_000276_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779209004872_000276.png",
+            "sync_delta_ms": 86,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779209004786,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S01"
+        ],
+        "vision_fact_cached_count": 0,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 0,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 0,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779209004872_000276"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779209004872_000276"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "98de9798-7b38-41e2-8618-bf9390cc1471",
+      "status": "ok",
+      "timestamp": "2026-05-19T16:43:29.098996+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S01",
+    "expected_overlay_target_ids": [
+      "battery_switch"
+    ],
+    "final_response_source": "model",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "614024be-1420-4188-91e9-f044acff9291",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "battery_switch",
+          "generator_left_switch",
+          "generator_right_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S01",
+        "supporting_evidence_refs": [
+          "GATES.S01.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "battery_switch",
+          "generator_left_switch",
+          "generator_right_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S01",
+        "supporting_evidence_refs": [
+          "GATES.S01.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "apu_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S03",
+        "supporting_evidence_refs": [
+          "GATES.S03.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S04",
+        "supporting_evidence_refs": [
+          "GATES.S04.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S05",
+        "supporting_evidence_refs": [
+          "GATES.S05.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "bleed_air_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S06",
+        "supporting_evidence_refs": [
+          "GATES.S06.completion"
+        ]
+      },
+      {
+        "confidence": 0.5,
+        "proposed_next_action_target_ids": [
+          "left_mdi_pb15",
+          "left_mdi_pb18"
+        ],
+        "role": "candidate",
+        "source": "recent_action",
+        "step_id": "S08",
+        "supporting_evidence_refs": [
+          "RECENT_ACTIONS.left_mdi_pb15",
+          "RECENT_ACTIONS.left_mdi_pb18"
+        ]
+      },
+      {
+        "confidence": 0.5,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_0",
+          "ufc_key_1"
+        ],
+        "role": "candidate",
+        "source": "recent_action",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+          "RECENT_ACTIONS.ufc_key_0",
+          "RECENT_ACTIONS.ufc_key_1"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+      "overlay_step_id": "S01",
+      "source": "model",
+      "step_id": "S01",
+      "targets": [
+        "battery_switch"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S01.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "battery_switch"
+      ],
+      "status": "ok",
+      "step_id": "S01"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "model"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "battery_switch",
+            "generator_left_switch",
+            "generator_right_switch"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S01",
+          "supporting_evidence_refs": [
+            "GATES.S01.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "battery_switch",
+            "generator_left_switch",
+            "generator_right_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S01",
+          "supporting_evidence_refs": [
+            "GATES.S01.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "apu_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S03",
+          "supporting_evidence_refs": [
+            "GATES.S03.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S04",
+          "supporting_evidence_refs": [
+            "GATES.S04.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S05",
+          "supporting_evidence_refs": [
+            "GATES.S05.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "bleed_air_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S06",
+          "supporting_evidence_refs": [
+            "GATES.S06.completion"
+          ]
+        },
+        {
+          "confidence": 0.5,
+          "proposed_next_action_target_ids": [
+            "left_mdi_pb15",
+            "left_mdi_pb18"
+          ],
+          "role": "candidate",
+          "source": "recent_action",
+          "step_id": "S08",
+          "supporting_evidence_refs": [
+            "RECENT_ACTIONS.left_mdi_pb15",
+            "RECENT_ACTIONS.left_mdi_pb18"
+          ]
+        },
+        {
+          "confidence": 0.5,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_0",
+            "ufc_key_1"
+          ],
+          "role": "candidate",
+          "source": "recent_action",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "RECENT_ACTIONS.ufc_comm1_channel_selector_pull",
+            "RECENT_ACTIONS.ufc_key_0",
+            "RECENT_ACTIONS.ufc_key_1"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "battery_switch",
+          "generator_left_switch",
+          "generator_right_switch"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S01",
+        "supporting_evidence_refs": [
+          "GATES.S01.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 8,
+        "telemetry_missing_source_count": 28,
+        "telemetry_status": "low_confidence_bootstrap",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 1,
+          "frame_count": 1,
+          "latest_seq": 1
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "final_decision_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "model_request_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "source_observation_id": "1ee204de-f86d-472a-b5b4-64c9578c4b2c",
+        "source_observation_seq": 1,
+        "source_observation_t_wall": 1779209004.800106,
+        "telemetry_window_first_seq": 1,
+        "telemetry_window_frame_count": 1,
+        "telemetry_window_latest_seq": 1,
+        "telemetry_window_latest_t_wall": 1779209004.800106,
+        "validator_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "overlay_step_id": "S01",
+        "source": "model",
+        "step_id": "S01",
+        "targets": [
+          "battery_switch"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "battery_switch"
+      ],
+      "message_category": "fallback_overlay",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S01.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "battery_switch"
+        ],
+        "status": "ok",
+        "step_id": "S01"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "model"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "final_decision": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "model_request": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb",
+        "validator": "8f77ac4e0ba9e7243e0e1cbe8cd71b4ef9d52c1a7b52e26bd477247ec844d3eb"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "model",
+        "fallback_overlay_used": true,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 0,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779209004872_000276"
+        ],
+        "ignored_fact_count": 0,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 0,
+        "sync_delta_ms": 86,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "model",
+      "fallback_overlay_used": true,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "614024be-1420-4188-91e9-f044acff9291",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S01"
+      },
+      "explanations": [
+        "请先操作 battery_switch。"
+      ],
+      "next": {
+        "step_id": "S01"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S01.completion",
+            "target": "battery_switch",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "battery_switch"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S01"
+      },
+      "explanations": [
+        "当前步骤 S01 未完成，电瓶开关未打开。请右键点击 battery_switch 将其拨到 ON 位置。"
+      ],
+      "next": {
+        "step_id": "S01"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S01.completion",
+            "target": "battery_switch",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "battery_switch"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "614024be-1420-4188-91e9-f044acff9291",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 13409,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_164221.jsonl"
+  }
+}

--- a/replay_eval/fa18c_startup_v04/suite.yaml
+++ b/replay_eval/fa18c_startup_v04/suite.yaml
@@ -148,6 +148,34 @@ coverage:
     fixture: artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json
     test_id: tests/test_live_dcs.py::test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance
     reason: Matrix must expose raw S28 / parking-brake decision separately from final repaired S29 / IFEI action.
+  - step_id: S11
+    state_category: completion_already_true
+    source: live_fixture_regression
+    issue: 312
+    regression_class: partial_completion_no_advance
+    action_mode: text_only
+    text_intent: left_throttle_text_only_no_s12
+    fixture: artifacts/live_fixtures/c4d7c369-f151-4ef6-b528-409b16f1fe34.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_311_keeps_s11_when_completion_is_partial
+    reason: S11 partial RPM completion must stay on text-only left-throttle guidance until idle-ready evidence is true.
+  - step_id: S12
+    state_category: completion_already_true
+    source: live_fixture_regression
+    issue: 312
+    regression_class: s12_satisfied_advances_to_s13_radar_opr
+    text_intent: radar_opr_detent_guidance_not_target_only
+    fixture: artifacts/live_fixtures/e96b29b7-b305-4444-beb3-60ddb0804b4b.fixture.json
+    test_id: tests/test_live_dcs.py::test_live_help_fixture_314_s13_radar_opr_uses_detent_guidance
+    reason: Already-satisfied S12 must repair forward to S13 and tell the user to set the Radar knob to OPR.
+  - step_id: S01
+    state_category: vlm_not_required
+    source: live_fixture_regression
+    issue: 312
+    regression_class: first_cycle_main_llm_latency_no_vlm
+    latency_class: first_cycle_main_llm_latency
+    fixture: artifacts/live_fixtures/614024be-1420-4188-91e9-f044acff9291.fixture.json
+    test_id: tests/test_replay_eval.py::test_replay_eval_report_records_latest_issue_312_fixture_regression_classes
+    reason: First-cycle low-confidence bootstrap latency must be recorded as main LLM response time, not VLM delay.
 cases:
   - case_id: noop_2min
     input: cases/noop_2min/dcs_bios_raw.jsonl

--- a/simtutor/replay_eval.py
+++ b/simtutor/replay_eval.py
@@ -105,6 +105,12 @@ def _extract_optional_bool(raw: Any) -> bool | None:
     return None
 
 
+def _extract_optional_int(raw: Any) -> int | None:
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        return None
+    return raw
+
+
 def _extract_optional_text(raw: Any) -> str | None:
     if not isinstance(raw, str):
         return None
@@ -153,6 +159,8 @@ def _normalize_coverage_tags(
                 test_id=_extract_optional_text(item.get("test_id")),
                 regression_class=_extract_optional_text(item.get("regression_class")),
                 text_intent=_extract_optional_text(item.get("text_intent")),
+                action_mode=_extract_optional_text(item.get("action_mode")),
+                latency_class=_extract_optional_text(item.get("latency_class")),
                 reason=_extract_optional_text(item.get("reason")),
             )
         )
@@ -193,6 +201,8 @@ class ReplayEvalCoverageTag:
     test_id: str | None = None
     regression_class: str | None = None
     text_intent: str | None = None
+    action_mode: str | None = None
+    latency_class: str | None = None
     reason: str | None = None
 
 
@@ -797,6 +807,16 @@ def _extract_live_fixture_assertions(fixture_path: Path) -> dict[str, Any]:
         raise ValueError(f"coverage fixture root is not a mapping: {fixture_path}")
 
     expectations = _as_mapping(raw.get("expectations"))
+    cycle = _as_mapping(raw.get("cycle"))
+    tutor_request = _as_mapping(cycle.get("tutor_request"))
+    request_context = _as_mapping(tutor_request.get("context"))
+    tutor_response = _as_mapping(cycle.get("tutor_response"))
+    response_metadata = _as_mapping(tutor_response.get("metadata"))
+    context = _as_mapping(raw.get("context"))
+    request_state_harness = _as_mapping(request_context.get("state_harness"))
+    telemetry_evidence = _as_mapping(request_state_harness.get("telemetry_evidence"))
+    evidence_packet_summary = _as_mapping(request_context.get("evidence_packet_summary"))
+    evidence_snapshot = _as_mapping(context.get("evidence_snapshot"))
     harness = _as_mapping(raw.get("harness"))
     trace = _as_mapping(harness.get("trace"))
     model_decision = _as_mapping(trace.get("model_decision") or harness.get("model_decision"))
@@ -810,12 +830,17 @@ def _extract_live_fixture_assertions(fixture_path: Path) -> dict[str, Any]:
         _extract_optional_text(final_plan.get("step_id"))
         or _extract_optional_text(expectations.get("expected_final_step_id"))
     )
-    final_targets = _string_list(final_plan.get("targets")) or _string_list(
-        expectations.get("expected_overlay_target_ids")
-    )
+    final_targets_raw = final_plan.get("targets")
+    has_final_targets = isinstance(final_targets_raw, (list, tuple))
+    final_targets = _string_list(final_targets_raw)
+    if not has_final_targets and isinstance(expectations.get("expected_overlay_target_ids"), list):
+        has_final_targets = True
+        final_targets = _string_list(expectations.get("expected_overlay_target_ids"))
     extractor_used = _extract_optional_bool(vlm_call.get("extractor_used"))
     extractor_called = _extract_optional_bool(vlm_call.get("extractor_called"))
     frame_capture_selected = _extract_optional_bool(vlm_call.get("frame_capture_selected"))
+    if frame_capture_selected is None:
+        frame_capture_selected = _extract_optional_bool(response_metadata.get("vision_frame_capture_selected"))
 
     assertions: dict[str, Any] = {}
     if raw_model_step_id is not None:
@@ -829,7 +854,9 @@ def _extract_live_fixture_assertions(fixture_path: Path) -> dict[str, Any]:
         repair_applied = _extract_optional_bool(repair_result.get("applied"))
         if repair_applied is not None:
             assertions["repair_applied"] = repair_applied
-    final_action_plan_source = _extract_optional_text(final_plan.get("source"))
+    final_action_plan_source = _extract_optional_text(final_plan.get("source")) or _extract_optional_text(
+        expectations.get("final_response_source")
+    )
     if final_action_plan_source is not None:
         assertions["final_action_plan_source"] = final_action_plan_source
     message_category = _extract_optional_text(trace.get("message_category"))
@@ -837,14 +864,22 @@ def _extract_live_fixture_assertions(fixture_path: Path) -> dict[str, Any]:
         assertions["message_category"] = message_category
     if final_step_id is not None:
         assertions["final_step_id"] = final_step_id
-    if final_targets:
+    if has_final_targets:
         assertions["final_targets"] = final_targets
     vlm_call_status = _extract_optional_text(vlm_call.get("status")) or _extract_optional_text(
         expectations.get("vlm_call_status")
+    ) or _extract_optional_text(
+        response_metadata.get("vlm_call_status")
     )
     if vlm_call_status is not None:
         assertions["vlm_call_status"] = vlm_call_status
-    vision_fact_extractor_used = extractor_used if extractor_used is not None else extractor_called
+    vision_fact_extractor_used = (
+        extractor_used
+        if extractor_used is not None
+        else extractor_called
+        if extractor_called is not None
+        else _extract_optional_bool(response_metadata.get("vision_fact_extractor_used"))
+    )
     if vision_fact_extractor_used is not None:
         assertions["vision_fact_extractor_used"] = vision_fact_extractor_used
     if extractor_called is not None:
@@ -855,6 +890,42 @@ def _extract_live_fixture_assertions(fixture_path: Path) -> dict[str, Any]:
         assertions["frame_capture_only"] = bool(
             frame_capture_selected and not bool(extractor_used) and not bool(extractor_called)
         )
+    latency_ms = _extract_optional_int(response_metadata.get("latency_ms"))
+    if latency_ms is not None:
+        assertions["latency_ms"] = latency_ms
+        assertions["latency_source"] = "main_llm_response"
+        telemetry_status = _extract_optional_text(telemetry_evidence.get("source_status")) or _extract_optional_text(
+            evidence_packet_summary.get("telemetry_status")
+        )
+        telemetry_window_digest = _as_mapping(evidence_packet_summary.get("telemetry_window_digest"))
+        source_observation_seq = _extract_optional_int(evidence_snapshot.get("source_observation_seq"))
+        multimodal_path_attempted = _extract_optional_bool(response_metadata.get("multimodal_path_attempted"))
+        telemetry_window_frame_count = _extract_optional_int(telemetry_window_digest.get("frame_count"))
+        telemetry_window_first_seq = _extract_optional_int(telemetry_window_digest.get("first_seq"))
+        telemetry_window_latest_seq = _extract_optional_int(telemetry_window_digest.get("latest_seq"))
+        if telemetry_status is not None:
+            assertions["latency_telemetry_status"] = telemetry_status
+        if source_observation_seq is not None:
+            assertions["latency_source_observation_seq"] = source_observation_seq
+        if multimodal_path_attempted is not None:
+            assertions["latency_multimodal_path_attempted"] = multimodal_path_attempted
+        if telemetry_window_frame_count is not None:
+            assertions["latency_telemetry_window_frame_count"] = telemetry_window_frame_count
+        if telemetry_window_first_seq is not None:
+            assertions["latency_telemetry_window_first_seq"] = telemetry_window_first_seq
+        if telemetry_window_latest_seq is not None:
+            assertions["latency_telemetry_window_latest_seq"] = telemetry_window_latest_seq
+        if (
+            vlm_call_status == "not_required"
+            and vision_fact_extractor_used is False
+            and telemetry_status == "low_confidence_bootstrap"
+            and source_observation_seq == 1
+            and telemetry_window_frame_count == 1
+            and telemetry_window_first_seq == 1
+            and telemetry_window_latest_seq == 1
+            and multimodal_path_attempted is False
+        ):
+            assertions["latency_not_vlm_delay"] = True
     return assertions
 
 
@@ -872,6 +943,8 @@ def _coverage_source_dict(
             "test_id": tag.test_id,
             "regression_class": tag.regression_class,
             "text_intent": tag.text_intent,
+            "action_mode": tag.action_mode,
+            "latency_class": tag.latency_class,
             "reason": tag.reason,
         }
     else:

--- a/tests/test_replay_eval.py
+++ b/tests/test_replay_eval.py
@@ -51,6 +51,12 @@ LATEST_ISSUE_312_FIXTURES = {
         "public_completion_message",
     "artifacts/live_fixtures/8d30d919-108d-4068-8b58-a9467aecdb21.fixture.json":
         "raw_wrong_final_repaired",
+    "artifacts/live_fixtures/c4d7c369-f151-4ef6-b528-409b16f1fe34.fixture.json":
+        "partial_completion_no_advance",
+    "artifacts/live_fixtures/e96b29b7-b305-4444-beb3-60ddb0804b4b.fixture.json":
+        "s12_satisfied_advances_to_s13_radar_opr",
+    "artifacts/live_fixtures/614024be-1420-4188-91e9-f044acff9291.fixture.json":
+        "first_cycle_main_llm_latency_no_vlm",
 }
 
 TEXT_INTENT_REGRESSION_CLASSES = {
@@ -58,6 +64,8 @@ TEXT_INTENT_REGRESSION_CLASSES = {
     "wheel_interaction_radar_altimeter",
     "wheel_interaction_standby_attitude",
     "public_completion_message",
+    "partial_completion_no_advance",
+    "s12_satisfied_advances_to_s13_radar_opr",
 }
 
 
@@ -250,6 +258,55 @@ def test_replay_eval_report_records_latest_issue_312_fixture_regression_classes(
         "artifacts/live_fixtures/7bea22f8-a4d1-4744-917b-f7ddc957f709.fixture.json"
     ]
     assert s7bea["text_intent"] == "public_completion_no_internal_evidence"
+
+    sc4d = sources_by_fixture[
+        "artifacts/live_fixtures/c4d7c369-f151-4ef6-b528-409b16f1fe34.fixture.json"
+    ]
+    assert sc4d["action_mode"] == "text_only"
+    assert sc4d["text_intent"] == "left_throttle_text_only_no_s12"
+    sc4d_assertions = sc4d["fixture_assertions"]
+    assert sc4d_assertions["final_step_id"] == "S11"
+    assert sc4d_assertions["final_targets"] == []
+    assert sc4d_assertions["final_action_plan_source"] == "model"
+
+    se96 = sources_by_fixture[
+        "artifacts/live_fixtures/e96b29b7-b305-4444-beb3-60ddb0804b4b.fixture.json"
+    ]
+    assert se96["text_intent"] == "radar_opr_detent_guidance_not_target_only"
+    assert se96 in report["coverage_matrix"]["steps"]["S12"]["completion_already_true"]["sources"]
+    se96_assertions = se96["fixture_assertions"]
+    assert se96_assertions["raw_model_step_id"] == "S12"
+    assert se96_assertions["raw_model_targets"] == ["ampcd_pb19"]
+    assert se96_assertions["validator_rejected"] is True
+    assert se96_assertions["repair_applied"] is True
+    assert se96_assertions["final_action_plan_source"] == "final_evidence_consistency_validator"
+    assert se96_assertions["message_category"] == "harness_validator_repair"
+    assert se96_assertions["final_step_id"] == "S13"
+    assert se96_assertions["final_targets"] == ["radar_mode_knob"]
+    assert se96_assertions["vlm_call_status"] == "not_required"
+    assert se96_assertions["vision_fact_extractor_used"] is False
+    assert se96_assertions["frame_capture_only"] is True
+
+    s614 = sources_by_fixture[
+        "artifacts/live_fixtures/614024be-1420-4188-91e9-f044acff9291.fixture.json"
+    ]
+    assert s614["latency_class"] == "first_cycle_main_llm_latency"
+    s614_assertions = s614["fixture_assertions"]
+    assert s614_assertions["final_step_id"] == "S01"
+    assert s614_assertions["final_targets"] == ["battery_switch"]
+    assert s614_assertions["latency_ms"] == 3978
+    assert s614_assertions["latency_source"] == "main_llm_response"
+    assert s614_assertions["latency_telemetry_status"] == "low_confidence_bootstrap"
+    assert s614_assertions["latency_source_observation_seq"] == 1
+    assert s614_assertions["latency_telemetry_window_frame_count"] == 1
+    assert s614_assertions["latency_telemetry_window_first_seq"] == 1
+    assert s614_assertions["latency_telemetry_window_latest_seq"] == 1
+    assert s614_assertions["latency_multimodal_path_attempted"] is False
+    assert s614_assertions["latency_not_vlm_delay"] is True
+    assert s614_assertions["vlm_call_status"] == "not_required"
+    assert s614_assertions["vision_fact_extractor_used"] is False
+    assert s614_assertions["frame_capture_selected"] is True
+    assert s614_assertions["frame_capture_only"] is True
 
 
 def test_harness_coverage_matrix_keeps_suite_regressions_without_pack_specs(tmp_path: Path) -> None:


### PR DESCRIPTION
Refs #312

## Summary
- add the latest #312 addendum coverage rows for c4d/e96/614
- extract fixture assertions for empty final targets, action mode, latency class, first-cycle bootstrap latency, and frame-capture-only VLM state
- add the 614 live fixture from logs/live_help_harness_smoke_20260519_164221.jsonl

## Verification
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_replay_eval.py tests/test_live_dcs.py::test_live_help_fixture_311_keeps_s11_when_completion_is_partial tests/test_live_dcs.py::test_live_help_fixture_314_s13_radar_opr_uses_detent_guidance

Full test suite intentionally not run per user request.