### PR TITLE
Add S12 PB19 replay coverage

### DIFF
--- a/artifacts/live_fixtures/22fec7a4-958a-449b-aae3-0ccc18daa84b.fixture.json
+++ b/artifacts/live_fixtures/22fec7a4-958a-449b-aae3-0ccc18daa84b.fixture.json
@@ -1,0 +1,3181 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 1,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 5,
+        "contradiction_count": 0,
+        "first_seq": 8281,
+        "frame_count": 20,
+        "latest_seq": 8300
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+      "source_observation_seq": 8300,
+      "source_observation_t_wall": 1779220486.4850829,
+      "telemetry_window_first_seq": 8281,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 8300,
+      "telemetry_window_latest_t_wall": 1779220486.4850829,
+      "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+    },
+    "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 5,
+          "delta_dropped_count": 2,
+          "from_addr": "192.168.0.105:52142",
+          "raw_delta_count": 5,
+          "seq": 8300
+        },
+        "observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "IFEI_TEMP_L",
+              "SAI_SLIP_BALL",
+              "HYD_IND_LEFT"
+            ],
+            "delta_count": 3,
+            "dropped_stats": {
+              "dropped_by_reason": {
+                "blacklist": 2
+              },
+              "dropped_total": 2
+            },
+            "raw_delta_count": 5,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 101,
+                "key": "IFEI_TEMP_L",
+                "ui_targets": [],
+                "value": "429"
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "SAI_SLIP_BALL",
+                "ui_targets": [],
+                "value": 32802
+              },
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_LEFT",
+                "ui_targets": [],
+                "value": 39038
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 8300,
+          "t_wall": 1779220486.4850829,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": false,
+            "hook_handle_value": 1,
+            "hook_retracted": true,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 65,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": false,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 429,
+            "temp_r": 296,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T19:54:46.485082+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 5,
+      "contradiction_count": 0,
+      "first_seq": 8281,
+      "frame_count": 20,
+      "latest_seq": 8300
+    },
+    "vision": {
+      "frame_ids": [
+        "1779220486535_000401"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779220486535_000401",
+        "frame_ids": [
+          "1779220486535_000401"
+        ],
+        "frame_stale": false,
+        "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+        "observation_seq": 8300,
+        "observation_t_wall_ms": 1779220486485,
+        "observation_t_wall_s": 1779220486.4850829,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779220486535,
+            "channel": "composite_panel",
+            "frame_id": "1779220486535_000401",
+            "frame_seq": 401,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779220486535_000401_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779220486535_000401.png",
+            "sync_delta_ms": 85,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 85,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779220486535,
+          "channel": "composite_panel",
+          "frame_id": "1779220486535_000401",
+          "frame_seq": 401,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779220486535_000401_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779220486535_000401.png",
+          "sync_delta_ms": 85,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779220486450,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779220486535_000401"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        "kind": "tutor_request",
+        "lineno": 9085,
+        "metadata": {
+          "frame_id": "1779220486535_000401",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 85,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779220486535_000401"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 2,
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "ampcd_pb19"
+              },
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S12",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S12",
+              "recent_ui_targets": [
+                "ins_mode_knob"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 5,
+                "contradiction_count": 0,
+                "first_seq": 8281,
+                "frame_count": 20,
+                "latest_seq": 8300
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+              "source_observation_seq": 8300,
+              "source_observation_t_wall": 1779220486.4850829,
+              "telemetry_window_first_seq": 8281,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 8300,
+              "telemetry_window_latest_t_wall": 1779220486.4850829,
+              "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_6",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "score": 29.945610099394816,
+                "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+                "snippet_id": "Appendix - Training Task Syllabus_6"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_5",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.3 Order Error (OR)",
+                "score": 25.869688205086103,
+                "section": "2.3 Order Error (OR)",
+                "snippet_id": "fa18c_error_coding_guide_5"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 19.296779946262046,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_115",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 116,
+                "score": 18.45452523872647,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_115"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_95",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 96,
+                "score": 18.313346294707916,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_95"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.rpm_l_gte_60==true"
+                ],
+                "overlay_step_id": "S12",
+                "role": "candidate_not_authoritative",
+                "step_id": "S12"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 8300,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [
+                  {
+                    "first_value": 800,
+                    "last_value": 700,
+                    "latest_transition_age_s": 0.393,
+                    "transition_count": 1,
+                    "var": "ff_l"
+                  },
+                  {
+                    "first_value": 0,
+                    "last_value": 2,
+                    "latest_transition_age_s": 0.433,
+                    "transition_count": 2,
+                    "var": "ins_mode"
+                  },
+                  {
+                    "first_value": false,
+                    "last_value": true,
+                    "latest_transition_age_s": 0.61,
+                    "transition_count": 1,
+                    "var": "ins_mode_cv_or_gnd"
+                  },
+                  {
+                    "first_value": false,
+                    "last_value": true,
+                    "latest_transition_age_s": 0.61,
+                    "transition_count": 1,
+                    "var": "ins_mode_set"
+                  },
+                  {
+                    "first_value": 503,
+                    "last_value": 429,
+                    "latest_transition_age_s": 0.0,
+                    "transition_count": 19,
+                    "var": "temp_l"
+                  }
+                ],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 8281,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 8300,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 8300,
+                "latest_t_wall": 1779220486.4850829,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.682
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779220486535_000401",
+              "frame_ids": [
+                "1779220486535_000401"
+              ],
+              "frame_stale": false,
+              "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+              "observation_seq": 8300,
+              "observation_t_wall_ms": 1779220486485,
+              "observation_t_wall_s": 1779220486.4850829,
+              "status": "partial",
+              "sync_delta_ms": 85,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779220486450,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779220486535_000401"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 5,
+                "contradiction_count": 0,
+                "first_seq": 8281,
+                "frame_count": 20,
+                "latest_seq": 8300
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+              "source_observation_seq": 8300,
+              "source_observation_t_wall": 1779220486.4850829,
+              "telemetry_window_first_seq": 8281,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 8300,
+              "telemetry_window_latest_t_wall": 1779220486.4850829,
+              "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "frame_id": "1779220486535_000401",
+            "fused_missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "fused_step_id": "S12",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "Appendix - Training Task Syllabus_6",
+              "fa18c_error_coding_guide_5",
+              "fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN_115",
+              "DCS FA-18C Early Access Guide EN_95"
+            ],
+            "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+            "prompt_tokens_est": 5555,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "source_chunk_refs": [
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_5",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_115",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_95"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 85,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779220486535_000401"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779220486535_000401"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+          "request_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+          "timestamp": "2026-05-19T19:54:46.986957+00:00",
+          "version": "v1"
+        },
+        "related_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        "vision_refs": [
+          "1779220486535_000401"
+        ]
+      },
+      {
+        "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        "kind": "overlay_requested",
+        "lineno": 9086,
+        "metadata": {
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779220486535_000401",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 85,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779220486535_000401"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "5f25e1da-af62-4fc3-bc44-7e999b5e487a",
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779220486535_000401",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "schema_version": "v2",
+          "sync_delta_ms": 85,
+          "target": "pnt_443",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779220486535_000401"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        "kind": "tutor_response",
+        "lineno": 9087,
+        "metadata": {
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779220486535_000401",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "sync_delta_ms": 85,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779220486535_000401"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_443",
+              "evidence_refs": [
+                "GATES.S12.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ins_mode_knob"
+              ],
+              "frame_id": "1779220486535_000401",
+              "fused_missing_conditions": [
+                "vars.rpm_l_gte_60==true"
+              ],
+              "fused_step_id": "S12",
+              "generation_mode": "model",
+              "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 85,
+              "target": "ins_mode_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779220486535_000401"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+          ],
+          "in_reply_to": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+          "message": "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。",
+          "metadata": {
+            "allowed_evidence_ref_count": 120,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "2a500d18-00be-4587-beb6-87b8bd34beb9",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+            },
+            "delta_dropped_count": 2,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "ins_mode_knob"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "diagnosis": {
+              "error_category": "CO",
+              "step_id": "S12"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+              "source_observation_seq": 8300,
+              "source_observation_t_wall": 1779220486.4850829,
+              "telemetry_window_first_seq": 8281,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 8300,
+              "telemetry_window_latest_t_wall": 1779220486.4850829,
+              "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "overlay_step_id": "S12",
+              "source": "model",
+              "step_id": "S12",
+              "targets": [
+                "ins_mode_knob"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "model",
+            "final_evidence_consistency_precondition_reasons": [
+              "precondition_satisfied:vars.rpm_l_gte_60==true"
+            ],
+            "final_evidence_consistency_precondition_satisfied": true,
+            "final_overlay_targets": [
+              "ins_mode_knob"
+            ],
+            "final_public_instruction_category": "actionable",
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_443",
+                  "evidence_refs": [
+                    "GATES.S12.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ins_mode_knob"
+                  ],
+                  "frame_id": "1779220486535_000401",
+                  "fused_missing_conditions": [
+                    "vars.rpm_l_gte_60==true"
+                  ],
+                  "fused_step_id": "S12",
+                  "generation_mode": "model",
+                  "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "model",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 85,
+                  "target": "ins_mode_knob",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779220486535_000401"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+              ],
+              "instruction_category": "actionable",
+              "message": "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。",
+              "next": {
+                "step_id": "S12"
+              }
+            },
+            "frame_id": "1779220486535_000401",
+            "fused_missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "fused_step_id": "S12",
+            "generation_mode": "model",
+            "generation_prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+            "generation_prompt_tokens_est": 5555,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S12",
+              "source": "model",
+              "step_id": "S12",
+              "targets": [
+                "ins_mode_knob"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "GATES.S13.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "obogs_control_switch",
+                    "obogs_flow_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S14",
+                  "supporting_evidence_refs": [
+                    "GATES.S14.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "fcs_reset_button",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S15",
+                  "supporting_evidence_refs": [
+                    "GATES.S15.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "flap_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S16",
+                  "supporting_evidence_refs": [
+                    "GATES.S16.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "takeoff_trim_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S17",
+                  "supporting_evidence_refs": [
+                    "GATES.S17.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.5,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "recent_action",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "RECENT_ACTIONS.ins_mode_knob"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "ins_mode_knob",
+                  "ampcd_pb19"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S12",
+                "supporting_evidence_refs": [
+                  "GATES.S12.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 1,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 5,
+                  "contradiction_count": 0,
+                  "first_seq": 8281,
+                  "frame_count": 20,
+                  "latest_seq": 8300
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+                "source_observation_seq": 8300,
+                "source_observation_t_wall": 1779220486.4850829,
+                "telemetry_window_first_seq": 8281,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 8300,
+                "telemetry_window_latest_t_wall": 1779220486.4850829,
+                "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "overlay_step_id": "S12",
+                "source": "model",
+                "step_id": "S12",
+                "targets": [
+                  "ins_mode_knob"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ins_mode_knob"
+              ],
+              "message_category": "model",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S12.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "ins_mode_knob"
+                ],
+                "status": "ok",
+                "step_id": "S12"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": false,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": null
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+                "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "precondition_satisfied:vars.rpm_l_gte_60==true"
+                ],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779220486535_000401"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 85,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "precondition_satisfied:vars.rpm_l_gte_60==true"
+            ],
+            "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+              ],
+              "next": {
+                "step_id": "S12"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S12.completion",
+                    "target": "ins_mode_knob",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ins_mode_knob"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+              ],
+              "next": {
+                "step_id": "S12"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S12.completion",
+                    "target": "ins_mode_knob",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ins_mode_knob"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4326,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "model",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S12"
+            },
+            "model_raw_explanations": [
+              "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S12"
+              },
+              "explanations": [
+                "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+              ],
+              "next": {
+                "step_id": "S12"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S12.completion",
+                    "target": "ins_mode_knob",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ins_mode_knob"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S12"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779220486535_000401"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779220486535_000401",
+            "next": {
+              "step_id": "S12"
+            },
+            "observability_status": "observable",
+            "precondition_satisfied_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "prompt_budget_used": 5426,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.rpm_l_gte_60",
+                "GATES.S12.completion",
+                "GATES.S12.precondition",
+                "GATES.S13.completion",
+                "GATES.S14.completion",
+                "GATES.S14.precondition",
+                "GATES.S15.completion",
+                "GATES.S16.completion",
+                "GATES.S17.completion",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_5",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_115",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_95"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 18,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "ampcd_pb19",
+              "prompt_chars": 22217,
+              "prompt_tokens_est": 5555,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "Appendix - Training Task Syllabus_6",
+                "fa18c_error_coding_guide_5",
+                "fa18c_startup_master_1",
+                "DCS FA-18C Early Access Guide EN_115",
+                "DCS FA-18C Early Access Guide EN_95"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+            "prompt_tokens_est": 5555,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+            "request_prompt_tokens_est": 5555,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 120,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S12"
+              },
+              "next": {
+                "step_id": "S12"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+              "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+            },
+            "state_key": "1eba64e1cc87fdab971202cdd0010301a729c47508779e7bde83f18da5dd5822",
+            "sync_delta_ms": 85,
+            "validator_rejected": false,
+            "vision": {
+              "frame_id": "1779220486535_000401",
+              "frame_ids": [
+                "1779220486535_000401"
+              ],
+              "frame_stale": false,
+              "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+              "observation_seq": 8300,
+              "observation_t_wall_ms": 1779220486485,
+              "observation_t_wall_s": 1779220486.4850829,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779220486535,
+                  "channel": "composite_panel",
+                  "frame_id": "1779220486535_000401",
+                  "frame_seq": 401,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779220486535_000401_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779220486535_000401.png",
+                  "sync_delta_ms": 85,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 85,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779220486535,
+                "channel": "composite_panel",
+                "frame_id": "1779220486535_000401",
+                "frame_seq": 401,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779220486535_000401_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779220486535_000401.png",
+                "sync_delta_ms": 85,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779220486450,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S12"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779220486535_000401"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779220486535_000401"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "16e4cace-8a15-4a94-b6d0-bf66c484e023",
+          "status": "ok",
+          "timestamp": "2026-05-19T19:54:51.314529+00:00",
+          "version": "v1"
+        },
+        "related_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        "vision_refs": [
+          "1779220486535_000401"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 2,
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "ampcd_pb19"
+          },
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S12",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S12",
+          "recent_ui_targets": [
+            "ins_mode_knob"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 5,
+            "contradiction_count": 0,
+            "first_seq": 8281,
+            "frame_count": 20,
+            "latest_seq": 8300
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+          "source_observation_seq": 8300,
+          "source_observation_t_wall": 1779220486.4850829,
+          "telemetry_window_first_seq": 8281,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 8300,
+          "telemetry_window_latest_t_wall": 1779220486.4850829,
+          "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_6",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "score": 29.945610099394816,
+            "section": "Phase P4 – Left Engine Start & Core Systems (S10–S14)",
+            "snippet_id": "Appendix - Training Task Syllabus_6"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_5",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.3 Order Error (OR)",
+            "score": 25.869688205086103,
+            "section": "2.3 Order Error (OR)",
+            "snippet_id": "fa18c_error_coding_guide_5"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 19.296779946262046,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_115",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 116,
+            "score": 18.45452523872647,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_115"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_95",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 96,
+            "score": 18.313346294707916,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_95"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.rpm_l_gte_60==true"
+            ],
+            "overlay_step_id": "S12",
+            "role": "candidate_not_authoritative",
+            "step_id": "S12"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 8300,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [
+              {
+                "first_value": 800,
+                "last_value": 700,
+                "latest_transition_age_s": 0.393,
+                "transition_count": 1,
+                "var": "ff_l"
+              },
+              {
+                "first_value": 0,
+                "last_value": 2,
+                "latest_transition_age_s": 0.433,
+                "transition_count": 2,
+                "var": "ins_mode"
+              },
+              {
+                "first_value": false,
+                "last_value": true,
+                "latest_transition_age_s": 0.61,
+                "transition_count": 1,
+                "var": "ins_mode_cv_or_gnd"
+              },
+              {
+                "first_value": false,
+                "last_value": true,
+                "latest_transition_age_s": 0.61,
+                "transition_count": 1,
+                "var": "ins_mode_set"
+              },
+              {
+                "first_value": 503,
+                "last_value": 429,
+                "latest_transition_age_s": 0.0,
+                "transition_count": 19,
+                "var": "temp_l"
+              }
+            ],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 8281,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 8300,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 8300,
+            "latest_t_wall": 1779220486.4850829,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.682
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779220486535_000401",
+          "frame_ids": [
+            "1779220486535_000401"
+          ],
+          "frame_stale": false,
+          "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+          "observation_seq": 8300,
+          "observation_t_wall_ms": 1779220486485,
+          "observation_t_wall_s": 1779220486.4850829,
+          "status": "partial",
+          "sync_delta_ms": 85,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779220486450,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779220486535_000401"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 5,
+            "contradiction_count": 0,
+            "first_seq": 8281,
+            "frame_count": 20,
+            "latest_seq": 8300
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+          "source_observation_seq": 8300,
+          "source_observation_t_wall": 1779220486.4850829,
+          "telemetry_window_first_seq": 8281,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 8300,
+          "telemetry_window_latest_t_wall": 1779220486.4850829,
+          "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "frame_id": "1779220486535_000401",
+        "fused_missing_conditions": [
+          "vars.rpm_l_gte_60==true"
+        ],
+        "fused_step_id": "S12",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "Appendix - Training Task Syllabus_6",
+          "fa18c_error_coding_guide_5",
+          "fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN_115",
+          "DCS FA-18C Early Access Guide EN_95"
+        ],
+        "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+        "prompt_tokens_est": 5555,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "source_chunk_refs": [
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_6",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_5",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_115",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_95"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 85,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779220486535_000401"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779220486535_000401"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+      "request_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+      "timestamp": "2026-05-19T19:54:46.986957+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_443",
+          "evidence_refs": [
+            "GATES.S12.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "frame_id": "1779220486535_000401",
+          "fused_missing_conditions": [
+            "vars.rpm_l_gte_60==true"
+          ],
+          "fused_step_id": "S12",
+          "generation_mode": "model",
+          "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "model",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 85,
+          "target": "ins_mode_knob",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779220486535_000401"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+      ],
+      "in_reply_to": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+      "message": "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。",
+      "metadata": {
+        "allowed_evidence_ref_count": 120,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "2a500d18-00be-4587-beb6-87b8bd34beb9",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+        },
+        "delta_dropped_count": 2,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "ins_mode_knob"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "diagnosis": {
+          "error_category": "CO",
+          "step_id": "S12"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+          "source_observation_seq": 8300,
+          "source_observation_t_wall": 1779220486.4850829,
+          "telemetry_window_first_seq": 8281,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 8300,
+          "telemetry_window_latest_t_wall": 1779220486.4850829,
+          "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "overlay_step_id": "S12",
+          "source": "model",
+          "step_id": "S12",
+          "targets": [
+            "ins_mode_knob"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "model",
+        "final_evidence_consistency_precondition_reasons": [
+          "precondition_satisfied:vars.rpm_l_gte_60==true"
+        ],
+        "final_evidence_consistency_precondition_satisfied": true,
+        "final_overlay_targets": [
+          "ins_mode_knob"
+        ],
+        "final_public_instruction_category": "actionable",
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_443",
+              "evidence_refs": [
+                "GATES.S12.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ins_mode_knob"
+              ],
+              "frame_id": "1779220486535_000401",
+              "fused_missing_conditions": [
+                "vars.rpm_l_gte_60==true"
+              ],
+              "fused_step_id": "S12",
+              "generation_mode": "model",
+              "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "model",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 85,
+              "target": "ins_mode_knob",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779220486535_000401"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+          ],
+          "instruction_category": "actionable",
+          "message": "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。",
+          "next": {
+            "step_id": "S12"
+          }
+        },
+        "frame_id": "1779220486535_000401",
+        "fused_missing_conditions": [
+          "vars.rpm_l_gte_60==true"
+        ],
+        "fused_step_id": "S12",
+        "generation_mode": "model",
+        "generation_prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+        "generation_prompt_tokens_est": 5555,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S12",
+          "source": "model",
+          "step_id": "S12",
+          "targets": [
+            "ins_mode_knob"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "GATES.S13.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "obogs_control_switch",
+                "obogs_flow_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S14",
+              "supporting_evidence_refs": [
+                "GATES.S14.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "fcs_reset_button",
+                "left_mdi_pb18",
+                "left_mdi_pb15"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S15",
+              "supporting_evidence_refs": [
+                "GATES.S15.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "flap_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S16",
+              "supporting_evidence_refs": [
+                "GATES.S16.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "takeoff_trim_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S17",
+              "supporting_evidence_refs": [
+                "GATES.S17.completion"
+              ]
+            },
+            {
+              "confidence": 0.5,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "recent_action",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "RECENT_ACTIONS.ins_mode_knob"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "ins_mode_knob",
+              "ampcd_pb19"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S12",
+            "supporting_evidence_refs": [
+              "GATES.S12.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 1,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 5,
+              "contradiction_count": 0,
+              "first_seq": 8281,
+              "frame_count": 20,
+              "latest_seq": 8300
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+            "source_observation_seq": 8300,
+            "source_observation_t_wall": 1779220486.4850829,
+            "telemetry_window_first_seq": 8281,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 8300,
+            "telemetry_window_latest_t_wall": 1779220486.4850829,
+            "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "overlay_step_id": "S12",
+            "source": "model",
+            "step_id": "S12",
+            "targets": [
+              "ins_mode_knob"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ins_mode_knob"
+          ],
+          "message_category": "model",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S12.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "ins_mode_knob"
+            ],
+            "status": "ok",
+            "step_id": "S12"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": false,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": null
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+            "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "precondition_satisfied:vars.rpm_l_gte_60==true"
+            ],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779220486535_000401"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 85,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "precondition_satisfied:vars.rpm_l_gte_60==true"
+        ],
+        "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+          ],
+          "next": {
+            "step_id": "S12"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S12.completion",
+                "target": "ins_mode_knob",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ins_mode_knob"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+          ],
+          "next": {
+            "step_id": "S12"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S12.completion",
+                "target": "ins_mode_knob",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ins_mode_knob"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4326,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "model",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S12"
+        },
+        "model_raw_explanations": [
+          "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S12"
+          },
+          "explanations": [
+            "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+          ],
+          "next": {
+            "step_id": "S12"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S12.completion",
+                "target": "ins_mode_knob",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ins_mode_knob"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S12"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779220486535_000401"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779220486535_000401",
+        "next": {
+          "step_id": "S12"
+        },
+        "observability_status": "observable",
+        "precondition_satisfied_conditions": [
+          "vars.rpm_l_gte_60==true"
+        ],
+        "prompt_budget_used": 5426,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.rpm_l_gte_60",
+            "GATES.S12.completion",
+            "GATES.S12.precondition",
+            "GATES.S13.completion",
+            "GATES.S14.completion",
+            "GATES.S14.precondition",
+            "GATES.S15.completion",
+            "GATES.S16.completion",
+            "GATES.S17.completion",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_6",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_5",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_115",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_95"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 18,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "ampcd_pb19",
+          "prompt_chars": 22217,
+          "prompt_tokens_est": 5555,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "Appendix - Training Task Syllabus_6",
+            "fa18c_error_coding_guide_5",
+            "fa18c_startup_master_1",
+            "DCS FA-18C Early Access Guide EN_115",
+            "DCS FA-18C Early Access Guide EN_95"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+        "prompt_tokens_est": 5555,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "44885cca912d5a559196c574fd5f225771ef9af993ffc1e0ce58c8e68bc5ab7e",
+        "request_prompt_tokens_est": 5555,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 120,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S12"
+          },
+          "next": {
+            "step_id": "S12"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+          "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+        },
+        "state_key": "1eba64e1cc87fdab971202cdd0010301a729c47508779e7bde83f18da5dd5822",
+        "sync_delta_ms": 85,
+        "validator_rejected": false,
+        "vision": {
+          "frame_id": "1779220486535_000401",
+          "frame_ids": [
+            "1779220486535_000401"
+          ],
+          "frame_stale": false,
+          "observation_ref": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+          "observation_seq": 8300,
+          "observation_t_wall_ms": 1779220486485,
+          "observation_t_wall_s": 1779220486.4850829,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779220486535,
+              "channel": "composite_panel",
+              "frame_id": "1779220486535_000401",
+              "frame_seq": 401,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779220486535_000401_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779220486535_000401.png",
+              "sync_delta_ms": 85,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 85,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779220486535,
+            "channel": "composite_panel",
+            "frame_id": "1779220486535_000401",
+            "frame_seq": 401,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779220486535_000401_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779220486535_000401.png",
+            "sync_delta_ms": 85,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779220486450,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S12"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779220486535_000401"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779220486535_000401"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "16e4cace-8a15-4a94-b6d0-bf66c484e023",
+      "status": "ok",
+      "timestamp": "2026-05-19T19:54:51.314529+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S12",
+    "expected_overlay_target_ids": [
+      "ampcd_pb19"
+    ],
+    "final_response_source": "validator_action_hint",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "obogs_control_switch",
+          "obogs_flow_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S14",
+        "supporting_evidence_refs": [
+          "GATES.S14.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "fcs_reset_button",
+          "left_mdi_pb18",
+          "left_mdi_pb15"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S15",
+        "supporting_evidence_refs": [
+          "GATES.S15.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "flap_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S16",
+        "supporting_evidence_refs": [
+          "GATES.S16.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "takeoff_trim_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S17",
+        "supporting_evidence_refs": [
+          "GATES.S17.completion"
+        ]
+      },
+      {
+        "confidence": 0.5,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "recent_action",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "RECENT_ACTIONS.ins_mode_knob"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+      "overlay_step_id": "S12",
+      "source": "model",
+      "step_id": "S12",
+      "targets": [
+        "ins_mode_knob"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S12.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "ins_mode_knob"
+      ],
+      "status": "ok",
+      "step_id": "S12"
+    },
+    "repair_result": {
+      "applied": false,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": null
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "GATES.S13.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "obogs_control_switch",
+            "obogs_flow_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S14",
+          "supporting_evidence_refs": [
+            "GATES.S14.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "fcs_reset_button",
+            "left_mdi_pb18",
+            "left_mdi_pb15"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S15",
+          "supporting_evidence_refs": [
+            "GATES.S15.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "flap_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S16",
+          "supporting_evidence_refs": [
+            "GATES.S16.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "takeoff_trim_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S17",
+          "supporting_evidence_refs": [
+            "GATES.S17.completion"
+          ]
+        },
+        {
+          "confidence": 0.5,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "recent_action",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "RECENT_ACTIONS.ins_mode_knob"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 1,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 5,
+          "contradiction_count": 0,
+          "first_seq": 8281,
+          "frame_count": 20,
+          "latest_seq": 8300
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "final_decision_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "model_request_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "source_observation_id": "aa134f64-dd8c-488b-b47c-a8dfbbe3b717",
+        "source_observation_seq": 8300,
+        "source_observation_t_wall": 1779220486.4850829,
+        "telemetry_window_first_seq": 8281,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 8300,
+        "telemetry_window_latest_t_wall": 1779220486.4850829,
+        "validator_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "overlay_step_id": "S12",
+        "source": "model",
+        "step_id": "S12",
+        "targets": [
+          "ins_mode_knob"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ins_mode_knob"
+      ],
+      "message_category": "model",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S12.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "ins_mode_knob"
+        ],
+        "status": "ok",
+        "step_id": "S12"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": false,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": null
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "final_decision": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "model_request": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b",
+        "validator": "643766db2eb8f2053e2bf6cf2e6403c88e62f3337eeae9c8299a96b8adb4e95b"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "precondition_satisfied:vars.rpm_l_gte_60==true"
+        ],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779220486535_000401"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 85,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "precondition_satisfied:vars.rpm_l_gte_60==true"
+      ],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S12"
+      },
+      "explanations": [
+        "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+      ],
+      "next": {
+        "step_id": "S12"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S12.completion",
+            "target": "ins_mode_knob",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "ins_mode_knob"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S12"
+      },
+      "explanations": [
+        "当前处于 S12 步骤。请右键旋转 INS 模式旋钮至下一挡位（通常为 GND 或 CV），以开始 INS 对准。"
+      ],
+      "next": {
+        "step_id": "S12"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S12.completion",
+            "target": "ins_mode_knob",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "ins_mode_knob"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "22fec7a4-958a-449b-aae3-0ccc18daa84b",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 16708,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_194636.jsonl"
+  }
+}

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -3277,8 +3277,8 @@ def test_live_loop_replaces_rejected_future_step_overlay_with_safe_current_step_
         "You are on S03. Left-click the APU switch to ON, then wait for the green APU READY light."
     )
     assert tutor_response_payload["explanations"] == [tutor_response_payload["message"]]
-    assert meta["fallback_message"] == "Please operate apu_switch first."
-    assert "Please operate apu_switch first." in meta["fallback_explanations"]
+    assert meta["fallback_message"] == "Set APU to ON with a left-click."
+    assert "Set APU to ON with a left-click." in meta["fallback_explanations"]
     assert meta["model_raw_help_response"]["next"]["step_id"] == "S04"
     assert meta["final_public_response"]["message"] == tutor_response_payload["message"]
 
@@ -9738,7 +9738,8 @@ def test_live_loop_audit_fields_flow_into_request_response_and_overlay(monkeypat
     assert request_meta["vision_fallback_reason"] is None
     assert request_meta["layout_id"] == "fa18c_composite_panel_v2"
     assert response_meta["fused_step_id"] == request_meta["fused_step_id"]
-    assert response_meta["fused_missing_conditions"] == request_meta["fused_missing_conditions"]
+    assert request_meta["fused_missing_conditions"] == ["vars.fire_test_b_complete==true"]
+    assert response_meta["fused_missing_conditions"] == []
     assert overlay_payload["vision_used"] is True
     assert overlay_payload["frame_id"] == "10000_000123"
     assert overlay_payload["sync_delta_ms"] == 0
@@ -13114,6 +13115,30 @@ def test_live_help_fixture_314_s12_pb19_hint_repairs_without_vars_snapshot() -> 
     assert "PB19" in repaired.message
     assert "GND 或 CV" not in repaired.message
     assert "action_hint_target_mismatch:ins_mode_knob" in repaired.metadata["harness_validation_reasons"]
+
+
+def test_live_help_fixture_315_s12_uses_pb19_after_ins_mode_set() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/22fec7a4-958a-449b-aae3-0ccc18daa84b.fixture.json"
+    )
+    request, response = _fixture_request_and_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    _assert_live_fixture_expectations(fixture, repaired)
+    assert repaired.metadata["final_action_plan"]["targets"] == ["ampcd_pb19"]
+    assert "PB19" in repaired.message
+    assert "GND 或 CV" not in repaired.message
+    assert "action_hint_target_mismatch:ins_mode_knob" in repaired.metadata["harness_validation_reasons"]
+    assert "precondition_satisfied:vars.rpm_l_gte_60==true" in repaired.metadata[
+        "harness_validation_reasons"
+    ]
+    final_public_actions = repaired.metadata["final_public_response"]["actions"]
+    assert [action["target"] for action in final_public_actions] == ["ampcd_pb19"]
+    for action in final_public_actions:
+        assert action["fused_step_id"] == "S12"
+        assert action["fused_missing_conditions"] == []
+        assert "vars.rpm_l_gte_60==true" not in action["fused_missing_conditions"]
 
 
 def test_live_help_fixture_299_s12_carrier_keeps_ins_knob_until_cv_mode() -> None:


### PR DESCRIPTION
## Summary
- add the #315 live fixture for request 22fec7a4 from logs/live_help_harness_smoke_20260519_194636.jsonl
- assert S12 repairs to AMPCD PB19 after INS mode is already set, and that final public action metadata clears satisfied RPM missing predicates
- sync two full-suite expectations with recent final-plan restamp/fallback guidance behavior

## Tests
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_live_dcs.py::test_live_help_fixture_315_s12_uses_pb19_after_ins_mode_set tests/test_live_dcs.py::test_live_loop_replaces_rejected_future_step_overlay_with_safe_current_step_overlay tests/test_live_dcs.py::test_live_loop_audit_fields_flow_into_request_response_and_overlay
- PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=/tmp/pytest-iefmmq-full
- python3 tools/ci_guard.py