### PR TITLE
Fix stale S17 candidate trace

### DIFF
--- a/adapters/base_help_model.py
+++ b/adapters/base_help_model.py
@@ -313,6 +313,23 @@ class BaseHelpModel(ModelPort):
             recent_ui_targets,
             inference_vars,
         )
+        request_hint = self._request_deterministic_hint(request)
+        if request_hint is not None:
+            request_hint.setdefault("recent_ui_targets", list(recent_ui_targets))
+            deterministic_hint = request_hint
+            hinted_step_id = request_hint.get("inferred_step_id")
+            if isinstance(hinted_step_id, str) and hinted_step_id:
+                raw_missing_conditions = request_hint.get("missing_conditions")
+                if not isinstance(raw_missing_conditions, (list, tuple)):
+                    raw_missing_conditions = []
+                deterministic_inference = StepInferenceResult(
+                    inferred_step_id=hinted_step_id,
+                    missing_conditions=tuple(
+                        item
+                        for item in raw_missing_conditions
+                        if isinstance(item, str) and item
+                    ),
+                )
         prompt_meta: dict[str, Any] = {}
         delta_dropped_count = self._extract_delta_dropped_count(request)
         prompt_budget_used = 0
@@ -520,6 +537,11 @@ class BaseHelpModel(ModelPort):
         inferred_step_id = None
         if inference is not None:
             inferred_step_id = inference.inferred_step_id
+        request_hint = self._request_deterministic_hint(request)
+        if request_hint is not None:
+            hinted_step_id = request_hint.get("inferred_step_id")
+            if isinstance(hinted_step_id, str) and hinted_step_id:
+                inferred_step_id = hinted_step_id
         state_harness = context.get("state_harness")
         harness_conflicts = (
             state_harness.get("conflicts")
@@ -545,11 +567,12 @@ class BaseHelpModel(ModelPort):
         if not isinstance(scenario_profile, str) or not scenario_profile:
             scenario_profile = None
         normalized_recent_ui_targets = list(recent_ui_targets or [])
-        hint_payload = (
-            dict(deterministic_hint)
-            if isinstance(deterministic_hint, Mapping)
-            else self._serialize_deterministic_hint(inference, normalized_recent_ui_targets)
-        )
+        if request_hint is not None:
+            hint_payload = dict(request_hint)
+        elif isinstance(deterministic_hint, Mapping):
+            hint_payload = dict(deterministic_hint)
+        else:
+            hint_payload = self._serialize_deterministic_hint(inference, normalized_recent_ui_targets)
         step_ui_targets = hint_payload.get("step_ui_targets")
         missing_conditions = hint_payload.get("missing_conditions")
         gate_blockers = hint_payload.get("gate_blockers")
@@ -584,6 +607,10 @@ class BaseHelpModel(ModelPort):
             "vision": context.get("vision"),
             "vision_facts": context.get("vision_facts"),
             "vision_fact_summary": context.get("vision_fact_summary"),
+            "state_harness": state_harness,
+            "evidence_packet_summary": context.get("evidence_packet_summary"),
+            "evidence_snapshot": context.get("evidence_snapshot"),
+            "snapshot_ids": context.get("snapshot_ids"),
             "observation": {
                 "procedure_hint": observation.procedure_hint,
                 "source": observation.source,
@@ -605,6 +632,15 @@ class BaseHelpModel(ModelPort):
             ],
             prompt_meta,
         )
