### PR TITLE
Add experiment export provenance gate

### DIFF
--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -7,8 +7,12 @@ behavior traces, system response metadata, and experiment-layer annotations.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field, asdict
+from pathlib import Path
 from typing import Any, Mapping, Sequence
+
+import yaml
 
 from core.help_cycle_audit import normalize_help_cycle_audit_fields
 from core.interaction_metrics import InteractionMetrics, compute_interaction_metrics
@@ -41,19 +45,95 @@ def _opt_int(raw: Any) -> int | None:
 def _opt_bool(raw: Any) -> bool | None:
     if isinstance(raw, bool):
         return raw
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in ("1", "true", "yes", "y"):
+            return True
+        if normalized in ("0", "false", "no", "n"):
+            return False
     return None
 
 
 # ── experiment-layer metadata ──────────────────────────────────────────
 
+EXPECTED_PACK_STEP_IDS = [f"S{i:02d}" for i in range(1, 34)]
+
+HELP_CYCLES_CSV_FIELDS = [
+    "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
+    "vision_used", "vision_status", "vision_fallback_reason", "sync_delta_ms",
+    "fused_step_id", "fused_missing_conditions", "model_next_step_id",
+    "overlay_targets", "overlay_executed", "overlay_rejected",
+    "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
+    "observability_status", "requires_visual_confirmation",
+    "scenario_profile",
+]
+
+CRITICAL_EXPORT_META_FIELDS = [
+    "trial_id",
+    "study_id",
+    "participant_id",
+    "condition",
+    "group",
+    "experimenter_id",
+    "questionnaire_ref",
+    "recording_ref",
+    "git_commit",
+    "git_dirty",
+    "pack_path",
+    "pack_hash",
+    "taxonomy_path",
+    "taxonomy_hash",
+    "ui_map_hash",
+    "bios_to_ui_hash",
+    "model_provider",
+    "model_name",
+    "vision_model_name",
+    "scenario_profile",
+    "dcs_mission",
+    "dcs_aircraft",
+    "raw_log_ref",
+    "raw_log_sha256",
+]
+
+RECOMMENDED_EXPORT_META_FIELDS: list[str] = []
+
+CRITICAL_ONE_OF_META_FIELDS = [
+    ("prompt_version or prompt_hash", ("prompt_version", "prompt_hash")),
+    ("vr_setup or monitor_setup", ("vr_setup", "monitor_setup")),
+]
+
 
 @dataclass
 class SessionMeta:
+    trial_id: str = ""
+    study_id: str = ""
     participant_id: str = ""
     session_id: str = ""
     condition: str = ""
     group: str = ""
+    experimenter_id: str | None = None
     questionnaire_ref: str | None = None
+    recording_ref: str | None = None
+    git_commit: str | None = None
+    git_dirty: bool | None = None
+    pack_path: str | None = None
+    pack_hash: str | None = None
+    taxonomy_path: str | None = None
+    taxonomy_hash: str | None = None
+    ui_map_hash: str | None = None
+    bios_to_ui_hash: str | None = None
+    model_provider: str | None = None
+    model_name: str | None = None
+    vision_model_name: str | None = None
+    prompt_version: str | None = None
+    prompt_hash: str | None = None
+    scenario_profile: str | None = None
+    dcs_mission: str | None = None
+    dcs_aircraft: str | None = None
+    vr_setup: str | None = None
+    monitor_setup: str | None = None
+    raw_log_ref: str | None = None
+    raw_log_sha256: str | None = None
     experimenter_notes: str | None = None
     started_at: str | None = None
     ended_at: str | None = None
@@ -64,15 +144,258 @@ class SessionMeta:
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> "SessionMeta":
         return cls(
+            trial_id=_opt_str(raw.get("trial_id")) or "",
+            study_id=_opt_str(raw.get("study_id")) or "",
             participant_id=_opt_str(raw.get("participant_id")) or "",
             session_id=_opt_str(raw.get("session_id")) or "",
             condition=_opt_str(raw.get("condition")) or "",
             group=_opt_str(raw.get("group")) or "",
+            experimenter_id=_opt_str(raw.get("experimenter_id")),
             questionnaire_ref=_opt_str(raw.get("questionnaire_ref")),
+            recording_ref=_opt_str(raw.get("recording_ref")),
+            git_commit=_opt_str(raw.get("git_commit")),
+            git_dirty=_opt_bool(raw.get("git_dirty")),
+            pack_path=_opt_str(raw.get("pack_path")),
+            pack_hash=_opt_str(raw.get("pack_hash")),
+            taxonomy_path=_opt_str(raw.get("taxonomy_path")),
+            taxonomy_hash=_opt_str(raw.get("taxonomy_hash")),
+            ui_map_hash=_opt_str(raw.get("ui_map_hash")),
+            bios_to_ui_hash=_opt_str(raw.get("bios_to_ui_hash")),
+            model_provider=_opt_str(raw.get("model_provider")),
+            model_name=_opt_str(raw.get("model_name")),
+            vision_model_name=_opt_str(raw.get("vision_model_name")),
+            prompt_version=_opt_str(raw.get("prompt_version")),
+            prompt_hash=_opt_str(raw.get("prompt_hash")),
+            scenario_profile=_opt_str(raw.get("scenario_profile")),
+            dcs_mission=_opt_str(raw.get("dcs_mission")),
+            dcs_aircraft=_opt_str(raw.get("dcs_aircraft")),
+            vr_setup=_opt_str(raw.get("vr_setup")),
+            monitor_setup=_opt_str(raw.get("monitor_setup")),
+            raw_log_ref=_opt_str(raw.get("raw_log_ref")),
+            raw_log_sha256=_opt_str(raw.get("raw_log_sha256")),
             experimenter_notes=_opt_str(raw.get("experimenter_notes")),
             started_at=_opt_str(raw.get("started_at")),
             ended_at=_opt_str(raw.get("ended_at")),
         )
