### PR TITLE
Fix issue 314 S18 default PB5 planning

### DIFF
--- a/artifacts/live_fixtures/82d871be-26ac-41f4-a722-8141efcd8f87.fixture.json
+++ b/artifacts/live_fixtures/82d871be-26ac-41f4-a722-8141efcd8f87.fixture.json
@@ -2343,7 +2343,7 @@
   "expectations": {
     "expected_final_step_id": "S18",
     "expected_overlay_target_ids": [
-      "right_mdi_pb18"
+      "right_mdi_pb5"
     ],
     "final_response_source": "final_evidence_consistency_validator",
     "llm_decision_status": "repaired",

--- a/artifacts/live_fixtures/f92855c5-6ed1-4101-899c-72bd8d8e8e25.fixture.json
+++ b/artifacts/live_fixtures/f92855c5-6ed1-4101-899c-72bd8d8e8e25.fixture.json
@@ -2387,7 +2387,7 @@
   "expectations": {
     "expected_final_step_id": "S18",
     "expected_overlay_target_ids": [
-      "right_mdi_pb18"
+      "right_mdi_pb5"
     ],
     "final_response_source": "final_evidence_consistency_validator",
     "llm_decision_status": "repaired",

--- a/core/harness_validation.py
+++ b/core/harness_validation.py
@@ -788,22 +788,56 @@ def _state_action_plan(
 
     seen_or_fresh = set(_strings(vision_seen_fact_ids)) | set(_strings(vision_fresh_fact_ids))
     not_seen = set(_strings(vision_not_seen_fact_ids))
-    if step_id == "S18" and "bit_root_page_visible" in seen_or_fresh:
+    if step_id == "S18":
+        if "bit_root_page_visible" in not_seen:
+            if "right_mdi_pb18" in allowed:
+                return _StateActionPlan(
+                    targets=("right_mdi_pb18",),
+                    guidance=(
+                        "Right DDI is not on the BIT root page; press Right DDI PB18/MENU "
+                        "to recover the BIT page first."
+                    ),
+                    text_only=False,
+                    source="state_action_planner",
+                    reasons=("s18_not_bit_root_to_pb18",),
+                )
+            return _StateActionPlan(
+                targets=(),
+                guidance=(
+                    "Right DDI is not on the BIT root page; PB18/MENU is required for recovery, "
+                    "but that target is not available."
+                ),
+                text_only=True,
+                source="state_action_planner",
+                reasons=("target_not_allowed:right_mdi_pb18",),
+            )
         if "right_mdi_pb5" in allowed:
+            reason = (
+                "s18_bit_root_to_pb5"
+                if "bit_root_page_visible" in seen_or_fresh
+                else "s18_default_bit_root_to_pb5"
+            )
+            guidance = (
+                "BIT root is visible; press Right DDI PB5/FCS-MC to enter the FCS-MC BIT page."
+                if "bit_root_page_visible" in seen_or_fresh
+                else (
+                    "In the normal cold-start flow the right DDI defaults to the BIT root page; "
+                    "press Right DDI PB5/FCS-MC to enter the FCS-MC BIT page."
+                )
+            )
             return _StateActionPlan(
                 targets=("right_mdi_pb5",),
-                guidance="BIT root is visible; press Right DDI PB5/FCS-MC to enter the FCS-MC BIT page.",
+                guidance=guidance,
                 text_only=False,
                 source="state_action_planner",
-                reasons=("s18_bit_root_to_pb5",),
+                reasons=(reason,),
             )
-    if step_id == "S18" and "right_mdi_pb18" in allowed:
         return _StateActionPlan(
-            targets=("right_mdi_pb18",),
-            guidance="Right DDI BIT page state is not confirmed; press Right DDI PB18/MENU to recover the BIT page first.",
-            text_only=False,
+            targets=(),
+            guidance="S18 requires Right DDI PB5/FCS-MC, but that target is not available.",
+            text_only=True,
             source="state_action_planner",
-            reasons=("s18_unknown_page_to_pb18",),
+            reasons=("target_not_allowed:right_mdi_pb5",),
         )
     if step_id == "S19":
         if "fcsmc_in_test_visible" in seen_or_fresh:

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -2787,6 +2787,16 @@ def _vision_summary_seen_or_fresh(
     return False
 
 
+def _vision_summary_not_seen(
+    summary: Mapping[str, Any] | None,
+    fact_id: str,
+) -> bool:
+    if not isinstance(summary, Mapping) or not fact_id:
+        return False
+    raw = summary.get("not_seen_fact_ids")
+    return isinstance(raw, (list, tuple, set)) and any(item == fact_id for item in raw)
+
+
 def _s19_final_go_seen_or_fresh(summary: Mapping[str, Any] | None) -> bool:
     return _vision_summary_seen_or_fresh(summary, "fcsmc_final_go_result_visible")
 
@@ -7744,7 +7754,32 @@ class LiveDcsTutorLoop:
             if next_step_id == "S18":
                 summary = context.get("vision_fact_summary")
                 bit_root_seen = _vision_summary_seen_or_fresh(summary, "bit_root_page_visible")
-                if bit_root_seen and "right_mdi_pb5" in self.overlay_allowset:
+                bit_root_not_seen = _vision_summary_not_seen(summary, "bit_root_page_visible")
+                if bit_root_not_seen:
+                    s18_target = "right_mdi_pb18"
+                    s18_guidance = (
+                        "S17 已完成。现在进入 S18：视觉证据显示右 DDI 不在 BIT root 页面；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+                        if self.lang == "zh"
+                        else "S17 is complete. Continue to S18: visual evidence says the right DDI is not on the BIT root page; left-click right DDI PB18/MENU to recover the BIT page first."
+                    )
+                    allowed_refs = _collect_request_evidence_refs(context)
+                    s18_ref = next(
+                        (
+                            ref for ref in (
+                                "GATES.S18.completion",
+                                "VARS.takeoff_trim_set",
+                                "GATES.S17.completion",
+                            )
+                            if ref in allowed_refs
+                        ),
+                        "GATES.S18.completion",
+                    )
+                    s18_evidence_type = "gate"
+                    if s18_ref.startswith("VARS."):
+                        s18_evidence_type = "var"
+                    s18_quote = "S18 requires PB18/MENU recovery because BIT root is not visible."
+                    fallback_reason = "s18_not_bit_root_to_pb18"
+                elif bit_root_seen:
                     s18_target = "right_mdi_pb5"
                     s18_guidance = (
                         "S17 已完成。现在进入 S18：右 DDI 已在 BIT root 页面；请左键按 PB5/FCS-MC 进入 FCS-MC BIT 页面。"
@@ -7771,11 +7806,11 @@ class LiveDcsTutorLoop:
                     s18_quote = "S18 BIT root page is visible; PB5 enters FCS-MC."
                     fallback_reason = "s18_bit_root_to_pb5"
                 else:
-                    s18_target = "right_mdi_pb18"
+                    s18_target = "right_mdi_pb5"
                     s18_guidance = (
-                        "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+                        "S17 已完成。现在进入 S18：正常冷启动流程中右 DDI 通常位于 BIT root 页面；请左键按右 DDI PB5/FCS-MC 进入 FCS-MC BIT 页面。"
                         if self.lang == "zh"
-                        else "S17 is complete. Continue to S18: the right DDI BIT page state is not confirmed; left-click right DDI PB18/MENU to recover the BIT page first."
+                        else "S17 is complete. Continue to S18: in the normal cold-start flow the right DDI defaults to the BIT root page; left-click right DDI PB5/FCS-MC to enter the FCS-MC BIT page."
                     )
                     allowed_refs = _collect_request_evidence_refs(context)
                     s18_ref = next(
@@ -7792,8 +7827,8 @@ class LiveDcsTutorLoop:
                     s18_evidence_type = "gate"
                     if s18_ref.startswith("VARS."):
                         s18_evidence_type = "var"
-                    s18_quote = "S18 requires right DDI BIT/FCS-MC page navigation."
-                    fallback_reason = "s18_unknown_page_to_pb18"
+                    s18_quote = "S17 is complete; normal S18 cold-start flow continues with PB5/FCS-MC."
+                    fallback_reason = "s18_default_bit_root_to_pb5"
                 if s18_target in self.overlay_allowset:
                     fallback_help_obj = {
                         "diagnosis": {"step_id": "S18", "error_category": "OM"},

--- a/tests/test_harness_validation.py
+++ b/tests/test_harness_validation.py
@@ -564,10 +564,10 @@ def test_plan_harness_action_keeps_s18_recovery_pb18_when_bit_root_not_visible()
     assert plan.repair_applied is True
     assert plan.validator_rejected is True
     assert plan.final_action_plan_source == "state_action_planner"
-    assert "s18_unknown_page_to_pb18" in plan.reasons
+    assert "s18_not_bit_root_to_pb18" in plan.reasons
 
 
-def test_plan_harness_action_uses_s18_safe_navigation_when_visual_state_unknown() -> None:
+def test_plan_harness_action_defaults_s18_unknown_visual_state_to_pb5() -> None:
     plan = plan_harness_action(
         step_specs={
             "S18": _spec(
@@ -587,11 +587,11 @@ def test_plan_harness_action_uses_s18_safe_navigation_when_visual_state_unknown(
         max_overlay_targets=1,
     )
 
-    assert plan.targets == ("right_mdi_pb18",)
+    assert plan.targets == ("right_mdi_pb5",)
     assert plan.text_only is False
     assert plan.final_action_plan_source == "state_action_planner"
-    assert "PB18" in (plan.guidance or "")
-    assert "s18_unknown_page_to_pb18" in plan.reasons
+    assert "PB5" in (plan.guidance or "")
+    assert "s18_default_bit_root_to_pb5" in plan.reasons
 
 
 def test_plan_harness_action_uses_s18_visual_state_without_live_hint() -> None:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -11703,17 +11703,18 @@ def test_live_help_fixture_315_s17_complete_advances_to_s18_actionable_text() ->
     assert repaired.metadata["next"]["step_id"] == "S18"
     assert repaired.metadata["final_action_plan"]["step_id"] == "S18"
     assert repaired.metadata["final_action_plan"]["text_only"] is False
-    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb18"]
-    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb18"]
+    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb5"]
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb5"]
     assert repaired.metadata["harness_trace"]["model_decision"]["step_id"] == "S17"
     assert repaired.metadata["harness_trace"]["repair_result"]["path"] == "final_evidence_consistency_validator"
     final_public = repaired.metadata["final_public_response"]
-    assert final_public["actions"][0]["target"] == "right_mdi_pb18"
+    assert final_public["actions"][0]["target"] == "right_mdi_pb5"
     public_text = _public_response_text(repaired)
     assert "最新证据" not in public_text
     assert "evidence" not in public_text.lower()
     assert "S18" in public_text
-    assert "PB18" in public_text
+    assert "PB5" in public_text
+    assert "PB18" not in public_text
     assert "takeoff_trim_button" not in public_text
 
 
@@ -11781,11 +11782,11 @@ def test_live_help_fixture_315_s18_advancement_uses_actionable_overlay() -> None
     final_plan = repaired.metadata["final_action_plan"]
     assert final_plan["step_id"] == "S18"
     assert final_plan["text_only"] is False
-    assert final_plan["targets"] == ["right_mdi_pb18"]
+    assert final_plan["targets"] == ["right_mdi_pb5"]
     assert repaired.metadata["final_evidence_consistency_overlay_applied"] is True
-    assert repaired.metadata["final_evidence_consistency_overlay_reason"] == "s18_unknown_page_to_pb18"
-    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb18"]
-    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb18"]
+    assert repaired.metadata["final_evidence_consistency_overlay_reason"] == "s18_default_bit_root_to_pb5"
+    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb5"]
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb5"]
     assert repaired.metadata["vlm_skipped_preliminary_step"] == "S17"
     assert repaired.metadata["final_step_requires_visual"] == "S18"
     assert repaired.metadata["harness_trace"]["vlm_skipped_preliminary_step"] == "S17"
@@ -11793,8 +11794,32 @@ def test_live_help_fixture_315_s18_advancement_uses_actionable_overlay() -> None
     assert repaired.metadata["fused_step_id"] == "S18"
     assert repaired.metadata["fused_missing_conditions"] == []
     public_text = _public_response_text(repaired)
-    assert "PB18" in public_text
+    assert "PB5" in public_text
+    assert "PB18" not in public_text
     assert "takeoff_trim_button" not in public_text
+
+
+def test_live_help_fixture_315_s18_advancement_uses_pb18_when_bit_root_not_seen() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/82d871be-26ac-41f4-a722-8141efcd8f87.fixture.json"
+    )
+    request, response = _fixture_request_and_raw_model_response(fixture)
+    request.context = dict(request.context)
+    summary = dict(request.context.get("vision_fact_summary") or {})
+    summary["seen_fact_ids"] = []
+    summary["fresh_fact_ids"] = []
+    summary["not_seen_fact_ids"] = ["bit_root_page_visible"]
+    request.context["vision_fact_summary"] = summary
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    assert repaired.metadata["diagnosis"]["step_id"] == "S18"
+    assert repaired.metadata["final_action_plan"]["targets"] == ["right_mdi_pb18"]
+    assert repaired.metadata["final_overlay_targets"] == ["right_mdi_pb18"]
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb18"]
+    assert repaired.metadata["final_evidence_consistency_overlay_reason"] == "s18_not_bit_root_to_pb18"
+    public_text = _public_response_text(repaired)
+    assert "PB18" in public_text
 
 
 def test_live_help_fixture_315_s18_advancement_uses_pb5_when_bit_root_seen() -> None:


### PR DESCRIPTION
Fixes #314. Summary: default S18 unknown/no-VLM normal cold-start progression to right_mdi_pb5, keep right_mdi_pb18 only for explicit bit_root_page_visible not_seen recovery, and update S18 replay expectations/tests. Validation: targeted S18 pytest slices passed; full pytest passed with -q -s --basetemp=.tmp/pytest-full; subagent review found no issues.