+
+    @staticmethod
+    def _request_deterministic_hint(request: TutorRequest | None) -> dict[str, Any] | None:
+        if request is None or not isinstance(request.context, dict):
+            return None
+        raw = request.context.get("deterministic_step_hint")
+        if not isinstance(raw, Mapping):
+            return None
+        return dict(raw)
 
     def _print_model_io_block(
         self,

--- a/artifacts/live_fixtures/f04ab6b4-b567-4449-8d23-e14f00cf0fea.fixture.json
+++ b/artifacts/live_fixtures/f04ab6b4-b567-4449-8d23-e14f00cf0fea.fixture.json
@@ -1,0 +1,3154 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 6795,
+        "frame_count": 20,
+        "latest_seq": 6814
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+      "source_observation_seq": 6814,
+      "source_observation_t_wall": 1779232236.9146523,
+      "telemetry_window_first_seq": 6795,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 6814,
+      "telemetry_window_latest_t_wall": 1779232236.9146523,
+      "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+    },
+    "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 2,
+          "delta_dropped_count": 2,
+          "from_addr": "192.168.0.105:59156",
+          "raw_delta_count": 2,
+          "seq": 6814
+        },
+        "observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [],
+            "delta_count": 0,
+            "dropped_stats": {
+              "dropped_by_reason": {
+                "blacklist": 2
+              },
+              "dropped_total": 2
+            },
+            "raw_delta_count": 2,
+            "recent_key_changes_topk": [],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 6814,
+          "t_wall": 1779232236.9146523,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": false,
+            "hook_handle_value": 1,
+            "hook_retracted": true,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 324,
+            "temp_r": 324,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T23:10:36.914652+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 6795,
+      "frame_count": 20,
+      "latest_seq": 6814
+    },
+    "vision": {
+      "frame_ids": [
+        "1779232236968_000451"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779232236968_000451",
+        "frame_ids": [
+          "1779232236968_000451"
+        ],
+        "frame_stale": false,
+        "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+        "observation_seq": 6814,
+        "observation_t_wall_ms": 1779232236915,
+        "observation_t_wall_s": 1779232236.9146523,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779232236968,
+            "channel": "composite_panel",
+            "frame_id": "1779232236968_000451",
+            "frame_seq": 451,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779232236968_000451_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779232236968_000451.png",
+            "sync_delta_ms": 90,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 90,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779232236968,
+          "channel": "composite_panel",
+          "frame_id": "1779232236968_000451",
+          "frame_seq": 451,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779232236968_000451_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779232236968_000451.png",
+          "sync_delta_ms": 90,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779232236878,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779232236968_000451"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "kind": "tutor_request",
+        "lineno": 7619,
+        "metadata": {
+          "frame_id": "1779232236968_000451",
+          "fused_missing_conditions": [
+            "vars.takeoff_trim_set==true"
+          ],
+          "fused_step_id": "S17",
+          "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 90,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 2,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S17",
+              "missing_conditions_count": 1,
+              "observability": "partial",
+              "observability_status": "partial",
+              "overlay_step_id": "S17",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "takeoff_trim_button"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 6795,
+                "frame_count": 20,
+                "latest_seq": 6814
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+              "source_observation_seq": 6814,
+              "source_observation_t_wall": 1779232236.9146523,
+              "telemetry_window_first_seq": 6795,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 6814,
+              "telemetry_window_latest_t_wall": 1779232236.9146523,
+              "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_error_coding_guide_10",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "3. Step Criticality",
+                "score": 21.879094298244468,
+                "section": "3. Step Criticality",
+                "snippet_id": "fa18c_error_coding_guide_10"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_12",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q12. Sequence Mini-Task 2",
+                "score": 20.005380060505324,
+                "section": "Q12. Sequence Mini-Task 2",
+                "snippet_id": "fa18c_coldstart_quiz_12"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_1",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "1. Scenario Definition",
+                "score": 18.62701342421707,
+                "section": "1. Scenario Definition",
+                "snippet_id": "Appendix - Training Task Syllabus_1"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_7",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P5 – FCS & Flight Controls (S15–S19)",
+                "score": 17.463809558100806,
+                "section": "Phase P5 – FCS & Flight Controls (S15–S19)",
+                "snippet_id": "Appendix - Training Task Syllabus_7"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_103",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 104,
+                "score": 16.814972114091987,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_103"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.takeoff_trim_set==true"
+                ],
+                "overlay_step_id": "S17",
+                "role": "candidate_not_authoritative",
+                "step_id": "S17"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 6814,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 6795,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6814,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 6814,
+                "latest_t_wall": 1779232236.9146523,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.785
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779232236968_000451",
+              "frame_ids": [
+                "1779232236968_000451"
+              ],
+              "frame_stale": false,
+              "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+              "observation_seq": 6814,
+              "observation_t_wall_ms": 1779232236915,
+              "observation_t_wall_s": 1779232236.9146523,
+              "status": "partial",
+              "sync_delta_ms": 90,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779232236878,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779232236968_000451"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 6795,
+                "frame_count": 20,
+                "latest_seq": 6814
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+              "source_observation_seq": 6814,
+              "source_observation_t_wall": 1779232236.9146523,
+              "telemetry_window_first_seq": 6795,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 6814,
+              "telemetry_window_latest_t_wall": 1779232236.9146523,
+              "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "frame_id": "1779232236968_000451",
+            "fused_missing_conditions": [
+              "vars.takeoff_trim_set==true"
+            ],
+            "fused_step_id": "S17",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_error_coding_guide_10",
+              "fa18c_coldstart_quiz_12",
+              "Appendix - Training Task Syllabus_1",
+              "Appendix - Training Task Syllabus_7",
+              "DCS FA-18C Early Access Guide EN_103"
+            ],
+            "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+            "prompt_tokens_est": 5475,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "source_chunk_refs": [
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_12",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_7",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_103"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 90,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779232236968_000451"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779232236968_000451"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+          "request_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "timestamp": "2026-05-19T23:10:37.454968+00:00",
+          "version": "v1"
+        },
+        "related_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "vision_refs": [
+          "1779232236968_000451"
+        ]
+      },
+      {
+        "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "kind": "overlay_requested",
+        "lineno": 7620,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779232236968_000451",
+          "fused_missing_conditions": [],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 90,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "e14dc013-74bd-4643-b196-4a6849d966b7",
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779232236968_000451",
+          "fused_missing_conditions": [],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 90,
+          "target": "pnt_346",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "kind": "overlay_requested",
+        "lineno": 7621,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779232236968_000451",
+          "fused_missing_conditions": [],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 90,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "161bdc46-ad47-4cef-830f-f9484c362780",
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779232236968_000451",
+          "fused_missing_conditions": [],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 90,
+          "target": "pnt_96",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "kind": "tutor_response",
+        "lineno": 7622,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779232236968_000451",
+          "fused_missing_conditions": [],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 90,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_96",
+              "evidence_refs": [
+                "VARS.takeoff_trim_set"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "right_mdi_pb18"
+              ],
+              "frame_id": "1779232236968_000451",
+              "fused_missing_conditions": [],
+              "fused_step_id": "S18",
+              "generation_mode": "model",
+              "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 90,
+              "target": "right_mdi_pb18",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779232236968_000451"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+          ],
+          "in_reply_to": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "message": "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。",
+          "metadata": {
+            "allowed_evidence_ref_count": 119,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "d0b104ae-39c6-496e-b8ce-21bb5550f648",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+            },
+            "delta_dropped_count": 2,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S18"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+              "source_observation_seq": 6814,
+              "source_observation_t_wall": 1779232236.9146523,
+              "telemetry_window_first_seq": 6795,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 6814,
+              "telemetry_window_latest_t_wall": 1779232236.9146523,
+              "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "overlay_step_id": "S18",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S18",
+              "targets": [
+                "right_mdi_pb18"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 119,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S18"
+              },
+              "next": {
+                "step_id": "S18"
+              },
+              "observability_status": "partial",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_original_actions": [
+              {
+                "element_id": "pnt_346",
+                "evidence_refs": [
+                  "GATES.S17.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "takeoff_trim_button",
+                "type": "overlay"
+              }
+            ],
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "s18_unknown_page_to_pb18",
+            "final_evidence_consistency_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+              "completion_gate_already_satisfied:S17"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "right_mdi_pb18"
+            ],
+            "final_public_instruction_category": "actionable",
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_96",
+                  "evidence_refs": [
+                    "VARS.takeoff_trim_set"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "right_mdi_pb18"
+                  ],
+                  "frame_id": "1779232236968_000451",
+                  "fused_missing_conditions": [],
+                  "fused_step_id": "S18",
+                  "generation_mode": "model",
+                  "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 90,
+                  "target": "right_mdi_pb18",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779232236968_000451"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+              ],
+              "instruction_category": "actionable",
+              "message": "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。",
+              "next": {
+                "step_id": "S18"
+              }
+            },
+            "final_step_requires_visual": "S18",
+            "frame_id": "1779232236968_000451",
+            "fused_missing_conditions": [],
+            "fused_step_id": "S18",
+            "generation_mode": "model",
+            "generation_prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+            "generation_prompt_tokens_est": 5475,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S18",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S18",
+              "targets": [
+                "right_mdi_pb18"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "takeoff_trim_button"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S17",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S24",
+                  "supporting_evidence_refs": [
+                    "GATES.S24.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "pitot_heater_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S26",
+                  "supporting_evidence_refs": [
+                    "GATES.S26.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "parking_brake_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S28",
+                  "supporting_evidence_refs": [
+                    "GATES.S28.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ifei_up_button",
+                    "ifei_down_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S29",
+                  "supporting_evidence_refs": [
+                    "GATES.S29.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "source": "final_action_plan",
+                "step_id": "S18"
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 6795,
+                  "frame_count": 20,
+                  "latest_seq": 6814
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+                "source_observation_seq": 6814,
+                "source_observation_t_wall": 1779232236.9146523,
+                "telemetry_window_first_seq": 6795,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 6814,
+                "telemetry_window_latest_t_wall": 1779232236.9146523,
+                "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "overlay_step_id": "S18",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S18",
+                "targets": [
+                  "right_mdi_pb18"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "right_mdi_pb18"
+              ],
+              "final_step_requires_visual": "S18",
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S17.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "takeoff_trim_button"
+                ],
+                "status": "ok",
+                "step_id": "S17"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S17"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+                "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+                  "completion_gate_already_satisfied:S17"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S17"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779232236968_000451"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 90,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              },
+              "vlm_skipped_preliminary_step": "S17"
+            },
+            "harness_validation_reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+              "completion_gate_already_satisfied:S17"
+            ],
+            "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+              ],
+              "next": {
+                "step_id": "S18"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.takeoff_trim_set",
+                    "target": "right_mdi_pb18",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "right_mdi_pb18"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S17"
+              },
+              "explanations": [
+                "当前步骤 S17 未完成。请左键按下 T/O TRIM 按钮以设置起飞配平。"
+              ],
+              "next": {
+                "step_id": "S17"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S17.completion",
+                    "target": "takeoff_trim_button",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "takeoff_trim_button"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4140,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "OM",
+              "step_id": "S17"
+            },
+            "model_raw_explanations": [
+              "当前步骤 S17 未完成。请左键按下 T/O TRIM 按钮以设置起飞配平。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S17"
+              },
+              "explanations": [
+                "当前步骤 S17 未完成。请左键按下 T/O TRIM 按钮以设置起飞配平。"
+              ],
+              "next": {
+                "step_id": "S17"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S17.completion",
+                    "target": "takeoff_trim_button",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "takeoff_trim_button"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S17"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779232236968_000451"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779232236968_000451",
+            "next": {
+              "step_id": "S18"
+            },
+            "observability_status": "partial",
+            "prompt_budget_used": 5621,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.attitude_source_auto",
+                "VARS.battery_on",
+                "VARS.bingo_fuel_set",
+                "VARS.bleed_air_cycle_complete",
+                "VARS.bleed_air_norm",
+                "VARS.comm1_channel_numeric",
+                "VARS.comm1_freq_134_000",
+                "VARS.comm1_freq_value",
+                "VARS.comm2_channel_numeric",
+                "VARS.comm2_freq_value",
+                "VARS.takeoff_trim_set",
+                "GATES.S17.completion",
+                "GATES.S17.precondition",
+                "GATES.S20.completion",
+                "GATES.S22.completion",
+                "GATES.S24.completion",
+                "GATES.S26.completion",
+                "GATES.S28.completion",
+                "GATES.S29.completion",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_10",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_12",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_1",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_7",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_103"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 28,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": null,
+              "prompt_chars": 21899,
+              "prompt_tokens_est": 5475,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_error_coding_guide_10",
+                "fa18c_coldstart_quiz_12",
+                "Appendix - Training Task Syllabus_1",
+                "Appendix - Training Task Syllabus_7",
+                "DCS FA-18C Early Access Guide EN_103"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+            "prompt_tokens_est": 5475,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vars.takeoff_trim_set==true"
+            ],
+            "rejected_model_step_id": "S17",
+            "rejected_model_target": "takeoff_trim_button",
+            "rejected_model_targets": [
+              "takeoff_trim_button"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+            "request_prompt_tokens_est": 5475,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 119,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S17"
+              },
+              "next": {
+                "step_id": "S17"
+              },
+              "observability_status": "partial",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+              "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+            },
+            "state_key": "6cc99f45d388027e9db4060207dfb041965d95ce960a15bbab9504335c741e88",
+            "sync_delta_ms": 90,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779232236968_000451",
+              "frame_ids": [
+                "1779232236968_000451"
+              ],
+              "frame_stale": false,
+              "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+              "observation_seq": 6814,
+              "observation_t_wall_ms": 1779232236915,
+              "observation_t_wall_s": 1779232236.9146523,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779232236968,
+                  "channel": "composite_panel",
+                  "frame_id": "1779232236968_000451",
+                  "frame_seq": 451,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779232236968_000451_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779232236968_000451.png",
+                  "sync_delta_ms": 90,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 90,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779232236968,
+                "channel": "composite_panel",
+                "frame_id": "1779232236968_000451",
+                "frame_seq": 451,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779232236968_000451_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779232236968_000451.png",
+                "sync_delta_ms": 90,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779232236878,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S17"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779232236968_000451"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779232236968_000451"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required",
+            "vlm_skipped_preliminary_step": "S17"
+          },
+          "response_id": "a84ca431-2897-42d3-98d4-6a20bb9af6ec",
+          "status": "ok",
+          "timestamp": "2026-05-19T23:10:41.596619+00:00",
+          "version": "v1"
+        },
+        "related_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "vision_refs": [
+          "1779232236968_000451"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 2,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S17",
+          "missing_conditions_count": 1,
+          "observability": "partial",
+          "observability_status": "partial",
+          "overlay_step_id": "S17",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "takeoff_trim_button"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 6795,
+            "frame_count": 20,
+            "latest_seq": 6814
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+          "source_observation_seq": 6814,
+          "source_observation_t_wall": 1779232236.9146523,
+          "telemetry_window_first_seq": 6795,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 6814,
+          "telemetry_window_latest_t_wall": 1779232236.9146523,
+          "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_error_coding_guide_10",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "3. Step Criticality",
+            "score": 21.879094298244468,
+            "section": "3. Step Criticality",
+            "snippet_id": "fa18c_error_coding_guide_10"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_12",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q12. Sequence Mini-Task 2",
+            "score": 20.005380060505324,
+            "section": "Q12. Sequence Mini-Task 2",
+            "snippet_id": "fa18c_coldstart_quiz_12"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_1",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "1. Scenario Definition",
+            "score": 18.62701342421707,
+            "section": "1. Scenario Definition",
+            "snippet_id": "Appendix - Training Task Syllabus_1"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_7",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P5 – FCS & Flight Controls (S15–S19)",
+            "score": 17.463809558100806,
+            "section": "Phase P5 – FCS & Flight Controls (S15–S19)",
+            "snippet_id": "Appendix - Training Task Syllabus_7"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_103",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 104,
+            "score": 16.814972114091987,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_103"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.takeoff_trim_set==true"
+            ],
+            "overlay_step_id": "S17",
+            "role": "candidate_not_authoritative",
+            "step_id": "S17"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 6814,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 6795,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6814,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 6814,
+            "latest_t_wall": 1779232236.9146523,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.785
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779232236968_000451",
+          "frame_ids": [
+            "1779232236968_000451"
+          ],
+          "frame_stale": false,
+          "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+          "observation_seq": 6814,
+          "observation_t_wall_ms": 1779232236915,
+          "observation_t_wall_s": 1779232236.9146523,
+          "status": "partial",
+          "sync_delta_ms": 90,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779232236878,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779232236968_000451"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 6795,
+            "frame_count": 20,
+            "latest_seq": 6814
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+          "source_observation_seq": 6814,
+          "source_observation_t_wall": 1779232236.9146523,
+          "telemetry_window_first_seq": 6795,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 6814,
+          "telemetry_window_latest_t_wall": 1779232236.9146523,
+          "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "frame_id": "1779232236968_000451",
+        "fused_missing_conditions": [
+          "vars.takeoff_trim_set==true"
+        ],
+        "fused_step_id": "S17",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_error_coding_guide_10",
+          "fa18c_coldstart_quiz_12",
+          "Appendix - Training Task Syllabus_1",
+          "Appendix - Training Task Syllabus_7",
+          "DCS FA-18C Early Access Guide EN_103"
+        ],
+        "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+        "prompt_tokens_est": 5475,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "source_chunk_refs": [
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_12",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_1",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_7",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_103"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 90,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779232236968_000451"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779232236968_000451"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+      "request_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+      "timestamp": "2026-05-19T23:10:37.454968+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_96",
+          "evidence_refs": [
+            "VARS.takeoff_trim_set"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "frame_id": "1779232236968_000451",
+          "fused_missing_conditions": [],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 90,
+          "target": "right_mdi_pb18",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+      ],
+      "in_reply_to": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+      "message": "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。",
+      "metadata": {
+        "allowed_evidence_ref_count": 119,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "d0b104ae-39c6-496e-b8ce-21bb5550f648",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+        },
+        "delta_dropped_count": 2,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S18"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+          "source_observation_seq": 6814,
+          "source_observation_t_wall": 1779232236.9146523,
+          "telemetry_window_first_seq": 6795,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 6814,
+          "telemetry_window_latest_t_wall": 1779232236.9146523,
+          "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "overlay_step_id": "S18",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S18",
+          "targets": [
+            "right_mdi_pb18"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 119,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S18"
+          },
+          "next": {
+            "step_id": "S18"
+          },
+          "observability_status": "partial",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_original_actions": [
+          {
+            "element_id": "pnt_346",
+            "evidence_refs": [
+              "GATES.S17.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "takeoff_trim_button",
+            "type": "overlay"
+          }
+        ],
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "s18_unknown_page_to_pb18",
+        "final_evidence_consistency_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+          "completion_gate_already_satisfied:S17"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "right_mdi_pb18"
+        ],
+        "final_public_instruction_category": "actionable",
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_96",
+              "evidence_refs": [
+                "VARS.takeoff_trim_set"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "right_mdi_pb18"
+              ],
+              "frame_id": "1779232236968_000451",
+              "fused_missing_conditions": [],
+              "fused_step_id": "S18",
+              "generation_mode": "model",
+              "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 90,
+              "target": "right_mdi_pb18",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779232236968_000451"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+          ],
+          "instruction_category": "actionable",
+          "message": "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。",
+          "next": {
+            "step_id": "S18"
+          }
+        },
+        "final_step_requires_visual": "S18",
+        "frame_id": "1779232236968_000451",
+        "fused_missing_conditions": [],
+        "fused_step_id": "S18",
+        "generation_mode": "model",
+        "generation_prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+        "generation_prompt_tokens_est": 5475,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S18",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S18",
+          "targets": [
+            "right_mdi_pb18"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "takeoff_trim_button"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S17",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S24",
+              "supporting_evidence_refs": [
+                "GATES.S24.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "pitot_heater_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S26",
+              "supporting_evidence_refs": [
+                "GATES.S26.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "parking_brake_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S28",
+              "supporting_evidence_refs": [
+                "GATES.S28.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ifei_up_button",
+                "ifei_down_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S29",
+              "supporting_evidence_refs": [
+                "GATES.S29.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "source": "final_action_plan",
+            "step_id": "S18"
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 6795,
+              "frame_count": 20,
+              "latest_seq": 6814
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+            "source_observation_seq": 6814,
+            "source_observation_t_wall": 1779232236.9146523,
+            "telemetry_window_first_seq": 6795,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 6814,
+            "telemetry_window_latest_t_wall": 1779232236.9146523,
+            "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "overlay_step_id": "S18",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S18",
+            "targets": [
+              "right_mdi_pb18"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "right_mdi_pb18"
+          ],
+          "final_step_requires_visual": "S18",
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S17.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "takeoff_trim_button"
+            ],
+            "status": "ok",
+            "step_id": "S17"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S17"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+            "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+              "completion_gate_already_satisfied:S17"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S17"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779232236968_000451"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 90,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          },
+          "vlm_skipped_preliminary_step": "S17"
+        },
+        "harness_validation_reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+          "completion_gate_already_satisfied:S17"
+        ],
+        "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+          ],
+          "next": {
+            "step_id": "S18"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.takeoff_trim_set",
+                "target": "right_mdi_pb18",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "right_mdi_pb18"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S17"
+          },
+          "explanations": [
+            "当前步骤 S17 未完成。请左键按下 T/O TRIM 按钮以设置起飞配平。"
+          ],
+          "next": {
+            "step_id": "S17"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S17.completion",
+                "target": "takeoff_trim_button",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "takeoff_trim_button"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4140,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "OM",
+          "step_id": "S17"
+        },
+        "model_raw_explanations": [
+          "当前步骤 S17 未完成。请左键按下 T/O TRIM 按钮以设置起飞配平。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S17"
+          },
+          "explanations": [
+            "当前步骤 S17 未完成。请左键按下 T/O TRIM 按钮以设置起飞配平。"
+          ],
+          "next": {
+            "step_id": "S17"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S17.completion",
+                "target": "takeoff_trim_button",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "takeoff_trim_button"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S17"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779232236968_000451"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779232236968_000451",
+        "next": {
+          "step_id": "S18"
+        },
+        "observability_status": "partial",
+        "prompt_budget_used": 5621,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.attitude_source_auto",
+            "VARS.battery_on",
+            "VARS.bingo_fuel_set",
+            "VARS.bleed_air_cycle_complete",
+            "VARS.bleed_air_norm",
+            "VARS.comm1_channel_numeric",
+            "VARS.comm1_freq_134_000",
+            "VARS.comm1_freq_value",
+            "VARS.comm2_channel_numeric",
+            "VARS.comm2_freq_value",
+            "VARS.takeoff_trim_set",
+            "GATES.S17.completion",
+            "GATES.S17.precondition",
+            "GATES.S20.completion",
+            "GATES.S22.completion",
+            "GATES.S24.completion",
+            "GATES.S26.completion",
+            "GATES.S28.completion",
+            "GATES.S29.completion",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_10",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_12",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_1",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_7",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_103"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 28,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": null,
+          "prompt_chars": 21899,
+          "prompt_tokens_est": 5475,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_error_coding_guide_10",
+            "fa18c_coldstart_quiz_12",
+            "Appendix - Training Task Syllabus_1",
+            "Appendix - Training Task Syllabus_7",
+            "DCS FA-18C Early Access Guide EN_103"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+        "prompt_tokens_est": 5475,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vars.takeoff_trim_set==true"
+        ],
+        "rejected_model_step_id": "S17",
+        "rejected_model_target": "takeoff_trim_button",
+        "rejected_model_targets": [
+          "takeoff_trim_button"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "68d1677cd45f8f8442a211ac01735965b1b26b6987e6a0faae3bc8e315233abb",
+        "request_prompt_tokens_est": 5475,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 119,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S17"
+          },
+          "next": {
+            "step_id": "S17"
+          },
+          "observability_status": "partial",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+          "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+        },
+        "state_key": "6cc99f45d388027e9db4060207dfb041965d95ce960a15bbab9504335c741e88",
+        "sync_delta_ms": 90,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779232236968_000451",
+          "frame_ids": [
+            "1779232236968_000451"
+          ],
+          "frame_stale": false,
+          "observation_ref": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+          "observation_seq": 6814,
+          "observation_t_wall_ms": 1779232236915,
+          "observation_t_wall_s": 1779232236.9146523,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779232236968,
+              "channel": "composite_panel",
+              "frame_id": "1779232236968_000451",
+              "frame_seq": 451,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779232236968_000451_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779232236968_000451.png",
+              "sync_delta_ms": 90,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 90,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779232236968,
+            "channel": "composite_panel",
+            "frame_id": "1779232236968_000451",
+            "frame_seq": 451,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779232236968_000451_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779232236968_000451.png",
+            "sync_delta_ms": 90,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779232236878,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S17"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779232236968_000451"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779232236968_000451"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required",
+        "vlm_skipped_preliminary_step": "S17"
+      },
+      "response_id": "a84ca431-2897-42d3-98d4-6a20bb9af6ec",
+      "status": "ok",
+      "timestamp": "2026-05-19T23:10:41.596619+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S18",
+    "expected_overlay_target_ids": [
+      "right_mdi_pb5"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "takeoff_trim_button"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S17",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S24",
+        "supporting_evidence_refs": [
+          "GATES.S24.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "pitot_heater_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S26",
+        "supporting_evidence_refs": [
+          "GATES.S26.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "parking_brake_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S28",
+        "supporting_evidence_refs": [
+          "GATES.S28.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ifei_up_button",
+          "ifei_down_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S29",
+        "supporting_evidence_refs": [
+          "GATES.S29.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+      "overlay_step_id": "S18",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S18",
+      "targets": [
+        "right_mdi_pb18"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S17.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "takeoff_trim_button"
+      ],
+      "status": "ok",
+      "step_id": "S17"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "takeoff_trim_button"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S17",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S24",
+          "supporting_evidence_refs": [
+            "GATES.S24.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "pitot_heater_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S26",
+          "supporting_evidence_refs": [
+            "GATES.S26.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "parking_brake_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S28",
+          "supporting_evidence_refs": [
+            "GATES.S28.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ifei_up_button",
+            "ifei_down_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S29",
+          "supporting_evidence_refs": [
+            "GATES.S29.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "source": "final_action_plan",
+        "step_id": "S18"
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 6795,
+          "frame_count": 20,
+          "latest_seq": 6814
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "final_decision_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "model_request_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "source_observation_id": "4e49c3d0-4ecf-48ad-a09b-c3a4ccf88abc",
+        "source_observation_seq": 6814,
+        "source_observation_t_wall": 1779232236.9146523,
+        "telemetry_window_first_seq": 6795,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 6814,
+        "telemetry_window_latest_t_wall": 1779232236.9146523,
+        "validator_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "overlay_step_id": "S18",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S18",
+        "targets": [
+          "right_mdi_pb18"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "right_mdi_pb18"
+      ],
+      "final_step_requires_visual": "S18",
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S17.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "takeoff_trim_button"
+        ],
+        "status": "ok",
+        "step_id": "S17"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S17"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "final_decision": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "model_request": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f",
+        "validator": "38b2b32740796e54f2e1d11335e0f4aac7252bd2f6d57fe446fd14cbaaf5762f"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+          "completion_gate_already_satisfied:S17"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S17"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779232236968_000451"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 90,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      },
+      "vlm_skipped_preliminary_step": "S17"
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "missing_condition_satisfied_by_latest_telemetry:vars.takeoff_trim_set==true",
+        "completion_gate_already_satisfied:S17"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S17"
+    }
+  },
+  "help_cycle_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S18"
+      },
+      "explanations": [
+        "S17 已完成。现在进入 S18：右 DDI 的 BIT 页面状态尚未确认；请先左键按右 DDI PB18/MENU 恢复到 BIT 页面。"
+      ],
+      "next": {
+        "step_id": "S18"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.takeoff_trim_set",
+            "target": "right_mdi_pb18",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "right_mdi_pb18"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S17"
+      },
+      "explanations": [
+        "当前步骤 S17 未完成。请左键按下 T/O TRIM 按钮以设置起飞配平。"
+      ],
+      "next": {
+        "step_id": "S17"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S17.completion",
+            "target": "takeoff_trim_button",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "takeoff_trim_button"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "f04ab6b4-b567-4449-8d23-e14f00cf0fea",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 11709,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_230300.jsonl"
+  }
+}

--- a/live_dcs.py
+++ b/live_dcs.py
@@ -705,6 +705,19 @@ def _sanitize_deterministic_hint_for_event(raw: Any) -> dict[str, Any]:
         sanitized["step_ui_targets"] = [
             item for item in step_ui_targets if isinstance(item, str) and item
         ][:8]
+    candidate_generation_reasons = raw.get("candidate_generation_reasons")
+    if isinstance(candidate_generation_reasons, list):
+        sanitized["candidate_generation_reasons"] = [
+            item for item in candidate_generation_reasons if isinstance(item, str) and item
+        ][:8]
+    stale_missing = raw.get("candidate_generation_stale_missing_conditions")
+    if isinstance(stale_missing, list):
+        sanitized["candidate_generation_stale_missing_conditions"] = [
+            item for item in stale_missing if isinstance(item, str) and item
+        ][:8]
+    rejected_step_id = raw.get("candidate_generation_rejected_step_id")
+    if isinstance(rejected_step_id, str) and rejected_step_id:
+        sanitized["candidate_generation_rejected_step_id"] = rejected_step_id
     visual_action_hint = raw.get("visual_action_hint")
     if isinstance(visual_action_hint, Mapping):
         target = visual_action_hint.get("target")
@@ -2291,6 +2304,26 @@ def _build_harness_trace_metadata(
         "message_category": message_category,
         "vlm_call": vlm_call,
     }
+    candidate_generation_reasons = _coerce_string_list(context.get("candidate_generation_reasons"))
+    candidate_generation_stale_missing_conditions = _coerce_string_list(
+        context.get("candidate_generation_stale_missing_conditions")
+    )
+    candidate_generation_rejected_step_id = context.get("candidate_generation_rejected_step_id")
+    if (
+        candidate_generation_reasons
+        or candidate_generation_stale_missing_conditions
+        or isinstance(candidate_generation_rejected_step_id, str)
+    ):
+        trace["candidate_generation"] = {
+            "status": "corrected",
+            "reasons": candidate_generation_reasons,
+            "stale_missing_conditions": candidate_generation_stale_missing_conditions,
+            "rejected_step_id": (
+                candidate_generation_rejected_step_id
+                if isinstance(candidate_generation_rejected_step_id, str)
+                else None
+            ),
+        }
     vlm_skipped_preliminary_step = response_metadata.get("vlm_skipped_preliminary_step")
     if isinstance(vlm_skipped_preliminary_step, str) and vlm_skipped_preliminary_step:
         trace["vlm_skipped_preliminary_step"] = vlm_skipped_preliminary_step
@@ -2736,23 +2769,43 @@ def _missing_conditions_satisfied_by_vars(
 ) -> bool:
     checked = False
     for condition in missing_conditions:
-        if not isinstance(condition, str) or not condition:
-            continue
-        matched = _MISSING_CONDITION_VAR_RE.search(condition)
-        if matched is None:
+        satisfied = _missing_condition_satisfied_by_vars(condition, vars_selected)
+        if satisfied is None:
             return False
-        var_name = matched.group(1)
-        if "==true" in condition:
-            checked = True
-            if var_name == "comm1_freq_134_000" and _s09_comm1_frequency_complete(vars_selected):
-                continue
-            if var_name == "engine_crank_left_complete" and _left_engine_start_complete(vars_selected):
-                continue
-            if vars_selected.get(var_name) is not True:
-                return False
-        else:
+        checked = True
+        if not satisfied:
             return False
     return checked
+
+
+def _missing_condition_satisfied_by_vars(
+    condition: str,
+    vars_selected: Mapping[str, Any],
+) -> bool | None:
+    if not isinstance(condition, str) or not condition:
+        return None
+    matched = _MISSING_CONDITION_VAR_RE.search(condition)
+    if matched is None or "==true" not in condition:
+        return None
+    var_name = matched.group(1)
+    if var_name == "comm1_freq_134_000" and _s09_comm1_frequency_complete(vars_selected):
+        return True
+    if var_name == "engine_crank_left_complete" and _left_engine_start_complete(vars_selected):
+        return True
+    return vars_selected.get(var_name) is True
+
+
+def _satisfied_missing_conditions_by_vars(
+    missing_conditions: Sequence[str],
+    vars_selected: Mapping[str, Any],
+) -> list[str]:
+    out: list[str] = []
+    for condition in missing_conditions:
+        if not isinstance(condition, str) or not condition:
+            continue
+        if _missing_condition_satisfied_by_vars(condition, vars_selected) is True:
+            out.append(condition)
+    return out
 
 
 def _s19_final_go_hold_satisfied_by_facts(
@@ -4043,6 +4096,9 @@ class LiveDcsTutorLoop:
         }
         self._sticky_inference_step_id: str | None = None
         self._sticky_inference_missing_conditions: tuple[str, ...] = ()
+        self._candidate_generation_rejected_step_id: str | None = None
+        self._candidate_generation_stale_missing_conditions: tuple[str, ...] = ()
+        self._candidate_generation_reasons: tuple[str, ...] = ()
         self._refuel_probe_s20_latched_complete = False
         self._refuel_probe_s21_latched_complete = False
         self._launch_bar_s22_latched_complete = False
@@ -4080,6 +4136,9 @@ class LiveDcsTutorLoop:
         self._last_inferred_step_id = None
         self._sticky_inference_step_id = None
         self._sticky_inference_missing_conditions = ()
+        self._candidate_generation_rejected_step_id = None
+        self._candidate_generation_stale_missing_conditions = ()
+        self._candidate_generation_reasons = ()
         self._refuel_probe_s20_latched_complete = False
         self._refuel_probe_s21_latched_complete = False
         self._launch_bar_s22_latched_complete = False
@@ -4667,6 +4726,19 @@ class LiveDcsTutorLoop:
             "scenario_profile": self.scenario_profile,
             "vision_fact_status": vision_fact_context.get("status"),
         }
+        candidate_generation_reasons = list(self._candidate_generation_reasons)
+        candidate_generation_stale_missing_conditions = list(
+            self._candidate_generation_stale_missing_conditions
+        )
+        candidate_generation_rejected_step_id = self._candidate_generation_rejected_step_id
+        if candidate_generation_reasons:
+            deterministic_hint["candidate_generation_reasons"] = candidate_generation_reasons
+        if candidate_generation_stale_missing_conditions:
+            deterministic_hint["candidate_generation_stale_missing_conditions"] = (
+                candidate_generation_stale_missing_conditions
+            )
+        if isinstance(candidate_generation_rejected_step_id, str) and candidate_generation_rejected_step_id:
+            deterministic_hint["candidate_generation_rejected_step_id"] = candidate_generation_rejected_step_id
         if isinstance(inference.inferred_step_id, str) and inference.inferred_step_id:
             step_harness_spec = self.step_harness_specs.get(inference.inferred_step_id)
             if step_harness_spec is not None:
@@ -4800,6 +4872,14 @@ class LiveDcsTutorLoop:
             "vision_facts": list(vision_fact_context.get("vision_facts", [])),
             "vision_fact_summary": dict(vision_fact_context.get("vision_fact_summary", {})),
         }
+        if candidate_generation_reasons:
+            context["candidate_generation_reasons"] = list(candidate_generation_reasons)
+        if candidate_generation_stale_missing_conditions:
+            context["candidate_generation_stale_missing_conditions"] = list(
+                candidate_generation_stale_missing_conditions
+            )
+        if isinstance(candidate_generation_rejected_step_id, str) and candidate_generation_rejected_step_id:
+            context["candidate_generation_rejected_step_id"] = candidate_generation_rejected_step_id
 
         prompt_result = build_help_prompt_result(
             context,
@@ -4912,6 +4992,21 @@ class LiveDcsTutorLoop:
         if isinstance(power_available, bool) and not power_available:
             return True
         return False
+
+    def _record_candidate_generation_stale_missing(
+        self,
+        *,
+        rejected_step_id: str,
+        missing_conditions: Sequence[str],
+        vars_selected: Mapping[str, Any],
+    ) -> None:
+        stale = _satisfied_missing_conditions_by_vars(missing_conditions, vars_selected)
+        self._candidate_generation_rejected_step_id = rejected_step_id
+        self._candidate_generation_stale_missing_conditions = tuple(stale)
+        self._candidate_generation_reasons = tuple(
+            f"candidate_generation_stale_missing_condition:{condition}"
+            for condition in stale
+        )
 
     def _stabilize_live_inference(
         self,
@@ -5045,7 +5140,7 @@ class LiveDcsTutorLoop:
                 self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
                 return advanced
         if (
-            current_step_id in {"S09", "S10"}
+            current_step_id in {"S09", "S10", "S17"}
             and _missing_conditions_satisfied_by_vars(inference.missing_conditions, vars_selected)
         ):
             advanced = self._infer_after_completed_step(
@@ -5055,6 +5150,11 @@ class LiveDcsTutorLoop:
                 vision_facts=None,
             )
             if advanced is not None:
+                self._record_candidate_generation_stale_missing(
+                    rejected_step_id=current_step_id,
+                    missing_conditions=inference.missing_conditions,
+                    vars_selected=vars_selected,
+                )
                 self._sticky_inference_step_id = advanced.inferred_step_id
                 self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
                 return advanced
@@ -5064,7 +5164,7 @@ class LiveDcsTutorLoop:
             return inference
         if (
             isinstance(sticky_step_id, str)
-            and sticky_step_id in {"S09", "S10"}
+            and sticky_step_id in {"S09", "S10", "S17"}
             and _missing_conditions_satisfied_by_vars(self._sticky_inference_missing_conditions, vars_selected)
         ):
             advanced = self._infer_after_completed_step(
@@ -5074,6 +5174,11 @@ class LiveDcsTutorLoop:
                 vision_facts=None,
             )
             if advanced is not None:
+                self._record_candidate_generation_stale_missing(
+                    rejected_step_id=sticky_step_id,
+                    missing_conditions=self._sticky_inference_missing_conditions,
+                    vars_selected=vars_selected,
+                )
                 self._sticky_inference_step_id = advanced.inferred_step_id
                 self._sticky_inference_missing_conditions = tuple(advanced.missing_conditions)
                 return advanced
@@ -9458,6 +9563,9 @@ class LiveDcsTutorLoop:
         obs = self._latest_enriched_obs
         if obs is None:
             return None, None
+        self._candidate_generation_rejected_step_id = None
+        self._candidate_generation_stale_missing_conditions = ()
+        self._candidate_generation_reasons = ()
 
         resolved_trigger_t_wall = _coerce_finite_float(trigger_t_wall)
         if resolved_trigger_t_wall is None:

--- a/tests/test_live_dcs.py
+++ b/tests/test_live_dcs.py
@@ -55,7 +55,12 @@ from live_dcs import (
 )
 from simtutor.schemas import validate_instance
 from tools.index_docs import build_index
-from tests._fakes import FakeClient
+from tests._fakes import (
+    FakeClient,
+    FakeResponse,
+    _extract_prompt_constraints_json,
+    _openai_chat_payload_from_help_obj,
+)
 from tests.adapters.socket_stubs import DummySocket
 
 
@@ -11844,6 +11849,156 @@ def test_live_help_fixture_315_s18_advancement_uses_pb5_when_bit_root_seen() -> 
     public_text = _public_response_text(repaired)
     assert "PB5" in public_text
     assert "PB18" not in public_text
+
+
+def test_live_help_fixture_315_f04_final_repair_uses_s18_default_pb5() -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/f04ab6b4-b567-4449-8d23-e14f00cf0fea.fixture.json"
+    )
+    request, response = _fixture_request_and_raw_model_response(fixture)
+
+    repaired = _validate_compact_live_help_response(request=request, response=response)
+
+    _assert_live_fixture_expectations(fixture, repaired)
+    assert repaired.metadata["diagnosis"]["step_id"] == "S18"
+    assert repaired.metadata["final_action_plan"]["targets"] == ["right_mdi_pb5"]
+    assert repaired.metadata["final_evidence_consistency_overlay_reason"] == "s18_default_bit_root_to_pb5"
+    assert [action["target"] for action in repaired.actions] == ["right_mdi_pb5"]
+    public_text = _public_response_text(repaired)
+    assert "PB5" in public_text
+    assert "PB18" not in public_text
+    assert "takeoff_trim_button" not in public_text
+
+
+def test_live_help_fixture_315_f04_stale_s17_candidate_advances_before_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _load_live_help_fixture(
+        "artifacts/live_fixtures/f04ab6b4-b567-4449-8d23-e14f00cf0fea.fixture.json"
+    )
+    observation_payload = fixture["context"]["observations"][0]
+    payload = dict(observation_payload["payload"])
+    vars_map = dict(payload["vars"])
+    payload["vars"] = vars_map
+    obs = Observation(
+        observation_id=observation_payload["observation_id"],
+        timestamp=observation_payload["timestamp"],
+        source=observation_payload["source"],
+        payload=payload,
+        version=observation_payload.get("version", "v1"),
+        procedure_hint=observation_payload.get("procedure_hint"),
+        tags=list(observation_payload.get("tags", [])),
+        attachments=list(observation_payload.get("attachments", [])),
+        metadata=dict(observation_payload.get("metadata", {})),
+    )
+    model = RecordingModel()
+    loop = LiveDcsTutorLoop(
+        source=_DelayedObservationSource(obs),
+        model=model,
+        action_executor=RecordingExecutor(),
+        rag_top_k=0,
+        lang="zh",
+    )
+
+    def _step_id(step: Any) -> str | None:
+        if isinstance(step, dict):
+            raw = step.get("id") or step.get("step_id")
+        else:
+            raw = getattr(step, "id", None) or getattr(step, "step_id", None)
+        return raw if isinstance(raw, str) else None
+
+    def fake_infer_step_id(pack_steps, *_args, **_kwargs) -> StepInferenceResult:
+        step_ids = [_step_id(step) for step in pack_steps]
+        if step_ids and step_ids[0] == "S18":
+            return StepInferenceResult(
+                inferred_step_id="S18",
+                missing_conditions=("vision_facts.fcsmc_page_visible==seen",),
+            )
+        return StepInferenceResult(
+            inferred_step_id="S17",
+            missing_conditions=("vars.takeoff_trim_set==true",),
+        )
+
+    monkeypatch.setattr("live_dcs.infer_step_id", fake_infer_step_id)
+    try:
+        loop._latest_enriched_obs = obs
+        loop._accumulated_vars.update(vars_map)
+        loop.telemetry_window_ring.add_delta(
+            vars_map,
+            t_wall=float(payload["t_wall"]),
+            seq=int(payload["seq"]),
+        )
+        loop._sticky_inference_step_id = "S17"
+        loop._sticky_inference_missing_conditions = ("vars.takeoff_trim_set==true",)
+        response, _report = loop.run_help_cycle(trigger_t_wall=float(payload["t_wall"]))
+    finally:
+        loop.close()
+
+    assert response is not None
+    assert model.calls
+    request = model.calls[0]["request"]
+    assert request is not None
+    hint = request.context["deterministic_step_hint"]
+    assert hint["inferred_step_id"] == "S18"
+    assert hint["overlay_step_id"] == "S18"
+    assert "vars.takeoff_trim_set==true" not in hint.get("missing_conditions", [])
+    assert hint["action_hint"]["target"] == "right_mdi_pb5"
+    assert hint["candidate_generation_rejected_step_id"] == "S17"
+    assert hint["candidate_generation_stale_missing_conditions"] == ["vars.takeoff_trim_set==true"]
+    assert "candidate_generation_stale_missing_condition:vars.takeoff_trim_set==true" in hint[
+        "candidate_generation_reasons"
+    ]
+
+    state_harness = request.context["state_harness"]
+    deterministic_candidate = state_harness["deterministic_candidate"]
+    assert deterministic_candidate["step_id"] == "S18"
+    assert deterministic_candidate["missing_conditions"] == ["vision_facts.fcsmc_page_visible==seen"]
+    assert request.context["vars"]["takeoff_trim_set"] is True
+    assert "vars.takeoff_trim_set==true" not in json.dumps(state_harness)
+    assert request.context["candidate_generation_rejected_step_id"] == "S17"
+    assert request.context["candidate_generation_stale_missing_conditions"] == [
+        "vars.takeoff_trim_set==true"
+    ]
+
+    trace = response.metadata["harness_trace"]
+    assert trace["candidate_generation"]["rejected_step_id"] == "S17"
+    assert trace["candidate_generation"]["stale_missing_conditions"] == [
+        "vars.takeoff_trim_set==true"
+    ]
+
+    help_obj = {
+        "diagnosis": {"step_id": "S18", "error_category": "OM"},
+        "next": {"step_id": "S18"},
+        "overlay": {
+            "targets": ["right_mdi_pb5"],
+            "evidence": [
+                {
+                    "target": "right_mdi_pb5",
+                    "type": "var",
+                    "ref": "VARS.takeoff_trim_set",
+                    "quote": "Takeoff trim is already set, so continue to the FCS-MC page.",
+                    "grounding_confidence": 0.9,
+                }
+            ],
+        },
+        "explanations": ["S17 is complete. Press right DDI PB5 to enter FCS-MC BIT."],
+    }
+    fake_client = FakeClient(
+        responses=[FakeResponse(_openai_chat_payload_from_help_obj(help_obj), status_code=200)]
+    )
+    provider = OpenAICompatModel(client=fake_client, lang="zh")
+    provider.explain_error(obs, request)
+
+    prompt_payload = _extract_prompt_constraints_json(
+        fake_client.calls[0]["json"]["messages"][1]["content"]
+    )
+    prompt_hint = prompt_payload["deterministic_step_hint"]
+    prompt_candidate = prompt_payload["state_harness"]["deterministic_candidate"]
+    assert prompt_hint["inferred_step_id"] == "S18"
+    assert prompt_hint["action_hint"]["target"] == "right_mdi_pb5"
+    assert prompt_candidate["step_id"] == "S18"
+    assert prompt_candidate["missing_conditions"] == ["vision_facts.fcsmc_page_visible==seen"]
+    assert "vars.takeoff_trim_set==true" not in json.dumps(prompt_payload)
 
 
 def test_live_help_visual_skip_trace_does_not_mark_s14_to_s15() -> None:


### PR DESCRIPTION
## Summary
- advance stale S17 candidates before model prompt when latest vars already satisfy takeoff trim
- preserve candidate-generation correction metadata in deterministic hints and harness trace
- pass request state harness/deterministic hint into real model prompt path so OpenAI-compatible prompts see repaired S18/PB5 packet
- add f04 replay fixture coverage for final PB5 repair and request/prompt packet consistency

## Tests
- pytest -q tests/test_live_dcs.py::test_live_help_fixture_315_f04_final_repair_uses_s18_default_pb5 tests/test_live_dcs.py::test_live_help_fixture_315_f04_stale_s17_candidate_advances_before_prompt tests/test_live_dcs.py::test_live_help_fixture_315_s18_advancement_uses_actionable_overlay tests/test_live_dcs.py::test_live_help_fixture_315_s18_advancement_uses_pb5_when_bit_root_seen tests/test_harness_validation.py::test_plan_harness_action_defaults_s18_unknown_visual_state_to_pb5
- pytest -q tests/test_openai_compat_model.py
- pytest -q tests/test_live_dcs.py -k 'fixture_315 or f04'
- pytest -q -s --basetemp=/tmp/pytest-iefmmq-full
- python3 tools/ci_guard.py

Closes #315