+
+
+@dataclass
+class ExportQualityReport:
+    strict: bool = False
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    checks: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "strict": self.strict,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+            "checks": dict(self.checks),
+        }
+
+
+def build_file_sha256(path: str | Path) -> str:
+    hasher = hashlib.sha256()
+    with Path(path).open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _meta_value_present(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _load_yaml_mapping(path: str | Path) -> Mapping[str, Any]:
+    payload = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("YAML root must be a mapping")
+    return payload
+
+
+def _append_gate_issue(report: ExportQualityReport, message: str, *, strict: bool) -> None:
+    if strict:
+        report.errors.append(message)
+    else:
+        report.warnings.append(message)
+
+
+def build_export_quality_report(
+    meta: SessionMeta,
+    *,
+    events: Sequence[Mapping[str, Any]],
+    strict: bool = False,
+    pack_path: str | Path | None = None,
+    taxonomy_path: str | Path | None = None,
+    ui_map_path: str | Path | None = None,
+    bios_to_ui_path: str | Path | None = None,
+    raw_log_copied: bool = False,
+    expected_help_cycle_rows: int | None = None,
+    actual_help_cycle_rows: int | None = None,
+    help_cycle_csv_headers: Sequence[str] | None = None,
+) -> ExportQualityReport:
+    report = ExportQualityReport(strict=bool(strict))
+    report.checks["event_count"] = len(events)
+
+    for field_name in CRITICAL_EXPORT_META_FIELDS:
+        if not _meta_value_present(getattr(meta, field_name)):
+            _append_gate_issue(
+                report,
+                f"missing critical metadata field: {field_name}",
+                strict=strict,
+            )
+
+    for group_name, field_names in CRITICAL_ONE_OF_META_FIELDS:
+        if not any(_meta_value_present(getattr(meta, field_name)) for field_name in field_names):
+            _append_gate_issue(
+                report,
+                f"missing critical metadata field: {group_name}",
+                strict=strict,
+            )
+
+    missing_recommended = [
+        field_name
+        for field_name in RECOMMENDED_EXPORT_META_FIELDS
+        if not _meta_value_present(getattr(meta, field_name))
+    ]
+    report.checks["missing_recommended_metadata_fields"] = missing_recommended
+    for field_name in missing_recommended:
+        report.warnings.append(f"missing recommended metadata field: {field_name}")
+
+    if not raw_log_copied:
+        _append_gate_issue(
+            report,
+            "raw_log was not copied into the export directory",
+            strict=strict,
+        )
+    report.checks["raw_log_copied"] = bool(raw_log_copied)
+
+    def _validate_hash(path: str | Path | None, meta_hash_field: str) -> None:
+        if path is None:
+            return
+        try:
+            actual_hash = build_file_sha256(path)
+        except Exception as exc:
+            _append_gate_issue(
+                report,
+                f"failed to hash {Path(path).name}: {exc}",
+                strict=strict,
+            )
+            return
+        recorded_hash = getattr(meta, meta_hash_field)
+        report.checks[f"actual_{meta_hash_field}"] = actual_hash
+        if _meta_value_present(recorded_hash) and recorded_hash != actual_hash:
+            _append_gate_issue(
+                report,
+                f"{meta_hash_field} does not match file content",
+                strict=strict,
+            )
+
+    if pack_path is None:
+        _append_gate_issue(report, "pack_path is required for S01-S33 quality gate", strict=strict)
+    else:
+        _validate_hash(pack_path, "pack_hash")
+        try:
+            pack = _load_yaml_mapping(pack_path)
+            steps = pack.get("steps")
+            if not isinstance(steps, list):
+                raise ValueError("pack.yaml missing top-level steps list")
+            step_ids = [
+                item.get("id")
+                for item in steps
+                if isinstance(item, Mapping) and isinstance(item.get("id"), str)
+            ]
+            report.checks["pack_step_ids"] = step_ids
+            if step_ids != EXPECTED_PACK_STEP_IDS:
+                _append_gate_issue(
+                    report,
+                    "pack steps must be exactly S01-S33 in order",
+                    strict=strict,
+                )
+        except Exception as exc:
+            _append_gate_issue(report, f"failed to validate pack steps: {exc}", strict=strict)
+
+    if taxonomy_path is None:
+        _append_gate_issue(report, "taxonomy_path is required for scoring quality gate", strict=strict)
+    else:
+        _validate_hash(taxonomy_path, "taxonomy_hash")
+        try:
+            taxonomy = _load_yaml_mapping(taxonomy_path)
+            scoring = taxonomy.get("scoring")
+            taxonomy_root = taxonomy.get("taxonomy")
+            categories = taxonomy_root.get("categories") if isinstance(taxonomy_root, Mapping) else None
+            if not isinstance(scoring, Mapping):
+                raise ValueError("taxonomy.yaml missing scoring mapping")
+            if not isinstance(categories, list) or not categories:
+                raise ValueError("taxonomy.yaml missing taxonomy.categories")
+            weights = scoring.get("base_weights")
+            if not isinstance(weights, Mapping):
+                raise ValueError("taxonomy.yaml missing scoring.base_weights")
+            category_codes = [
+                item.get("code")
+                for item in categories
+                if isinstance(item, Mapping) and isinstance(item.get("code"), str)
+            ]
+            report.checks["taxonomy_category_codes"] = category_codes
+            missing_weights = [code for code in category_codes if code not in weights]
+            if missing_weights:
+                _append_gate_issue(
+                    report,
+                    "taxonomy categories missing scoring weights: " + ", ".join(missing_weights),
+                    strict=strict,
+                )
+        except Exception as exc:
+            _append_gate_issue(report, f"failed to validate taxonomy/scoring docs: {exc}", strict=strict)
+
+    _validate_hash(ui_map_path, "ui_map_hash")
+    _validate_hash(bios_to_ui_path, "bios_to_ui_hash")
+
+    if help_cycle_csv_headers is not None:
+        header_list = list(help_cycle_csv_headers)
+        report.checks["help_cycles_csv_headers"] = header_list
+        if header_list != HELP_CYCLES_CSV_FIELDS:
+            _append_gate_issue(
+                report,
+                "help_cycles.csv headers do not match expected export contract",
+                strict=strict,
+            )
+    elif expected_help_cycle_rows is not None:
+        _append_gate_issue(
+            report,
+            "help_cycles.csv was not generated for row/header validation",
+            strict=strict,
+        )
+
+    if actual_help_cycle_rows is not None and expected_help_cycle_rows is not None:
+        report.checks["help_cycle_row_count"] = actual_help_cycle_rows
+        report.checks["expected_help_cycle_row_count"] = expected_help_cycle_rows
+        if actual_help_cycle_rows != expected_help_cycle_rows:
+            _append_gate_issue(
+                report,
+                (
+                    "help_cycles.csv row count mismatch: "
+                    f"expected {expected_help_cycle_rows}, got {actual_help_cycle_rows}"
+                ),
+                strict=strict,
+            )
+    elif expected_help_cycle_rows is not None:
+        _append_gate_issue(
+            report,
+            "help_cycles.csv row count was not available for validation",
+            strict=strict,
+        )
+
+    return report
 
 
 # ── per-cycle behavioural record ───────────────────────────────────────
@@ -137,6 +460,7 @@ class ExperimentExport:
     help_cycles: list[HelpCycleRecord] = field(default_factory=list)
     scoring: dict[str, Any] | None = None
     timeline: list[TimelineSnapshot] = field(default_factory=list)
+    quality_gate: ExportQualityReport | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -145,6 +469,7 @@ class ExperimentExport:
             "help_cycles": [c.to_dict() for c in self.help_cycles],
             "scoring": self.scoring,
             "timeline": [t.to_dict() for t in self.timeline],
+            "quality_gate": self.quality_gate.to_dict() if self.quality_gate is not None else None,
         }
 
 
