### PR TITLE
Fix issue 298 final visual skip trace

### DIFF
--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2259,6 +2259,12 @@ def _build_harness_trace_metadata(
         "message_category": message_category,
         "vlm_call": vlm_call,
     }
+    vlm_skipped_preliminary_step = response_metadata.get("vlm_skipped_preliminary_step")
+    if isinstance(vlm_skipped_preliminary_step, str) and vlm_skipped_preliminary_step:
+        trace["vlm_skipped_preliminary_step"] = vlm_skipped_preliminary_step
+    final_step_requires_visual = response_metadata.get("final_step_requires_visual")
+    if isinstance(final_step_requires_visual, str) and final_step_requires_visual:
+        trace["final_step_requires_visual"] = final_step_requires_visual
     response.metadata["message_category"] = message_category
     response.metadata["vlm_call_status"] = vlm_call["status"]
     response.metadata["vlm_call_reason"] = vlm_call["reason"]
@@ -5540,6 +5546,31 @@ class LiveDcsTutorLoop:
             ]
         response.metadata["final_public_response"] = final_public_response
         response.metadata["final_public_instruction_category"] = final_public_response["instruction_category"]
+
+    def _annotate_final_visual_step_vlm_skip(
+        self,
+        response: TutorResponse,
+        request: TutorRequest,
+    ) -> None:
+        if response.metadata.get("vision_fact_status") != VISION_NOT_REQUIRED:
+            return
+        final_plan = response.metadata.get("harness_action_plan") or response.metadata.get("final_action_plan")
+        if not isinstance(final_plan, Mapping):
+            return
+        final_step_id = final_plan.get("step_id")
+        if not isinstance(final_step_id, str) or final_step_id not in self.vision_priority_step_set:
+            return
+        context = request.context if isinstance(request.context, Mapping) else {}
+        hint = context.get("deterministic_step_hint")
+        preliminary_step_id = request.metadata.get("fused_step_id")
+        if not isinstance(preliminary_step_id, str) or not preliminary_step_id:
+            preliminary_step_id = hint.get("inferred_step_id") if isinstance(hint, Mapping) else None
+        if not isinstance(preliminary_step_id, str) or not preliminary_step_id:
+            return
+        if preliminary_step_id != "S17" or final_step_id != "S18":
+            return
+        response.metadata["vlm_skipped_preliminary_step"] = preliminary_step_id
+        response.metadata["final_step_requires_visual"] = final_step_id
 
     def _normalize_observable_text_only_response(
         self,
@@ -9119,6 +9150,7 @@ class LiveDcsTutorLoop:
             fallback_overlay_used = bool(response.actions)
             fallback_overlay_reason = final_consistency_reason
         self._rewrite_public_target_id_action_text(response, request)
+        self._annotate_final_visual_step_vlm_skip(response, request)
 
         if mapped_meta:
             mapping_failure_codes = classify_mapping_failure(mapped_meta)

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11783,6 +11783,10 @@ def test_live_help_fixture_315_s18_advancement_uses_actionable_overlay() -> None
     assert repaired.metadata["final_evidence_consistency_overlay_reason"] == "s18_unknown_page_to_pb18"
     assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb18"]
     assert [action["target"] for action in repaired.actions] == ["right_mdi_pb18"]
+    assert repaired.metadata["vlm_skipped_preliminary_step"] == "S17"
+    assert repaired.metadata["final_step_requires_visual"] == "S18"
+    assert repaired.metadata["harness_trace"]["vlm_skipped_preliminary_step"] == "S17"
+    assert repaired.metadata["harness_trace"]["final_step_requires_visual"] == "S18"
     assert repaired.metadata["fused_step_id"] == "S18"
     assert repaired.metadata["fused_missing_conditions"] == []
     public_text = _public_response_text(repaired)
@@ -11812,6 +11816,51 @@ def test_live_help_fixture_315_s18_advancement_uses_pb5_when_bit_root_seen() -> 
     public_text = _public_response_text(repaired)
     assert "PB5" in public_text
     assert "PB18" not in public_text
+
+
+def test_live_help_visual_skip_trace_does_not_mark_s14_to_s15() -> None:
+    request = TutorRequest(
+        request_id="s14-to-s15-no-visual-skip-trace",
+        intent="help",
+        message="help",
+        context={
+            "vars": {},
+            "gates": {},
+            "deterministic_step_hint": {
+                "inferred_step_id": "S14",
+                "missing_conditions": ["vars.obogs_ready==true"],
+            },
+        },
+        metadata={"fused_step_id": "S14"},
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="S14 is complete; continue to S15.",
+        actions=[],
+        explanations=["S14 is complete; continue to S15."],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "harness_action_plan": {
+                "step_id": "S15",
+                "overlay_step_id": "S15",
+                "targets": [],
+                "text_only": True,
+                "source": "final_evidence_consistency_validator",
+            },
+            "diagnosis": {"step_id": "S15", "error_category": "OM"},
+            "next": {"step_id": "S15"},
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["final_action_plan"]["step_id"] == "S15"
+    assert "vlm_skipped_preliminary_step" not in repaired.metadata
+    assert "final_step_requires_visual" not in repaired.metadata
+    assert "vlm_skipped_preliminary_step" not in repaired.metadata["harness_trace"]
+    assert "final_step_requires_visual" not in repaired.metadata["harness_trace"]
 
 
 def test_live_help_fixture_315_s28_raw_model_repair_advances_to_s29_guidance() -> None:


### PR DESCRIPTION
## Summary
- record when VLM was skipped for preliminary S17 but final repair advances into visual-priority S18
- copy the new trace markers into harness_trace for log visibility
- add positive S17->S18 and negative S14->S15 regression coverage

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k "s18_advancement_uses_actionable_overlay or s18_advancement_uses_pb5_when_bit_root_seen or visual_skip_trace_does_not_mark_s14_to_s15"
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_issue_298_vlm_progress.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py -k "s18"

Refs #298