### PR TITLE
Fix S18 advancement overlay planning

### DIFF
--- a/artifacts/live_fixtures/82d871be-26ac-41f4-a722-8141efcd8f87.fixture.json
+++ b/artifacts/live_fixtures/82d871be-26ac-41f4-a722-8141efcd8f87.fixture.json
@@ -2342,7 +2342,9 @@
   },
   "expectations": {
     "expected_final_step_id": "S18",
-    "expected_overlay_target_ids": [],
+    "expected_overlay_target_ids": [
+      "right_mdi_pb18"
+    ],
     "final_response_source": "final_evidence_consistency_validator",
     "llm_decision_status": "repaired",
     "vlm_call_status": "not_required"

--- a/artifacts/live_fixtures/f92855c5-6ed1-4101-899c-72bd8d8e8e25.fixture.json
+++ b/artifacts/live_fixtures/f92855c5-6ed1-4101-899c-72bd8d8e8e25.fixture.json
@@ -2386,7 +2386,9 @@
   },
   "expectations": {
     "expected_final_step_id": "S18",
-    "expected_overlay_target_ids": [],
+    "expected_overlay_target_ids": [
+      "right_mdi_pb18"
+    ],
     "final_response_source": "final_evidence_consistency_validator",
     "llm_decision_status": "repaired",
     "vlm_call_status": "not_required"

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -677,7 +677,7 @@ def _state_action_plan(
 
     seen_or_fresh = set(_strings(vision_seen_fact_ids)) | set(_strings(vision_fresh_fact_ids))
     not_seen = set(_strings(vision_not_seen_fact_ids))
-    if step_id == "S18" and "bit_root_page_visible" in seen_or_fresh and "fcsmc_page_visible" in not_seen:
+    if step_id == "S18" and "bit_root_page_visible" in seen_or_fresh:
         if "right_mdi_pb5" in allowed:
             return _StateActionPlan(
                 targets=("right_mdi_pb5",),
@@ -686,6 +686,14 @@ def _state_action_plan(
                 source="state_action_planner",
                 reasons=("s18_bit_root_to_pb5",),
             )
+    if step_id == "S18" and "right_mdi_pb18" in allowed:
+        return _StateActionPlan(
+            targets=("right_mdi_pb18",),
+            guidance="Right DDI BIT page state is not confirmed; press Right DDI PB18/MENU to recover the BIT page first.",
+            text_only=False,
+            source="state_action_planner",
+            reasons=("s18_unknown_page_to_pb18",),
+        )
     if step_id == "S19":
         if "fcsmc_in_test_visible" in seen_or_fresh:
             return _StateActionPlan(

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -7580,36 +7580,111 @@ class LiveDcsTutorLoop:
                 ]
             fallback_reason = "s08_visual_recovery"
         else:
-            fallback_request = request
-            completed_latch_by_step = {
-                "S20": "s20_latched_complete",
-                "S22": "s22_latched_complete",
-                "S24": "s24_latched_complete",
-            }
-            completed_latch = completed_latch_by_step.get(rejected_step_id)
-            if completed_latch is not None and next_step_id in {"S21", "S23", "S25"}:
-                patched_context = dict(context)
-                patched_latches = _four_down_completion_latches_from_context(patched_context)
-                patched_latches[completed_latch] = True
-                patched_context["four_down_completion_latches"] = patched_latches
-                fallback_request = TutorRequest(
-                    request_id=request.request_id,
-                    timestamp=request.timestamp,
-                    actor=request.actor,
-                    intent=request.intent,
-                    version=request.version,
-                    message=request.message,
-                    observation_ref=request.observation_ref,
-                    context=patched_context,
-                    metadata=dict(request.metadata),
+            if next_step_id == "S18":
+                summary = context.get("vision_fact_summary")
+                bit_root_seen = _vision_summary_seen_or_fresh(summary, "bit_root_page_visible")
+                if bit_root_seen and "right_mdi_pb5" in self.overlay_allowset:
+                    s18_target = "right_mdi_pb5"
+                    s18_guidance = (
+                        "S17 已完成。现在进入 S18：右 DDI 已在 BIT root 页面；请左键按 PB5/FCS-MC 进入 FCS-MC BIT 页面。"
+                        if self.lang == "zh"
+                        else "S17 is complete. Continue to S18: the right DDI is on the BIT root page; left-click PB5/FCS-MC to enter the FCS-MC BIT page."
+                    )
+                    allowed_refs = _collect_request_evidence_refs(context)
+                    visual_ref = _visual_fact_ref_from_context(context, "bit_root_page_visible")
+                    s18_ref = next(
+                        (
+                            ref for ref in (
+                                visual_ref,
+                                "VARS.takeoff_trim_set",
+                                "GATES.S17.completion",
+                                "GATES.S18.completion",
+                            )
+                            if isinstance(ref, str) and ref in allowed_refs
+                        ),
+                        visual_ref if isinstance(visual_ref, str) and visual_ref else "GATES.S18.completion",
+                    )
+                    s18_evidence_type = "visual" if s18_ref.startswith("VISION_FACTS.") else "gate"
+                    if s18_ref.startswith("VARS."):
+                        s18_evidence_type = "var"
+                    s18_quote = "S18 BIT root page is visible; PB5 enters FCS-MC."
+                    fallback_reason = "s18_bit_root_to_pb5"
+                else:
+                    s18_target = "right_mdi_pb18"
+                    s18_guidance = (
+                        "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+                        if self.lang == "zh"
+                        else "S17 is complete. Continue to S18: the right DDI BIT page state is not confirmed; left-click right DDI PB18/MENU to recover the BIT page first."
+                    )
+                    allowed_refs = _collect_request_evidence_refs(context)
+                    s18_ref = next(
+                        (
+                            ref for ref in (
+                                "GATES.S18.completion",
+                                "VARS.takeoff_trim_set",
+                                "GATES.S17.completion",
+                            )
+                            if ref in allowed_refs
+                        ),
+                        "GATES.S18.completion",
+                    )
+                    s18_evidence_type = "gate"
+                    if s18_ref.startswith("VARS."):
+                        s18_evidence_type = "var"
+                    s18_quote = "S18 requires right DDI BIT/FCS-MC page navigation."
+                    fallback_reason = "s18_unknown_page_to_pb18"
+                if s18_target in self.overlay_allowset:
+                    fallback_help_obj = {
+                        "diagnosis": {"step_id": "S18", "error_category": "OM"},
+                        "next": {"step_id": "S18"},
+                        "overlay": {
+                            "targets": [s18_target],
+                            "evidence": [
+                                {
+                                    "target": s18_target,
+                                    "type": s18_evidence_type,
+                                    "ref": s18_ref,
+                                    "quote": s18_quote,
+                                    "grounding_confidence": 0.51,
+                                }
+                            ],
+                        },
+                        "explanations": [s18_guidance],
+                    }
+                else:
+                    fallback_help_obj = None
+                    fallback_reason = f"target_not_in_runtime_allowlist:{s18_target}"
+            else:
+                fallback_request = request
+                completed_latch_by_step = {
+                    "S20": "s20_latched_complete",
+                    "S22": "s22_latched_complete",
+                    "S24": "s24_latched_complete",
+                }
+                completed_latch = completed_latch_by_step.get(rejected_step_id)
+                if completed_latch is not None and next_step_id in {"S21", "S23", "S25"}:
+                    patched_context = dict(context)
+                    patched_latches = _four_down_completion_latches_from_context(patched_context)
+                    patched_latches[completed_latch] = True
+                    patched_context["four_down_completion_latches"] = patched_latches
+                    fallback_request = TutorRequest(
+                        request_id=request.request_id,
+                        timestamp=request.timestamp,
+                        actor=request.actor,
+                        intent=request.intent,
+                        version=request.version,
+                        message=request.message,
+                        observation_ref=request.observation_ref,
+                        context=patched_context,
+                        metadata=dict(request.metadata),
+                    )
+                    response.metadata["final_evidence_consistency_completion_advance_latches"] = dict(patched_latches)
+                fallback_help_obj, fallback_reason = self._build_safe_fallback_overlay_help_obj(
+                    fallback_request,
+                    override_inferred_step_id=next_step_id,
+                    override_overlay_step_id=next_step_id,
+                    ignore_request_allowlist=True,
                 )
-                response.metadata["final_evidence_consistency_completion_advance_latches"] = dict(patched_latches)
-            fallback_help_obj, fallback_reason = self._build_safe_fallback_overlay_help_obj(
-                fallback_request,
-                override_inferred_step_id=next_step_id,
-                override_overlay_step_id=next_step_id,
-                ignore_request_allowlist=True,
-            )
         fallback_used = False
         if isinstance(fallback_help_obj, Mapping):
             planned_help_obj = copy.deepcopy(dict(fallback_help_obj))

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -561,9 +561,37 @@ def test_plan_harness_action_keeps_s18_recovery_pb18_when_bit_root_not_visible()
     )
 
     assert plan.targets == ("right_mdi_pb18",)
-    assert plan.repair_applied is False
-    assert plan.validator_rejected is False
-    assert plan.final_action_plan_source == "model"
+    assert plan.repair_applied is True
+    assert plan.validator_rejected is True
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "s18_unknown_page_to_pb18" in plan.reasons
+
+
+def test_plan_harness_action_uses_s18_safe_navigation_when_visual_state_unknown() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=[],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        request_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        allowed_evidence_refs=["GATES.S18.completion"],
+        evidence_refs=["GATES.S18.completion"],
+        max_overlay_targets=1,
+    )
+
+    assert plan.targets == ("right_mdi_pb18",)
+    assert plan.text_only is False
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "PB18" in (plan.guidance or "")
+    assert "s18_unknown_page_to_pb18" in plan.reasons
 
 
 def test_plan_harness_action_uses_s18_visual_state_without_live_hint() -> None:
@@ -588,6 +616,31 @@ def test_plan_harness_action_uses_s18_visual_state_without_live_hint() -> None:
 
     assert plan.targets == ("right_mdi_pb5",)
     assert plan.final_action_plan_source == "state_action_planner"
+    assert "state_action_target_mismatch:right_mdi_pb18" in plan.reasons
+
+
+def test_plan_harness_action_uses_s18_pb5_when_bit_root_seen_without_fcsmc_not_seen() -> None:
+    plan = plan_harness_action(
+        step_specs={
+            "S18": _spec(
+                "S18",
+                ("right_mdi_pb18", "right_mdi_pb5"),
+                recovery_kind="visual_confirmation",
+            )
+        },
+        inferred_step_id="S18",
+        model_step_id="S18",
+        proposed_overlay_targets=["right_mdi_pb18"],
+        candidate_step_ids=["S18"],
+        runtime_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        request_overlay_targets=["right_mdi_pb18", "right_mdi_pb5"],
+        max_overlay_targets=1,
+        vision_seen_fact_ids=["bit_root_page_visible"],
+    )
+
+    assert plan.targets == ("right_mdi_pb5",)
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "s18_bit_root_to_pb5" in plan.reasons
     assert "state_action_target_mismatch:right_mdi_pb18" in plan.reasons
 
 

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11699,18 +11699,18 @@ def test_live_help_fixture_315_s17_complete_advances_to_s18_actionable_text() ->
     assert repaired.metadata["diagnosis"]["step_id"] == "S18"
     assert repaired.metadata["next"]["step_id"] == "S18"
     assert repaired.metadata["final_action_plan"]["step_id"] == "S18"
-    assert repaired.metadata["final_action_plan"]["text_only"] is True
-    assert repaired.metadata["final_overlay_targets"] == []
+    assert repaired.metadata["final_action_plan"]["text_only"] is False
+    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb18"]
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb18"]
     assert repaired.metadata["harness_trace"]["model_decision"]["step_id"] == "S17"
     assert repaired.metadata["harness_trace"]["repair_result"]["path"] == "final_evidence_consistency_validator"
     final_public = repaired.metadata["final_public_response"]
-    assert final_public["instruction_category"] == "text-only/manual"
+    assert final_public["actions"][0]["target"] == "right_mdi_pb18"
     public_text = _public_response_text(repaired)
     assert "最新证据" not in public_text
     assert "evidence" not in public_text.lower()
     assert "S18" in public_text
-    assert "PB5" in public_text
-    assert "FCS-MC" in public_text
+    assert "PB18" in public_text
     assert "takeoff_trim_button" not in public_text
 
 
@@ -11765,7 +11765,7 @@ def test_live_help_fixture_315_final_repair_restamps_s12_action_metadata() -> No
     assert "vars.rpm_l>=25" not in json.dumps(final_public_action)
 
 
-def test_live_help_fixture_315_s18_text_only_plan_records_reason() -> None:
+def test_live_help_fixture_315_s18_advancement_uses_actionable_overlay() -> None:
     fixture = _load_live_help_fixture(
         "artifacts/live_fixtures/82d871be-26ac-41f4-a722-8141efcd8f87.fixture.json"
     )
@@ -11777,13 +11777,41 @@ def test_live_help_fixture_315_s18_text_only_plan_records_reason() -> None:
     assert repaired.metadata["diagnosis"]["step_id"] == "S18"
     final_plan = repaired.metadata["final_action_plan"]
     assert final_plan["step_id"] == "S18"
-    assert final_plan["text_only"] is True
-    assert final_plan["targets"] == []
-    assert final_plan["text_only_reason"] == "text-only/manual"
-    assert isinstance(final_plan["text_only_detail"], str) and final_plan["text_only_detail"]
+    assert final_plan["text_only"] is False
+    assert final_plan["targets"] == ["right_mdi_pb18"]
+    assert repaired.metadata["final_evidence_consistency_overlay_applied"] is True
+    assert repaired.metadata["final_evidence_consistency_overlay_reason"] == "s18_unknown_page_to_pb18"
+    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb18"]
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb18"]
     assert repaired.metadata["fused_step_id"] == "S18"
     assert repaired.metadata["fused_missing_conditions"] == []
-    assert "PB5" in _public_response_text(repaired)
+    public_text = _public_response_text(repaired)
+    assert "PB18" in public_text
+    assert "takeoff_trim_button" not in public_text
+
+
+def test_live_help_fixture_315_s18_advancement_uses_pb5_when_bit_root_seen() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/82d871be-26ac-41f4-a722-8141efcd8f87.fixture.json"
+    )
+    request, response = _fixture_request_and_raw_model_response(fixture)
+    request.context = dict(request.context)
+    summary = dict(request.context.get("vision_fact_summary") or {})
+    summary["seen_fact_ids"] = ["bit_root_page_visible"]
+    summary["fresh_fact_ids"] = []
+    summary["not_seen_fact_ids"] = []
+    request.context["vision_fact_summary"] = summary
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S18"
+    assert repaired.metadata["final_action_plan"]["targets"] == ["right_mdi_pb5"]
+    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb5"]
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb5"]
+    assert repaired.metadata["final_evidence_consistency_overlay_reason"] == "s18_bit_root_to_pb5"
+    public_text = _public_response_text(repaired)
+    assert "PB5" in public_text
+    assert "PB18" not in public_text
 
 
 def test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance() -> None:


### PR DESCRIPTION
## Summary
- make S18 state planning actionable when page state is unknown by choosing right DDI PB18/MENU
- make BIT-root-seen S18 advancement choose right_mdi_pb5 even without explicit fcsmc not_seen
- update live fixtures and assertions so S17->S18 final consistency repair produces overlay targets instead of text-only output

## Tests
- python -m pytest -q tests/test_harness_validation.py::test_plan_harness_action_uses_s18_safe_navigation_when_visual_state_unknown tests/test_harness_validation.py::test_plan_harness_action_keeps_s18_recovery_pb18_when_bit_root_not_visible tests/test_live_dcs.py::test_live_help_fixture_315_s17_complete_advances_to_s18_actionable_text tests/test_live_dcs.py::test_live_help_fixture_315_s18_advancement_uses_actionable_overlay
- python -m pytest -q tests/test_harness_validation.py::test_plan_harness_action_uses_s18_pb5_when_bit_root_seen_without_fcsmc_not_seen tests/test_harness_validation.py::test_plan_harness_action_uses_s18_safe_navigation_when_visual_state_unknown tests/test_live_dcs.py::test_live_help_fixture_315_s18_advancement_uses_pb5_when_bit_root_seen tests/test_live_dcs.py::test_live_help_fixture_315_s18_advancement_uses_actionable_overlay
- python -m pytest -q tests/test_harness_validation.py -k 's18 or final_evidence or plan_harness_action'
- python -m pytest -q tests/test_live_dcs.py -k '315_s17_complete_advances_to_s18 or 315_s18_advancement or s18 or final_evidence_consistency'
- git diff --check

Related to #314