@@ -479,8 +804,12 @@ def build_experiment_export(
 
 __all__ = [
     "SessionMeta",
+    "ExportQualityReport",
     "HelpCycleRecord",
     "TimelineSnapshot",
     "ExperimentExport",
+    "HELP_CYCLES_CSV_FIELDS",
+    "build_export_quality_report",
     "build_experiment_export",
+    "build_file_sha256",
 ]

--- a/simtutor/__main__.py
+++ b/simtutor/__main__.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import shutil
+import subprocess
 import sys
 import time
 from typing import Any, Iterable, Tuple
@@ -376,23 +378,151 @@ def _run_extract_live_fixture(args: argparse.Namespace) -> int:
 
 def _sanitize_participant_slug(raw: str) -> str:
     """Return a safe directory name from a participant identifier."""
+    return _sanitize_export_slug(raw, field_name="participant_id")
+
+
+def _sanitize_export_slug(raw: str, *, field_name: str) -> str:
+    """Return a safe directory name from an experiment identifier."""
     # Discard any path component; only use the terminal name.
     slug = Path(raw).name.strip()
     if not slug or slug in (".", ".."):
-        raise ValueError(f"participant_id resolves to unsafe or empty path component: {raw!r}")
+        raise ValueError(f"{field_name} resolves to unsafe or empty path component: {raw!r}")
     # Restrict to alphanumeric + underscore + hyphen for filesystem safety.
     if not slug.replace("_", "").replace("-", "").isalnum():
         raise ValueError(
-            f"participant_id must contain only letters, digits, underscores, and hyphens: {slug!r}"
+            f"{field_name} must contain only letters, digits, underscores, and hyphens: {slug!r}"
         )
     return slug
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _git_text(args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=_repo_root(),
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return None
+    return result.stdout.strip()
+
+
+def _current_git_commit() -> str | None:
+    return _git_text(["rev-parse", "HEAD"])
+
+
+def _current_git_dirty() -> bool | None:
+    status = _git_text(["status", "--short"])
+    if status is None:
+        return None
+    return bool(status)
+
+
+def _coerce_optional_bool(raw: Any) -> bool | None:
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        if normalized in ("1", "true", "yes", "y"):
+            return True
+        if normalized in ("0", "false", "no", "n"):
+            return False
+    return None
+
+
+def _optional_file_sha256(path: str | None) -> str | None:
+    if not path:
+        return None
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        from core.experiment_export import build_file_sha256
+
+        return build_file_sha256(p)
+    except OSError:
+        return None
+
+
+def _print_quality_report(report: Any) -> None:
+    for warning in getattr(report, "warnings", []):
+        print(f"[EXPERIMENT_EXPORT] warning: {warning}")
+    for error in getattr(report, "errors", []):
+        print(f"[EXPERIMENT_EXPORT] error: {error}")
+
+
+def _read_csv_header_and_row_count(path: Path) -> tuple[list[str] | None, int | None]:
+    import csv
+
+    if not path.exists():
+        return None, None
+    with path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        try:
+            header = next(reader)
+        except StopIteration:
+            return [], 0
+        return header, sum(1 for _ in reader)
+
+
+def _new_export_staging_dir(out_dir: Path) -> Path:
+    return out_dir.parent / f".{out_dir.name}.tmp-{os.getpid()}-{time.time_ns()}"
+
+
+def _publish_managed_outputs(staging_dir: Path, out_dir: Path, names: list[str]) -> None:
+    backup_dir = out_dir.parent / f".{out_dir.name}.bak-{os.getpid()}-{time.time_ns()}"
+    backed_up = False
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            dest = out_dir / name
+            if dest.exists():
+                backup_dir.mkdir(parents=True, exist_ok=True)
+                os.replace(dest, backup_dir / name)
+                backed_up = True
+
+        for name in names:
+            src = staging_dir / name
+            if src.exists():
+                os.replace(src, out_dir / name)
+
+        if backed_up:
+            shutil.rmtree(backup_dir, ignore_errors=True)
+    except OSError:
+        if backed_up:
+            for name in names:
+                backup = backup_dir / name
+                dest = out_dir / name
+                if backup.exists():
+                    try:
+                        if dest.exists():
+                            dest.unlink()
+                        os.replace(backup, dest)
+                    except OSError:
+                        pass
+        raise
+    finally:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        shutil.rmtree(backup_dir, ignore_errors=True)
 
 
 def _run_experiment_export(args: argparse.Namespace) -> int:
     import csv
 
     from core.event_store import JsonlEventStore
-    from core.experiment_export import build_experiment_export
+    from core.experiment_export import (
+        HELP_CYCLES_CSV_FIELDS,
+        build_export_quality_report,
+        build_experiment_export,
+        build_file_sha256,
+    )
 
     input_path = Path(args.file)
     if not input_path.exists():
@@ -416,11 +546,53 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
         else:
             print(f"[EXPERIMENT_EXPORT] warning: --scoring path not found: {scoring_path}")
 
+    pack_path = getattr(args, "pack", None)
+    taxonomy_path = getattr(args, "taxonomy", None)
+    ui_map_path = getattr(args, "ui_map", None)
+    bios_to_ui_path = getattr(args, "bios_to_ui", None)
+    copy_raw_log = bool(getattr(args, "copy_raw_log", True))
+    raw_log_ref = "raw_events.jsonl" if copy_raw_log else str(input_path.resolve())
+
+    git_commit = getattr(args, "git_commit", None) or _current_git_commit()
+    git_dirty = _coerce_optional_bool(getattr(args, "git_dirty", None))
+    if git_dirty is None:
+        git_dirty = _current_git_dirty()
+
+    try:
+        raw_log_hash = build_file_sha256(input_path)
+    except OSError as exc:
+        print(f"[EXPERIMENT_EXPORT] failed to hash raw event log: {exc}")
+        return 1
+
     meta_overrides = {
+        "trial_id": getattr(args, "trial_id", None),
+        "study_id": getattr(args, "study_id", None),
         "participant_id": args.participant_id,
         "condition": args.condition,
         "group": args.group,
+        "experimenter_id": getattr(args, "experimenter_id", None),
         "questionnaire_ref": args.questionnaire,
+        "recording_ref": getattr(args, "recording_ref", None),
+        "git_commit": git_commit,
+        "git_dirty": git_dirty,
+        "pack_path": pack_path,
+        "pack_hash": _optional_file_sha256(pack_path),
+        "taxonomy_path": taxonomy_path,
+        "taxonomy_hash": _optional_file_sha256(taxonomy_path),
+        "ui_map_hash": _optional_file_sha256(ui_map_path),
+        "bios_to_ui_hash": _optional_file_sha256(bios_to_ui_path),
+        "model_provider": getattr(args, "model_provider", None),
+        "model_name": getattr(args, "model_name", None),
+        "vision_model_name": getattr(args, "vision_model_name", None),
+        "prompt_version": getattr(args, "prompt_version", None),
+        "prompt_hash": getattr(args, "prompt_hash", None),
+        "scenario_profile": getattr(args, "scenario_profile", None),
+        "dcs_mission": getattr(args, "dcs_mission", None),
+        "dcs_aircraft": getattr(args, "dcs_aircraft", None),
+        "vr_setup": getattr(args, "vr_setup", None),
+        "monitor_setup": getattr(args, "monitor_setup", None),
+        "raw_log_ref": raw_log_ref,
+        "raw_log_sha256": raw_log_hash,
         "experimenter_notes": args.notes,
     }
 
@@ -433,38 +605,56 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
             print(f"[EXPERIMENT_EXPORT] invalid participant_id: {exc}")
             return 1
         out_dir = out_dir / safe_id
-    try:
-        out_dir.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        print(f"[EXPERIMENT_EXPORT] failed to create output directory: {exc}")
+    if getattr(args, "trial_id", None):
+        try:
+            safe_trial_id = _sanitize_export_slug(args.trial_id, field_name="trial_id")
+        except ValueError as exc:
+            print(f"[EXPERIMENT_EXPORT] invalid trial_id: {exc}")
+            return 1
+        out_dir = out_dir / safe_trial_id
+
+    managed_output_names = [
+        "session.json",
+        "summary.json",
+        "help_cycles.csv",
+        "raw_events.jsonl",
+        "quality_gate.json",
+    ]
+    managed_outputs = [out_dir / name for name in managed_output_names]
+    existing_outputs = [p for p in managed_outputs if p.exists()]
+    if existing_outputs and not bool(getattr(args, "overwrite", False)):
+        existing = ", ".join(str(p) for p in existing_outputs)
+        print(f"[EXPERIMENT_EXPORT] output already exists; pass --overwrite to replace: {existing}")
         return 1
 
-    # session.json
-    session_path = out_dir / "session.json"
-    try:
-        session_path.write_text(
-            json.dumps(export.to_dict(), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-    except OSError as exc:
-        print(f"[EXPERIMENT_EXPORT] failed to write session.json: {exc}")
+    preflight_report = build_export_quality_report(
+        export.meta,
+        events=events,
+        strict=bool(getattr(args, "strict", False)),
+        pack_path=pack_path,
+        taxonomy_path=taxonomy_path,
+        ui_map_path=ui_map_path,
+        bios_to_ui_path=bios_to_ui_path,
+        raw_log_copied=copy_raw_log,
+        expected_help_cycle_rows=None,
+        actual_help_cycle_rows=None,
+        help_cycle_csv_headers=None,
+    )
+    _print_quality_report(preflight_report)
+    if preflight_report.errors:
         return 1
-    print(f"[EXPERIMENT_EXPORT] wrote {session_path}")
 
-    # help_cycles.csv
-    if export.help_cycles:
-        csv_path = out_dir / "help_cycles.csv"
-        cycle_fields = [
-            "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
-            "vision_used", "vision_status", "vision_fallback_reason", "sync_delta_ms",
-            "fused_step_id", "fused_missing_conditions", "model_next_step_id",
-            "overlay_targets", "overlay_executed", "overlay_rejected",
-            "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
-            "observability_status", "requires_visual_confirmation",
-            "scenario_profile",
-        ]
+    staging_dir = _new_export_staging_dir(out_dir)
+    try:
+        staging_dir.mkdir(parents=True, exist_ok=False)
+
+        if copy_raw_log:
+            shutil.copy2(input_path, staging_dir / "raw_events.jsonl")
+
+        # help_cycles.csv
+        csv_path = staging_dir / "help_cycles.csv"
         with csv_path.open("w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=cycle_fields, extrasaction="ignore")
+            writer = csv.DictWriter(f, fieldnames=HELP_CYCLES_CSV_FIELDS, extrasaction="ignore")
             writer.writeheader()
             for c in export.help_cycles:
                 row = c.to_dict()
@@ -472,19 +662,63 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
                 row["fused_missing_conditions"] = ";".join(c.fused_missing_conditions)
                 row["overlay_targets"] = ";".join(c.overlay_targets)
                 writer.writerow(row)
-        print(f"[EXPERIMENT_EXPORT] wrote {csv_path} ({len(export.help_cycles)} cycles)")
 
-    # summary.json
-    summary_path = out_dir / "summary.json"
-    try:
+        # summary.json
+        summary_path = staging_dir / "summary.json"
         summary_path.write_text(
             json.dumps(export.summary.to_dict(), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+
+        csv_headers, csv_rows = _read_csv_header_and_row_count(staging_dir / "help_cycles.csv")
+        final_report = build_export_quality_report(
+            export.meta,
+            events=events,
+            strict=bool(getattr(args, "strict", False)),
+            pack_path=pack_path,
+            taxonomy_path=taxonomy_path,
+            ui_map_path=ui_map_path,
+            bios_to_ui_path=bios_to_ui_path,
+            raw_log_copied=(staging_dir / "raw_events.jsonl").exists() if copy_raw_log else False,
+            expected_help_cycle_rows=len(export.help_cycles),
+            actual_help_cycle_rows=csv_rows,
+            help_cycle_csv_headers=csv_headers,
+        )
+        _print_quality_report(final_report)
+        if final_report.errors:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            return 1
+
+        export.quality_gate = final_report
+        quality_path = staging_dir / "quality_gate.json"
+        quality_path.write_text(
+            json.dumps(final_report.to_dict(), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        # session.json
+        session_path = staging_dir / "session.json"
+        session_path.write_text(
+            json.dumps(export.to_dict(), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     except OSError as exc:
-        print(f"[EXPERIMENT_EXPORT] failed to write summary.json: {exc}")
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        print(f"[EXPERIMENT_EXPORT] failed to write staged export artifacts: {exc}")
         return 1
-    print(f"[EXPERIMENT_EXPORT] wrote {summary_path}")
+
+    try:
+        _publish_managed_outputs(staging_dir, out_dir, managed_output_names)
+    except OSError as exc:
+        print(f"[EXPERIMENT_EXPORT] failed to publish export artifacts: {exc}")
+        return 1
+
+    if copy_raw_log:
+        print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'raw_events.jsonl'}")
+    print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'help_cycles.csv'} ({len(export.help_cycles)} cycles)")
+    print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'summary.json'}")
+    print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'quality_gate.json'}")
+    print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'session.json'}")
 
     return 0
 
@@ -528,13 +762,47 @@ def main() -> int:
         help="Export runtime event log as study-ready experiment artifacts",
     )
     exp_export.add_argument("file", help="Event log JSONL")
+    exp_export.add_argument("--trial-id", default=None, help="Trial identifier")
+    exp_export.add_argument("--study-id", default=None, help="Study identifier")
     exp_export.add_argument("--participant-id", default=None, help="Participant identifier")
     exp_export.add_argument("--condition", default=None, help="Experimental condition (e.g. with_tutor, without_tutor)")
     exp_export.add_argument("--group", default=None, help="Participant group (e.g. novice, expert)")
+    exp_export.add_argument("--experimenter-id", default=None, help="Experimenter identifier")
     exp_export.add_argument("--questionnaire", default=None, help="Path to linked questionnaire YAML/JSON")
+    exp_export.add_argument("--recording-ref", default=None, help="Immutable recording reference for the trial")
     exp_export.add_argument("--notes", default=None, help="Free-text experimenter notes")
     exp_export.add_argument("--output-dir", default="artifacts/experiments", help="Output directory")
     exp_export.add_argument("--scoring", default=None, help="Optional scoring JSON to embed (from simtutor score)")
+    exp_export.add_argument("--pack", default="packs/fa18c_startup/pack.yaml", help="pack.yaml path")
+    exp_export.add_argument("--taxonomy", default="packs/fa18c_startup/taxonomy.yaml", help="taxonomy.yaml path")
+    exp_export.add_argument("--ui-map", default="packs/fa18c_startup/ui_map.yaml", help="ui_map.yaml path")
+    exp_export.add_argument("--bios-to-ui", default="packs/fa18c_startup/bios_to_ui.yaml", help="bios_to_ui.yaml path")
+    exp_export.add_argument("--model-provider", default=None, help="Model provider used for the trial")
+    exp_export.add_argument("--model-name", default=None, help="Text/help model name used for the trial")
+    exp_export.add_argument("--vision-model-name", default=None, help="Vision model name used for the trial")
+    exp_export.add_argument("--prompt-version", default=None, help="Prompt version label used for the trial")
+    exp_export.add_argument("--prompt-hash", default=None, help="Prompt hash used for the trial, when available")
+    exp_export.add_argument("--scenario-profile", default=None, help="Scenario profile used for the trial")
+    exp_export.add_argument("--dcs-mission", default=None, help="DCS mission file or immutable mission reference")
+    exp_export.add_argument("--dcs-aircraft", default=None, help="DCS aircraft/module used for the trial")
+    exp_export.add_argument("--vr-setup", default=None, help="VR setup description/reference")
+    exp_export.add_argument("--monitor-setup", default=None, help="Monitor/export setup description/reference")
+    exp_export.add_argument("--git-commit", default=None, help="Override detected git commit")
+    exp_export.add_argument(
+        "--git-dirty",
+        choices=["true", "false", "1", "0", "yes", "no"],
+        default=None,
+        help="Override detected git dirty flag",
+    )
+    exp_export.add_argument("--strict", action="store_true", help="Fail when critical export metadata/gates are missing")
+    exp_export.add_argument("--overwrite", action="store_true", help="Allow replacing an existing participant/trial export")
+    exp_export.add_argument(
+        "--no-copy-raw-log",
+        dest="copy_raw_log",
+        action="store_false",
+        help="Record the raw log reference without copying it into the export directory",
+    )
+    exp_export.set_defaults(copy_raw_log=True)
 
     sub.add_parser("model-config", help="Validate model provider env and print non-sensitive startup info")
 

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -2,14 +2,22 @@
 End-to-end tests for experiment export pipeline.
 """
 
+import argparse
+import csv
+import hashlib
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
+import simtutor.__main__ as simtutor_cli
 from core.experiment_export import (
     SessionMeta,
     HelpCycleRecord,
+    build_export_quality_report,
     build_experiment_export,
+    build_file_sha256,
 )
+from simtutor.__main__ import _run_experiment_export
 
 
 # ── helpers ────────────────────────────────────────────────────────────
@@ -251,24 +259,58 @@ def _make_events_with_help_cycles() -> list[dict]:
 
 def test_session_meta_roundtrip():
     meta = SessionMeta(
+        trial_id="T01",
+        study_id="study-alpha",
         participant_id="P01",
         session_id="sess-1",
         condition="with_tutor",
         group="novice",
+        experimenter_id="E01",
         questionnaire_ref="questionnaires/P01_pre.yml",
+        recording_ref="recordings/P01_T01.mp4",
+        git_commit="abc123",
+        git_dirty=False,
+        pack_path="packs/fa18c_startup/pack.yaml",
+        pack_hash="pack-sha",
+        taxonomy_path="packs/fa18c_startup/taxonomy.yaml",
+        taxonomy_hash="taxonomy-sha",
+        ui_map_hash="ui-map-sha",
+        bios_to_ui_hash="bios-ui-sha",
+        model_provider="stub",
+        model_name="ModelStub",
+        vision_model_name="VisionStub",
+        prompt_version="prompt-v1",
+        prompt_hash="prompt-sha",
+        scenario_profile="airfield",
+        dcs_mission="cold-start.miz",
+        dcs_aircraft="FA-18C",
+        vr_setup="Quest 3",
+        monitor_setup="native-viewports",
+        raw_log_ref="raw_events.jsonl",
+        raw_log_sha256="raw-sha",
         experimenter_notes="no issues",
         started_at="2026-05-09T10:00:00+00:00",
         ended_at="2026-05-09T10:30:00+00:00",
     )
     d = meta.to_dict()
+    assert d["trial_id"] == "T01"
+    assert d["study_id"] == "study-alpha"
     assert d["participant_id"] == "P01"
     assert d["condition"] == "with_tutor"
     assert d["questionnaire_ref"] == "questionnaires/P01_pre.yml"
+    assert d["recording_ref"] == "recordings/P01_T01.mp4"
+    assert d["git_dirty"] is False
+    assert d["pack_hash"] == "pack-sha"
+    assert d["raw_log_sha256"] == "raw-sha"
 
     reloaded = SessionMeta.from_dict(d)
+    assert reloaded.trial_id == "T01"
     assert reloaded.participant_id == "P01"
     assert reloaded.condition == "with_tutor"
     assert reloaded.questionnaire_ref == "questionnaires/P01_pre.yml"
+    assert reloaded.recording_ref == "recordings/P01_T01.mp4"
+    assert reloaded.git_dirty is False
+    assert reloaded.raw_log_ref == "raw_events.jsonl"
 
 
 def test_session_meta_from_partial():
@@ -435,3 +477,385 @@ def test_timeline_snapshot_fields():
         assert isinstance(snap.blocked_step_ids, list)
         # active_step_id may be None or str
         assert snap.active_step_id is None or isinstance(snap.active_step_id, str)
+
+
+def test_build_file_sha256(tmp_path: Path):
+    payload = b"experiment provenance\n"
+    path = tmp_path / "raw.jsonl"
+    path.write_bytes(payload)
+
+    assert build_file_sha256(path) == hashlib.sha256(payload).hexdigest()
+
+
+def test_quality_gate_strict_reports_missing_critical_metadata():
+    report = build_export_quality_report(
+        SessionMeta(participant_id="P01"),
+        events=[],
+        strict=True,
+        pack_path=None,
+        taxonomy_path=None,
+        raw_log_copied=False,
+        expected_help_cycle_rows=0,
+        actual_help_cycle_rows=None,
+        help_cycle_csv_headers=None,
+    )
+
+    assert report.passed is False
+    assert any("trial_id" in error for error in report.errors)
+    assert any("study_id" in error for error in report.errors)
+    assert any("raw_log" in error for error in report.errors)
+
+
+def test_quality_gate_strict_requires_model_prompt_and_dcs_metadata(tmp_path: Path):
+    root = _repo_root()
+    raw_log = tmp_path / "raw.jsonl"
+    raw_log.write_text("{}\n", encoding="utf-8")
+    meta = SessionMeta(
+        trial_id="T01",
+        study_id="study-alpha",
+        participant_id="P01",
+        condition="with_tutor",
+        group="novice",
+        experimenter_id="E01",
+        questionnaire_ref="questionnaires/P01_pre.yml",
+        recording_ref="recordings/P01_T01.mp4",
+        git_commit="abc123",
+        git_dirty=False,
+        pack_path=str(root / "packs/fa18c_startup/pack.yaml"),
+        pack_hash=build_file_sha256(root / "packs/fa18c_startup/pack.yaml"),
+        taxonomy_path=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        taxonomy_hash=build_file_sha256(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map_hash=build_file_sha256(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui_hash=build_file_sha256(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        raw_log_ref="raw_events.jsonl",
+        raw_log_sha256=build_file_sha256(raw_log),
+    )
+
+    report = build_export_quality_report(
+        meta,
+        events=[],
+        strict=True,
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        taxonomy_path=root / "packs/fa18c_startup/taxonomy.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        raw_log_copied=True,
+        expected_help_cycle_rows=0,
+        actual_help_cycle_rows=0,
+        help_cycle_csv_headers=[
+            "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
+            "vision_used", "vision_status", "vision_fallback_reason", "sync_delta_ms",
+            "fused_step_id", "fused_missing_conditions", "model_next_step_id",
+            "overlay_targets", "overlay_executed", "overlay_rejected",
+            "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
+            "observability_status", "requires_visual_confirmation",
+            "scenario_profile",
+        ],
+    )
+
+    assert report.passed is False
+    assert any("model_provider" in error for error in report.errors)
+    assert any("prompt_version or prompt_hash" in error for error in report.errors)
+    assert any("dcs_mission" in error for error in report.errors)
+    assert any("vr_setup or monitor_setup" in error for error in report.errors)
+
+
+def test_quality_gate_rejects_hash_mismatch():
+    root = _repo_root()
+    meta = SessionMeta(
+        trial_id="T01",
+        study_id="study-alpha",
+        participant_id="P01",
+        condition="with_tutor",
+        group="novice",
+        experimenter_id="E01",
+        questionnaire_ref="questionnaires/P01_pre.yml",
+        recording_ref="recordings/P01_T01.mp4",
+        git_commit="abc123",
+        git_dirty=False,
+        pack_path=str(root / "packs/fa18c_startup/pack.yaml"),
+        pack_hash="wrong-pack-hash",
+        taxonomy_path=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        taxonomy_hash=build_file_sha256(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map_hash=build_file_sha256(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui_hash=build_file_sha256(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        model_provider="stub",
+        model_name="ModelStub",
+        vision_model_name="VisionStub",
+        prompt_version="prompt-v1",
+        scenario_profile="airfield",
+        dcs_mission="cold-start.miz",
+        dcs_aircraft="FA-18C",
+        vr_setup="Quest 3",
+        monitor_setup="native-viewports",
+        raw_log_ref="raw_events.jsonl",
+        raw_log_sha256="raw-sha",
+    )
+
+    report = build_export_quality_report(
+        meta,
+        events=[],
+        strict=True,
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        taxonomy_path=root / "packs/fa18c_startup/taxonomy.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        raw_log_copied=True,
+        expected_help_cycle_rows=0,
+        actual_help_cycle_rows=0,
+        help_cycle_csv_headers=[
+            "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
+            "vision_used", "vision_status", "vision_fallback_reason", "sync_delta_ms",
+            "fused_step_id", "fused_missing_conditions", "model_next_step_id",
+            "overlay_targets", "overlay_executed", "overlay_rejected",
+            "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
+            "observability_status", "requires_visual_confirmation",
+            "scenario_profile",
+        ],
+    )
+
+    assert report.passed is False
+    assert any("pack_hash" in error and "does not match" in error for error in report.errors)
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(event, ensure_ascii=False) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_experiment_export_cli_freezes_metadata_and_copies_raw_log(tmp_path: Path):
+    raw_log = tmp_path / "events.jsonl"
+    _write_jsonl(raw_log, _make_events_with_help_cycles())
+    output_dir = tmp_path / "exports"
+    root = _repo_root()
+
+    args = argparse.Namespace(
+        file=str(raw_log),
+        participant_id="P01",
+        trial_id="T01",
+        study_id="study-alpha",
+        condition="with_tutor",
+        group="novice",
+        experimenter_id="E01",
+        questionnaire="questionnaires/P01_pre.yml",
+        recording_ref="recordings/P01_T01.mp4",
+        notes="no issues",
+        output_dir=str(output_dir),
+        scoring=None,
+        pack=str(root / "packs/fa18c_startup/pack.yaml"),
+        taxonomy=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map=str(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui=str(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        model_provider="stub",
+        model_name="ModelStub",
+        vision_model_name="VisionStub",
+        prompt_version="prompt-v1",
+        prompt_hash=None,
+        scenario_profile="airfield",
+        dcs_mission="cold-start.miz",
+        dcs_aircraft="FA-18C",
+        vr_setup="Quest 3",
+        monitor_setup="native-viewports",
+        git_commit="abc123",
+        git_dirty=False,
+        strict=True,
+        overwrite=False,
+        copy_raw_log=True,
+    )
+
+    assert _run_experiment_export(args) == 0
+
+    trial_dir = output_dir / "P01" / "T01"
+    session = json.loads((trial_dir / "session.json").read_text(encoding="utf-8"))
+    meta = session["meta"]
+    assert meta["trial_id"] == "T01"
+    assert meta["study_id"] == "study-alpha"
+    assert meta["git_commit"] == "abc123"
+    assert meta["git_dirty"] is False
+    assert meta["pack_hash"] == build_file_sha256(root / "packs/fa18c_startup/pack.yaml")
+    assert meta["taxonomy_hash"] == build_file_sha256(root / "packs/fa18c_startup/taxonomy.yaml")
+    assert meta["ui_map_hash"] == build_file_sha256(root / "packs/fa18c_startup/ui_map.yaml")
+    assert meta["bios_to_ui_hash"] == build_file_sha256(root / "packs/fa18c_startup/bios_to_ui.yaml")
+    assert meta["raw_log_ref"] == "raw_events.jsonl"
+    assert meta["raw_log_sha256"] == build_file_sha256(raw_log)
+    assert build_file_sha256(trial_dir / "raw_events.jsonl") == build_file_sha256(raw_log)
+    assert session["quality_gate"]["passed"] is True
+
+    # A second export to the same participant/trial directory must not
+    # silently replace study data unless explicitly allowed.
+    assert _run_experiment_export(args) == 1
+    args.overwrite = True
+    assert _run_experiment_export(args) == 0
+
+
+def test_experiment_export_cli_overwrite_replaces_stale_managed_outputs(tmp_path: Path):
+    raw_log = tmp_path / "events.jsonl"
+    _write_jsonl(raw_log, _make_events_with_help_cycles())
+    output_dir = tmp_path / "exports"
+    root = _repo_root()
+    args = argparse.Namespace(
+        file=str(raw_log),
+        participant_id="P01",
+        trial_id="T01",
+        study_id="study-alpha",
+        condition="with_tutor",
+        group="novice",
+        experimenter_id="E01",
+        questionnaire="questionnaires/P01_pre.yml",
+        recording_ref="recordings/P01_T01.mp4",
+        notes="no issues",
+        output_dir=str(output_dir),
+        scoring=None,
+        pack=str(root / "packs/fa18c_startup/pack.yaml"),
+        taxonomy=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map=str(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui=str(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        model_provider="stub",
+        model_name="ModelStub",
+        vision_model_name="VisionStub",
+        prompt_version="prompt-v1",
+        prompt_hash=None,
+        scenario_profile="airfield",
+        dcs_mission="cold-start.miz",
+        dcs_aircraft="FA-18C",
+        vr_setup="Quest 3",
+        monitor_setup="native-viewports",
+        git_commit="abc123",
+        git_dirty=False,
+        strict=True,
+        overwrite=False,
+        copy_raw_log=True,
+    )
+    assert _run_experiment_export(args) == 0
+
+    _write_jsonl(raw_log, [
+        {
+            "kind": "step_activated",
+            "payload": {"step_id": "S01"},
+            "t_wall": 0.0,
+            "session_id": "sess-no-help",
+        }
+    ])
+    args.overwrite = True
+    assert _run_experiment_export(args) == 0
+
+    trial_dir = output_dir / "P01" / "T01"
+    with (trial_dir / "help_cycles.csv").open("r", newline="", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    assert len(rows) == 1
+    assert build_file_sha256(trial_dir / "raw_events.jsonl") == build_file_sha256(raw_log)
+
+
+def test_experiment_export_cli_overwrite_preserves_old_export_when_preflight_fails(tmp_path: Path):
+    raw_log = tmp_path / "events.jsonl"
+    _write_jsonl(raw_log, _make_events_with_help_cycles())
+    output_dir = tmp_path / "exports"
+    root = _repo_root()
+    args = argparse.Namespace(
+        file=str(raw_log),
+        participant_id="P01",
+        trial_id="T01",
+        study_id="study-alpha",
+        condition="with_tutor",
+        group="novice",
+        experimenter_id="E01",
+        questionnaire="questionnaires/P01_pre.yml",
+        recording_ref="recordings/P01_T01.mp4",
+        notes="no issues",
+        output_dir=str(output_dir),
+        scoring=None,
+        pack=str(root / "packs/fa18c_startup/pack.yaml"),
+        taxonomy=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map=str(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui=str(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        model_provider="stub",
+        model_name="ModelStub",
+        vision_model_name="VisionStub",
+        prompt_version="prompt-v1",
+        prompt_hash=None,
+        scenario_profile="airfield",
+        dcs_mission="cold-start.miz",
+        dcs_aircraft="FA-18C",
+        vr_setup="Quest 3",
+        monitor_setup="native-viewports",
+        git_commit="abc123",
+        git_dirty=False,
+        strict=True,
+        overwrite=False,
+        copy_raw_log=True,
+    )
+    assert _run_experiment_export(args) == 0
+
+    trial_dir = output_dir / "P01" / "T01"
+    old_session = json.loads((trial_dir / "session.json").read_text(encoding="utf-8"))
+    args.overwrite = True
+    args.study_id = None
+    assert _run_experiment_export(args) == 1
+
+    preserved_session = json.loads((trial_dir / "session.json").read_text(encoding="utf-8"))
+    assert preserved_session["meta"]["study_id"] == old_session["meta"]["study_id"]
+    assert (trial_dir / "raw_events.jsonl").exists()
+
+
+def test_experiment_export_cli_overwrite_preserves_old_export_when_staging_write_fails(
+    tmp_path: Path,
+    monkeypatch,
+):
+    raw_log = tmp_path / "events.jsonl"
+    _write_jsonl(raw_log, _make_events_with_help_cycles())
+    output_dir = tmp_path / "exports"
+    root = _repo_root()
+    args = argparse.Namespace(
+        file=str(raw_log),
+        participant_id="P01",
+        trial_id="T01",
+        study_id="study-alpha",
+        condition="with_tutor",
+        group="novice",
+        experimenter_id="E01",
+        questionnaire="questionnaires/P01_pre.yml",
+        recording_ref="recordings/P01_T01.mp4",
+        notes="no issues",
+        output_dir=str(output_dir),
+        scoring=None,
+        pack=str(root / "packs/fa18c_startup/pack.yaml"),
+        taxonomy=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map=str(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui=str(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        model_provider="stub",
+        model_name="ModelStub",
+        vision_model_name="VisionStub",
+        prompt_version="prompt-v1",
+        prompt_hash=None,
+        scenario_profile="airfield",
+        dcs_mission="cold-start.miz",
+        dcs_aircraft="FA-18C",
+        vr_setup="Quest 3",
+        monitor_setup="native-viewports",
+        git_commit="abc123",
+        git_dirty=False,
+        strict=True,
+        overwrite=False,
+        copy_raw_log=True,
+    )
+    assert _run_experiment_export(args) == 0
+
+    trial_dir = output_dir / "P01" / "T01"
+    old_session_text = (trial_dir / "session.json").read_text(encoding="utf-8")
+    old_raw_hash = build_file_sha256(trial_dir / "raw_events.jsonl")
+
+    def _fail_copy(*_args, **_kwargs):
+        raise OSError("simulated copy failure")
+
+    args.overwrite = True
+    monkeypatch.setattr(simtutor_cli.shutil, "copy2", _fail_copy)
+
+    assert _run_experiment_export(args) == 1
+    assert (trial_dir / "session.json").read_text(encoding="utf-8") == old_session_text
+    assert build_file_sha256(trial_dir / "raw_events.jsonl") == old_raw_hash


### PR DESCRIPTION
## Summary
- extend experiment export session metadata with trial/study/provenance fields and reproducibility hashes
- add strict export quality gate for critical metadata, pack/taxonomy consistency, file hash validation, CSV headers/row counts, and raw log copy
- make experiment-export write raw_events.jsonl, quality_gate.json, and participant/trial directories with overwrite protection via staging + backup restore

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/test_interaction_metrics.py tests/test_scoring_engine.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

## Review-fix loop
- fixed strict metadata coverage for model/prompt/DCS/VR setup
- fixed hash validation to compare recorded hashes to actual file contents
- fixed empty help_cycles.csv contract by always writing headers
- fixed overwrite safety with staging writes and backup restore

Closes #354