### PR TITLE
Fix issue 314 S08/S09/S12 substate regressions

### DIFF
--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -413,6 +413,13 @@ _S08_DISPLAY_POWER_TARGETS = (
 
 _S08_DISPLAY_POWER_VARS = ("left_ddi_on", "right_ddi_on", "mpcd_on", "hud_on")
 
+_S08_DISPLAY_POWER_STEPS = (
+    ("left_ddi_on", "left_mdi_brightness_selector", "Left DDI is still off. Turn up the left DDI brightness selector."),
+    ("right_ddi_on", "right_mdi_brightness_selector", "Right DDI is still off. Turn up the right DDI brightness selector."),
+    ("mpcd_on", "ampcd_off_brightness_knob", "AMPCD is still reported off. Turn the AMPCD brightness knob up."),
+    ("hud_on", "hud_symbology_brightness_knob", "HUD is still reported off. Turn the HUD symbology brightness knob up."),
+)
+
 _S09_NUMERIC_SEQUENCE_TARGETS = ("ufc_key_1", "ufc_key_3", "ufc_key_4", "ufc_key_0")
 
 
@@ -421,14 +428,66 @@ def _s08_state_action_plan(
     *,
     spec: StepHarnessSpec | None,
     max_overlay_targets: int,
+    recent_action_targets: Sequence[str] | None,
+    vision_seen_fact_ids: Sequence[str] | None,
+    vision_fresh_fact_ids: Sequence[str] | None,
 ) -> _StateActionPlan | None:
     allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
     if not allowed:
         return None
-    if not all(vars_map.get(var_name) is False for var_name in _S08_DISPLAY_POWER_VARS):
+    seen_or_fresh = set(_strings(vision_seen_fact_ids)) | set(_strings(vision_fresh_fact_ids))
+    recent = set(_strings(recent_action_targets))
+    mpcd_visually_alive = bool({"hsi_page_visible", "hsi_map_layer_visible"} & seen_or_fresh)
+    effective_vars = dict(vars_map)
+    s08_reasons: tuple[str, ...] = ()
+    if mpcd_visually_alive and vars_map.get("mpcd_on") is False:
+        effective_vars["mpcd_on"] = True
+        s08_reasons = ("s08_mpcd_visual_alive",)
+
+    raw_all_displays_off = all(vars_map.get(var_name) is False for var_name in _S08_DISPLAY_POWER_VARS)
+    effective_all_displays_off = all(effective_vars.get(var_name) is False for var_name in _S08_DISPLAY_POWER_VARS)
+    if not effective_all_displays_off:
+        for var_name, target, guidance in _S08_DISPLAY_POWER_STEPS:
+            if effective_vars.get(var_name) is not False:
+                continue
+            if target not in allowed:
+                return _StateActionPlan(
+                    targets=(),
+                    guidance=guidance,
+                    text_only=True,
+                    source="state_action_planner",
+                    reasons=(*s08_reasons, f"s08_power_target_unavailable:{target}"),
+                )
+            if target in recent:
+                return _StateActionPlan(
+                    targets=(),
+                    guidance=(
+                        f"{target} was just highlighted or operated, but telemetry still reports no progress. "
+                        "Wait briefly, turn it further if needed, and visually confirm the display before repeating the same highlight."
+                    ),
+                    text_only=True,
+                    source="state_action_planner_wait",
+                    reasons=(*s08_reasons, f"s08_recent_power_target_no_progress:{target}"),
+                )
+            return _StateActionPlan(
+                targets=(target,),
+                guidance=guidance,
+                text_only=False,
+                source="state_action_planner",
+                reasons=(*s08_reasons, f"s08_power_target:{target}"),
+            )
         return None
-    if max_overlay_targets < len(_S08_DISPLAY_POWER_TARGETS):
-        target = next((item for item in _S08_DISPLAY_POWER_TARGETS if item in allowed), None)
+    power_targets = (
+        tuple(
+            target
+            for var_name, target, _guidance in _S08_DISPLAY_POWER_STEPS
+            if effective_vars.get(var_name) is False
+        )
+        if raw_all_displays_off and s08_reasons
+        else _S08_DISPLAY_POWER_TARGETS
+    )
+    if max_overlay_targets < len(power_targets):
+        target = next((item for item in power_targets if item in allowed), None)
         if target is None:
             return None
         return _StateActionPlan(
@@ -439,29 +498,71 @@ def _s08_state_action_plan(
             ),
             text_only=False,
             source="state_action_planner",
-            reasons=("s08_all_displays_off_single_power_target",),
+            reasons=(*s08_reasons, "s08_all_displays_off_single_power_target"),
         )
-    if not all(target in allowed for target in _S08_DISPLAY_POWER_TARGETS):
+    if not all(target in allowed for target in power_targets):
         return _StateActionPlan(
-            targets=_S08_DISPLAY_POWER_TARGETS,
+            targets=power_targets,
             guidance=(
                 "All displays are still off. Power the left DDI, right DDI, AMPCD, and HUD brightness controls; "
                 "DDI warm-up can lag, so wait for the displays before page navigation."
             ),
             text_only=True,
             source="state_action_planner",
-            reasons=("s08_all_displays_off_power_targets_unavailable",),
+            reasons=(*s08_reasons, "s08_all_displays_off_power_targets_unavailable"),
         )
     return _StateActionPlan(
-        targets=_S08_DISPLAY_POWER_TARGETS,
+        targets=power_targets,
         guidance=(
             "All displays are still off. Power the left DDI, right DDI, AMPCD, and HUD brightness controls; "
             "DDI warm-up can lag, so wait for the displays before page navigation."
         ),
         text_only=False,
         source="state_action_planner",
-        reasons=("s08_all_displays_off_power_targets",),
+        reasons=(*s08_reasons, "s08_all_displays_off_power_targets"),
     )
+
+
+def _s12_state_action_plan(
+    vars_map: Mapping[str, Any],
+    *,
+    spec: StepHarnessSpec | None,
+    scenario_profile: str | None,
+) -> _StateActionPlan | None:
+    allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
+    if not allowed or vars_map.get("ins_fast_align_complete") is True:
+        return None
+    raw_mode = vars_map.get("ins_mode")
+    mode = int(raw_mode) if isinstance(raw_mode, (int, float)) and not isinstance(raw_mode, bool) else None
+    profile = scenario_profile if isinstance(scenario_profile, str) else None
+    if profile == "carrier":
+        mode_ready = mode == 1
+    elif profile == "airfield":
+        mode_ready = mode == 2 or vars_map.get("ins_mode_set") is True
+    else:
+        mode_ready = vars_map.get("ins_mode_cv_or_gnd") is True or vars_map.get("ins_mode_set") is True
+
+    if mode_ready and "ampcd_pb19" in allowed:
+        return _StateActionPlan(
+            targets=("ampcd_pb19",),
+            guidance="INS mode is already set for alignment; press AMPCD PB19 to start fast INS alignment.",
+            text_only=False,
+            source="state_action_planner",
+            reasons=("s12_ins_mode_set_to_ampcd_pb19",),
+        )
+    has_mode_evidence = any(
+        key in vars_map
+        for key in ("ins_mode", "ins_mode_set", "ins_mode_cv_or_gnd")
+    )
+    if profile == "airfield" and has_mode_evidence and mode != 2 and "ins_mode_knob" in allowed:
+        return _StateActionPlan(
+            targets=("ins_mode_knob",),
+            guidance="Set the INS mode knob to GND for airfield startup.",
+            text_only=False,
+            source="state_action_planner",
+            reasons=("s12_airfield_ins_knob_to_gnd",),
+        )
+    return None
 
 
 def _normalize_ufc_scratchpad_text(vars_map: Mapping[str, Any]) -> str:
@@ -601,6 +702,7 @@ def _state_action_plan(
     vision_fresh_fact_ids: Sequence[str] | None = None,
     vision_not_seen_fact_ids: Sequence[str] | None = None,
     max_overlay_targets: int = 1,
+    scenario_profile: str | None = None,
 ) -> _StateActionPlan | None:
     vars_map = _latest_vars(latest_vars)
     if step_id == "S08":
@@ -608,6 +710,9 @@ def _state_action_plan(
             vars_map,
             spec=spec,
             max_overlay_targets=max_overlay_targets,
+            recent_action_targets=recent_action_targets,
+            vision_seen_fact_ids=vision_seen_fact_ids,
+            vision_fresh_fact_ids=vision_fresh_fact_ids,
         )
     if step_id == "S09":
         return _s09_state_action_plan(
@@ -615,6 +720,12 @@ def _state_action_plan(
             spec=spec,
             recent_action_targets=recent_action_targets,
             max_overlay_targets=max_overlay_targets,
+        )
+    if step_id == "S12":
+        return _s12_state_action_plan(
+            vars_map,
+            spec=spec,
+            scenario_profile=scenario_profile,
         )
     allowed = set(spec.allowed_overlay_targets) if spec is not None else set()
     if step_id == "S10" and vars_map.get("engine_crank_left_complete") is not True:
@@ -740,6 +851,7 @@ def plan_harness_action(
     latest_vars: Mapping[str, Any] | None = None,
     evidence_packet: Any = None,
     recent_action_targets: Sequence[str] | None = None,
+    scenario_profile: str | None = None,
 ) -> HarnessActionPlan:
     reasons: list[str] = []
     rejected_model_step_id: str | None = None
@@ -796,6 +908,7 @@ def plan_harness_action(
         vision_fresh_fact_ids=vision_fresh_fact_ids,
         vision_not_seen_fact_ids=vision_not_seen_fact_ids,
         max_overlay_targets=max_overlay_targets,
+        scenario_profile=scenario_profile,
     )
     if state_plan is not None and state_plan.text_only:
         return HarnessActionPlan(
@@ -851,11 +964,14 @@ def plan_harness_action(
             use_hint = True
             source = hint_rule_source
 
-    if state_plan is not None and len(state_plan.targets) > 1 and hinted_targets != state_plan.targets:
-        if use_hint and hinted_targets:
-            reasons.append(
-                "action_hint_incomplete_for_state_plan:" + ",".join(hinted_targets)
+    if state_plan is not None and hinted_targets and hinted_targets != state_plan.targets:
+        if use_hint:
+            reason_prefix = (
+                "action_hint_incomplete_for_state_plan"
+                if len(state_plan.targets) > 1
+                else "action_hint_mismatch_for_state_plan"
             )
+            reasons.append(f"{reason_prefix}:" + ",".join(hinted_targets))
         use_hint = False
 
     if completion_advance is not None:

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -159,6 +159,22 @@ _S08_POWER_SEQUENCE: tuple[tuple[str, str, str], ...] = (
 )
 
 _TARGET_ACTION_GUIDANCE_BY_STEP: dict[tuple[str, str], dict[str, str]] = {
+    ("S08", "left_mdi_brightness_selector"): {
+        "zh": "左 DDI 还未开启。请将左 DDI 亮度/电源旋钮调到 NIGHT 或 DAY；屏幕点亮可能有短暂延迟。",
+        "en": "The left DDI is not powered. Set the left DDI brightness/power selector to NIGHT or DAY; illumination can lag briefly.",
+    },
+    ("S08", "right_mdi_brightness_selector"): {
+        "zh": "右 DDI 还未开启。请将右 DDI 亮度/电源旋钮调到 NIGHT 或 DAY；屏幕点亮可能有短暂延迟。",
+        "en": "The right DDI is not powered. Set the right DDI brightness/power selector to NIGHT or DAY; illumination can lag briefly.",
+    },
+    ("S08", "ampcd_off_brightness_knob"): {
+        "zh": "AMPCD 还未开启。请向上滚轮调高 AMPCD 亮度旋钮，并等待画面稳定点亮。",
+        "en": "The AMPCD is not powered. Mouse-wheel up on the AMPCD brightness knob and wait for the display to illuminate.",
+    },
+    ("S08", "hud_symbology_brightness_knob"): {
+        "zh": "HUD 还未开启。请向上滚轮调高 HUD 亮度，并目视确认 HUD 符号亮起。",
+        "en": "The HUD is not powered. Mouse-wheel up on the HUD brightness control and visually confirm HUD symbology appears.",
+    },
     ("S18", "right_mdi_pb5"): {
         "zh": "请在右 DDI BIT 页面左键按 PB5/FCS-MC，进入 FCS-MC BIT 页面。",
         "en": "On the right DDI BIT page, left-click PB5/FCS-MC to enter the FCS-MC BIT page.",
@@ -166,6 +182,22 @@ _TARGET_ACTION_GUIDANCE_BY_STEP: dict[tuple[str, str], dict[str, str]] = {
     ("S13", "radar_mode_knob"): {
         "zh": "请将 RADAR knob 设到 OPR：右键点击到下一挡。",
         "en": "Set the radar knob to OPR with a right-click to the next detent.",
+    },
+    ("S12", "ampcd_pb19"): {
+        "zh": "INS 已设置到对准模式。请左键按 AMPCD PB19，启动快速 INS 校准。",
+        "en": "INS is set for alignment. Left-click AMPCD PB19 to start fast INS alignment.",
+    },
+    ("S12", "ins_mode_knob"): {
+        "zh": "请将 INS 模式旋钮设置到对准挡位：机场冷启动用 GND，航母冷启动用 CV。",
+        "en": "Set the INS mode knob to the alignment detent: GND for airfield startup, CV for carrier startup.",
+    },
+    ("S09", "ufc_comm1_channel_selector_pull"): {
+        "zh": "请先拉出 UFC 的 COMM1 频道选择钮，打开预置 1 输入模式；目标频率是 134.000 MHz。",
+        "en": "Pull the UFC COMM1 channel selector to open preset 1 entry mode; the target frequency is 134.000 MHz.",
+    },
+    ("S10", "eng_crank_switch"): {
+        "zh": "当前处于 S10。请将 Engine Crank 开关拨到 LEFT/L 位置：用左键点击 ENG CRANK 开关启动左发。",
+        "en": "You are on S10. Set the Engine Crank switch to LEFT/L with a left-click to start the left engine.",
     },
     ("S20", "refuel_probe_switch"): {
         "zh": "请右键将受油管开关拨到 EXTEND，开始四落检查。",
@@ -3321,8 +3353,6 @@ def _s12_fast_align_action_hint_allowed(
 ) -> bool:
     if not isinstance(action_hint, Mapping) or action_hint.get("target") != "ampcd_pb19":
         return False
-    if "vars.ins_fast_align_complete==true" not in missing_conditions:
-        return False
     if any("vars.ins_mode" in item for item in missing_conditions):
         return False
 
@@ -3352,6 +3382,9 @@ def _s12_fast_align_action_hint_allowed(
     scenario_profile = context.get("scenario_profile")
     if not isinstance(scenario_profile, str) or not scenario_profile:
         scenario_profile = hint.get("scenario_profile")
+    recent_targets = set(_normalize_step_ui_targets(hint.get("recent_ui_targets")))
+    interacted_targets = set(_normalize_step_ui_targets(hint.get("step_interacted_targets")))
+    ins_mode_recently_handled = "ins_mode_knob" in (recent_targets | interacted_targets)
 
     ins_mode = vars_selected.get("ins_mode")
     if isinstance(ins_mode, (int, float)) and not isinstance(ins_mode, bool):
@@ -3359,6 +3392,13 @@ def _s12_fast_align_action_hint_allowed(
         if scenario_profile == "carrier":
             return normalized_mode == 1
         return normalized_mode == 2
+
+    if "vars.ins_fast_align_complete==true" not in missing_conditions:
+        return (
+            vars_selected.get("ins_mode_cv_or_gnd") is True
+            or vars_selected.get("ins_mode_set") is True
+            or (not bool(vars_selected) and ins_mode_recently_handled)
+        )
 
     return (
         vars_selected.get("ins_mode_cv_or_gnd") is True
@@ -5985,6 +6025,11 @@ class LiveDcsTutorLoop:
         inferred_step_id = hint.get("inferred_step_id")
         if response.metadata.get("refuel_probe_motion_guidance_rewritten") is True:
             return False, "refuel_probe_motion_wait_already_rewritten"
+        final_plan = response.metadata.get("harness_action_plan") or response.metadata.get("final_action_plan")
+        if inferred_step_id == "S08" and isinstance(final_plan, Mapping):
+            final_plan_source = final_plan.get("source")
+            if isinstance(final_plan_source, str) and final_plan_source.startswith("state_action_planner"):
+                return False, "state_action_planner_already_repaired"
         action_hint = hint.get("action_hint")
         if bool(hint.get("requires_visual_confirmation")) is True:
             if isinstance(action_hint, Mapping):
@@ -6472,6 +6517,9 @@ class LiveDcsTutorLoop:
         hint_recent_targets = hint.get("recent_ui_targets")
         if isinstance(hint_recent_targets, (list, tuple, set)):
             recent_action_targets.extend(item for item in hint_recent_targets if isinstance(item, str) and item)
+        hint_interacted_targets = hint.get("step_interacted_targets")
+        if isinstance(hint_interacted_targets, (list, tuple, set)):
+            recent_action_targets.extend(item for item in hint_interacted_targets if isinstance(item, str) and item)
         recent_action_targets = _dedupe_strings(recent_action_targets)
 
         missing_conditions = hint.get("missing_conditions")
@@ -6664,6 +6712,11 @@ class LiveDcsTutorLoop:
             latest_vars=vars_map,
             evidence_packet=state_action_evidence_packet,
             recent_action_targets=recent_action_targets,
+            scenario_profile=(
+                context.get("scenario_profile")
+                if isinstance(context.get("scenario_profile"), str)
+                else hint.get("scenario_profile") if isinstance(hint.get("scenario_profile"), str) else None
+            ),
         )
         plan_guidance = plan.guidance
         if (
@@ -6702,6 +6755,18 @@ class LiveDcsTutorLoop:
                 if self.lang == "zh"
                 else "Continue to S13. Set the radar knob to OPR with a right-click to the next detent."
             )
+        elif plan.step_id == "S12" and plan.targets == ("ampcd_pb19",):
+            plan_guidance = (
+                "INS 已设置到对准模式。请左键按 AMPCD PB19，启动快速 INS 校准。"
+                if self.lang == "zh"
+                else "INS is set for alignment. Left-click AMPCD PB19 to start fast INS alignment."
+            )
+        elif "s12_airfield_ins_knob_to_gnd" in plan.reasons:
+            plan_guidance = (
+                "当前处于 S12。机场冷启动请将 INS 模式旋钮设到 GND：右键点击到下一挡。"
+                if self.lang == "zh"
+                else "You are on S12. For airfield startup, set the INS mode knob to GND with a right-click to the next detent."
+            )
         elif "s31_radar_altimeter_mouse_wheel_guidance" in plan.reasons:
             plan_guidance = (
                 "现在进入 S31。请用鼠标滚轮调整雷达高度表告警高度旋钮：机场 200 ft，航母 40 ft。"
@@ -6714,7 +6779,14 @@ class LiveDcsTutorLoop:
                 if self.lang == "zh"
                 else "Continue to S32. Use the mouse wheel on the standby attitude cage knob to uncage the standby attitude indicator."
             )
-        if self.lang == "zh" and len(plan.targets) == 1:
+        skip_localized_target_hint = (
+            plan.step_id == "S08"
+            and any(
+                isinstance(reason, str) and reason.startswith("s08_power_target:")
+                for reason in plan.reasons
+            )
+        )
+        if self.lang == "zh" and len(plan.targets) == 1 and not skip_localized_target_hint:
             localized_plan_guidance = _localized_target_action_guidance(
                 plan.targets[0],
                 step_id=plan.step_id,
@@ -6792,6 +6864,31 @@ class LiveDcsTutorLoop:
                         if self.lang == "zh"
                         else "The FCS BIT is already running. Release the switch and wait for the final GO result."
                     )
+                elif any(
+                    isinstance(reason, str) and reason.startswith("s08_recent_power_target_no_progress:")
+                    for reason in plan.reasons
+                ):
+                    recent_target = next(
+                        (
+                            str(reason).split(":", 1)[1]
+                            for reason in plan.reasons
+                            if isinstance(reason, str)
+                            and reason.startswith("s08_recent_power_target_no_progress:")
+                        ),
+                        "",
+                    )
+                    if self.lang == "zh":
+                        if recent_target == "hud_symbology_brightness_knob":
+                            plan_guidance = "HUD 亮度控件刚刚已经提示或操作过，但 telemetry 仍显示 HUD 未点亮。请稍等片刻，必要时继续向上滚轮，并目视确认 HUD 亮起。"
+                        elif recent_target == "ampcd_off_brightness_knob":
+                            plan_guidance = "AMPCD 亮度控件刚刚已经提示或操作过，但 telemetry 仍显示 AMPCD 未点亮。请稍等片刻，必要时继续向上滚轮，并目视确认 AMPCD 亮起。"
+                        else:
+                            plan_guidance = "该显示亮度控件刚刚已经提示或操作过，但 telemetry 暂时还没有进展。请稍等片刻，并目视确认显示是否已经亮起。"
+                    else:
+                        plan_guidance = (
+                            "That display brightness control was just highlighted or operated, but telemetry still "
+                            "shows no progress. Wait briefly, turn it further if needed, and visually confirm the display."
+                        )
             if isinstance(plan_guidance, str) and plan_guidance:
                 original_message = response.message
                 original_explanations = list(response.explanations)
@@ -7004,9 +7101,17 @@ class LiveDcsTutorLoop:
         response.metadata["next"] = {"step_id": plan.step_id}
         response.metadata["help_response"] = planned_help_obj
         response.metadata["harness_validator_fallback_reason"] = fallback_reason
-        if isinstance(plan_guidance, str) and plan_guidance:
-            response.message = plan_guidance
-            response.explanations = [plan_guidance]
+        planned_public_guidance = plan_guidance if isinstance(plan_guidance, str) and plan_guidance else None
+        if planned_public_guidance is None:
+            planned_explanations = planned_help_obj.get("explanations")
+            if isinstance(planned_explanations, list):
+                planned_public_guidance = next(
+                    (item for item in planned_explanations if isinstance(item, str) and item),
+                    None,
+                )
+        if planned_public_guidance is not None:
+            response.message = planned_public_guidance
+            response.explanations = [planned_public_guidance]
         elif mapped.explanations and response.metadata.get("procedural_guidance_rewritten") is not True:
             response.message = mapped.explanations[0]
             response.explanations = list(mapped.explanations)
@@ -8740,6 +8845,17 @@ class LiveDcsTutorLoop:
             and _s08_power_condition_missing_for_target(fallback_target, missing_set, vars_map)
         ):
             fallback_guidance = _s08_power_guidance_for_target(fallback_target, self.lang)
+        elif (
+            overlay_step_id == "S08"
+            and len(fallback_targets_list) == 1
+            and fallback_target in {
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+            }
+        ):
+            fallback_guidance = _s08_power_guidance_for_target(fallback_target, self.lang)
         elif len(fallback_targets_list) == 1 and (
             localized_fallback_guidance := _localized_target_action_guidance(
                 fallback_target,
@@ -8898,6 +9014,10 @@ class LiveDcsTutorLoop:
             response.metadata.get("completion_conflict_rewritten") is True
             and _message_mentions_any_target(original_text, rejected_targets)
             and not _message_mentions_any_target(original_text, current_targets)
+        ) or (
+            presentation_plan_source == "validator_action_hint"
+            and fallback_step_id == "S12"
+            and fallback_targets == ["ampcd_pb19"]
         )
         if mapped.message and (not response.message or should_sync_fallback_text):
             if response.message and mapped.message != response.message:

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -751,6 +751,125 @@ def test_plan_harness_action_keeps_s08_all_displays_off_single_target_when_max_b
     assert "state_action_target_mismatch:right_mdi_brightness_selector" in plan.reasons
 
 
+def test_plan_harness_action_treats_hsi_visual_fact_as_ampcd_visible() -> None:
+    specs = {
+        "S08": _spec(
+            "S08",
+            (
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S08"].allowed_overlay_targets)
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S08",
+        model_step_id="S08",
+        proposed_overlay_targets=["ampcd_off_brightness_knob"],
+        candidate_step_ids=["S08"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=4,
+        latest_vars={
+            "left_ddi_on": True,
+            "right_ddi_on": True,
+            "mpcd_on": False,
+            "hud_on": False,
+        },
+        vision_seen_fact_ids=["hsi_page_visible", "hsi_map_layer_visible"],
+        action_hint={"target": "ampcd_off_brightness_knob"},
+        action_hint_step_ids=["S08"],
+    )
+
+    assert plan.targets == ("hud_symbology_brightness_knob",)
+    assert plan.final_action_plan_source == "state_action_planner"
+    assert "s08_mpcd_visual_alive" in plan.reasons
+    assert "state_action_target_mismatch:ampcd_off_brightness_knob" in plan.reasons
+
+
+def test_plan_harness_action_does_not_include_ampcd_when_hsi_seen_and_telemetry_all_off() -> None:
+    specs = {
+        "S08": _spec(
+            "S08",
+            (
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S08"].allowed_overlay_targets)
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S08",
+        model_step_id="S08",
+        proposed_overlay_targets=["ampcd_off_brightness_knob"],
+        candidate_step_ids=["S08"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=4,
+        latest_vars={
+            "left_ddi_on": False,
+            "right_ddi_on": False,
+            "mpcd_on": False,
+            "hud_on": False,
+        },
+        vision_seen_fact_ids=["hsi_page_visible"],
+        action_hint={"target": "ampcd_off_brightness_knob"},
+        action_hint_step_ids=["S08"],
+    )
+
+    assert "ampcd_off_brightness_knob" not in plan.targets
+    assert plan.targets == ("left_mdi_brightness_selector",)
+    assert "s08_mpcd_visual_alive" in plan.reasons
+
+
+def test_plan_harness_action_waits_when_s08_power_target_was_recently_used_without_progress() -> None:
+    specs = {
+        "S08": _spec(
+            "S08",
+            (
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+            ),
+        )
+    }
+    allowed_targets = list(specs["S08"].allowed_overlay_targets)
+
+    plan = plan_harness_action(
+        step_specs=specs,
+        inferred_step_id="S08",
+        model_step_id="S08",
+        proposed_overlay_targets=["hud_symbology_brightness_knob"],
+        candidate_step_ids=["S08"],
+        runtime_overlay_targets=allowed_targets,
+        request_overlay_targets=allowed_targets,
+        max_overlay_targets=4,
+        latest_vars={
+            "left_ddi_on": True,
+            "right_ddi_on": True,
+            "mpcd_on": True,
+            "hud_on": False,
+        },
+        recent_action_targets=["hud_symbology_brightness_knob"],
+        action_hint={"target": "hud_symbology_brightness_knob"},
+        action_hint_step_ids=["S08"],
+    )
+
+    assert plan.targets == ()
+    assert plan.text_only is True
+    assert plan.final_action_plan_source == "state_action_planner_wait"
+    assert "s08_recent_power_target_no_progress:hud_symbology_brightness_knob" in plan.reasons
+
+
 def test_plan_harness_action_uses_s09_scratchpad_state_without_live_hint() -> None:
     specs = {
         "S09": _spec(

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11126,6 +11126,7 @@ def _validate_compact_live_help_response(
     vision_status: str = "vision_not_required",
     vision_selection: HelpCycleVisionSelection | None = None,
     vision_fact_context: dict[str, Any] | None = None,
+    max_overlay_targets: int | None = None,
 ) -> TutorResponse:
     if vision_selection is None:
         vision_selection = HelpCycleVisionSelection(
@@ -11160,6 +11161,7 @@ def _validate_compact_live_help_response(
         session_id=f"sess-{request.request_id}",
         rag_top_k=0,
         lang="zh",
+        **({"max_overlay_targets": max_overlay_targets} if max_overlay_targets is not None else {}),
     )
     try:
         result = loop._validate_and_repair_live_help_response(
@@ -11446,7 +11448,7 @@ def test_live_help_fixture_312_s11_completion_advances_to_s12() -> None:
     assert repaired.metadata["harness_trace"]["vlm_call"]["frame_capture_selected"] is True
     assert repaired.metadata["harness_trace"]["vlm_call"]["extractor_used"] is False
     public_text = _public_response_text(repaired)
-    assert "ins_mode_knob" in public_text
+    assert "INS" in public_text
     assert "RPM >= 25" not in public_text
 
 
@@ -12883,6 +12885,92 @@ def test_live_help_fixture_294_s09_uses_stage_action_hint_for_next_digit() -> No
     assert repaired.message == "COMM1 preset entry shows 13; press 4 next."
 
 
+def test_live_help_fixture_314_s09_advances_after_recent_selector_interaction() -> None:
+    request = TutorRequest(
+        request_id="186759d2-5ded-4fca-98b8-bdaf13176721",
+        message="help",
+        context={
+            "vars": {
+                "comm1_freq_134_000": False,
+                "comm1_freq_value": 30500,
+                "ufc_comm1_pull_pressed": False,
+                "ufc_scratchpad_number_display": "",
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S09",
+                "overlay_step_id": "S09",
+                "missing_conditions": ["vars.comm1_freq_134_000==true"],
+                "step_ui_targets": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button",
+                ],
+                "step_interacted_targets": ["ufc_comm1_channel_selector_pull"],
+                "action_hint": {"target": "ufc_comm1_channel_selector_pull"},
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button",
+            ],
+            "rag_topk": [],
+            "vision_fact_summary": {"status": "vision_not_required", "seen_fact_ids": [], "fresh_fact_ids": []},
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="UFC COMM1 拉出：左键。",
+        actions=[],
+        explanations=["UFC COMM1 拉出：左键。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S09", "error_category": "OM"},
+                "next": {"step_id": "S09"},
+                "overlay": {
+                    "targets": ["ufc_comm1_channel_selector_pull"],
+                    "evidence": [
+                        {
+                            "target": "ufc_comm1_channel_selector_pull",
+                            "type": "var",
+                            "ref": "VARS.comm1_freq_134_000",
+                            "quote": "COMM1 is not tuned.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": ["UFC COMM1 拉出：左键。"],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(
+        request=request,
+        response=response,
+        max_overlay_targets=4,
+    )
+
+    assert repaired.metadata["final_overlay_targets"] == [
+        "ufc_key_1",
+        "ufc_key_3",
+        "ufc_key_4",
+        "ufc_key_0",
+    ]
+    assert "ufc_comm1_channel_selector_pull" not in repaired.metadata["final_overlay_targets"]
+    assert "134.000" in repaired.message
+    assert "1-3-4-0-0-0" in repaired.message
+
+
 def test_live_help_fixture_299_s12_aligns_pb19_message_and_overlay() -> None:
     request = TutorRequest(
         request_id="2c936164-c567-4865-997c-ce65b827209d",
@@ -12951,6 +13039,81 @@ def test_live_help_fixture_299_s12_aligns_pb19_message_and_overlay() -> None:
     assert repaired.metadata["final_public_response"]["message"] == repaired.message
     assert repaired.metadata["final_public_response"]["explanations"] == [repaired.message]
     assert repaired.metadata["final_public_response"]["actions"][0]["target"] == "ampcd_pb19"
+
+
+def test_live_help_fixture_314_s12_pb19_hint_repairs_without_vars_snapshot() -> None:
+    request = TutorRequest(
+        request_id="22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        message="help",
+        context={
+            "scenario_profile": "airfield",
+            "state_harness": {
+                "deterministic_candidate": {
+                    "step_id": "S12",
+                    "overlay_step_id": "S12",
+                    "missing_conditions": ["vars.rpm_l_gte_60==true"],
+                },
+            },
+            "deterministic_step_hint": {
+                "inferred_step_id": "S12",
+                "overlay_step_id": "S12",
+                "scenario_profile": "airfield",
+                "recent_ui_targets": ["ins_mode_knob"],
+                "step_ui_targets": ["ins_mode_knob", "ampcd_pb19"],
+                "action_hint": {"target": "ampcd_pb19"},
+                "observability_status": "observable",
+                "requires_visual_confirmation": False,
+            },
+            "overlay_target_allowlist": ["ins_mode_knob", "ampcd_pb19"],
+            "rag_topk": [{"snippet_id": "DCS FA-18C Early Access Guide EN_115"}],
+        },
+    )
+    response = TutorResponse(
+        status="ok",
+        in_reply_to=request.request_id,
+        message="当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。",
+        actions=[
+            {
+                "type": "overlay",
+                "intent": "highlight",
+                "target": "ins_mode_knob",
+                "evidence_refs": ["GATES.S12.completion"],
+            }
+        ],
+        explanations=["当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"],
+        metadata={
+            "provider": "mock_qwen",
+            "generation_mode": "model",
+            "help_response": {
+                "diagnosis": {"step_id": "S12", "error_category": "OM"},
+                "next": {"step_id": "S12"},
+                "overlay": {
+                    "targets": ["ins_mode_knob"],
+                    "evidence": [
+                        {
+                            "target": "ins_mode_knob",
+                            "type": "gate",
+                            "ref": "GATES.S12.completion",
+                            "quote": "INS mode must be set for alignment.",
+                            "grounding_confidence": 0.9,
+                        }
+                    ],
+                },
+                "explanations": [
+                    "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+                ],
+            },
+        },
+    )
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert [action["target"] for action in repaired.actions] == ["ampcd_pb19"]
+    assert repaired.metadata["final_overlay_targets"] == ["ampcd_pb19"]
+    assert repaired.metadata["final_action_plan"]["source"] == "validator_action_hint"
+    assert "PB19" in repaired.message
+    assert "GND 或 CV" not in repaired.message
+    assert "action_hint_target_mismatch:ins_mode_knob" in repaired.metadata["harness_validation_reasons"]
 
 
 def test_live_help_fixture_299_s12_carrier_keeps_ins_knob_until_cv_mode() -> None:
@@ -13618,7 +13781,10 @@ def test_live_loop_clears_conflicting_overlay_before_fallback_rebuilds_current_s
     assert response.metadata["fallback_overlay_used"] is True
     assert response.actions
     assert response.actions[0]["target"] == "eng_crank_switch"
-    assert response.message == "S10 is not complete yet. Please operate eng_crank_switch first and confirm that step is complete."
+    assert response.message == (
+        "S10 is not complete yet. You are on S10. Set the Engine Crank switch "
+        "to LEFT/L with a left-click to start the left engine."
+    )
     assert "vars.engine_crank_left_complete" not in response.message
     assert response.metadata["final_public_response"]["actions"][0]["target"] == "eng_crank_switch"
 


### PR DESCRIPTION
## Summary
- treat HSI/map visual facts as AMPCD-visible evidence in S08 planning and avoid repeated stale display-power highlights
- use prior selector/INS knob interactions to advance S09/S12 substates without stale generic target text
- align S10/S12/S08 fallback public text with repaired overlay targets

## Tests
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_harness_validation.py tests/test_live_dcs.py -k 'S08 or s08 or S09 or s09 or S10 or s10 or S12 or s12 or fixture_314 or fixture_299 or fixture_310 or fixture_312'
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py -k 's08 or s09 or s12' tests/test_harness_validation.py

Refs #314