### PR TITLE
Export study-ready experiment tables

### DIFF
--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -60,12 +60,56 @@ EXPECTED_PACK_STEP_IDS = [f"S{i:02d}" for i in range(1, 34)]
 
 HELP_CYCLES_CSV_FIELDS = [
     "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
-    "vision_used", "vision_status", "vision_fallback_reason", "sync_delta_ms",
-    "fused_step_id", "fused_missing_conditions", "model_next_step_id",
+    "vision_used", "vision_status", "vision_fact_status", "vision_fallback_reason", "sync_delta_ms",
+    "frame_ids", "layout_id", "fused_step_id", "fused_missing_conditions", "model_next_step_id",
     "overlay_targets", "overlay_executed", "overlay_rejected",
     "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
+    "fallback_overlay_reason", "response_mapping_failure_codes",
     "observability_status", "requires_visual_confirmation",
     "scenario_profile",
+]
+
+STEP_CODING_CSV_FIELDS = [
+    "ParticipantID",
+    "Condition",
+    "TrialID",
+    "StepID",
+    "StepTitle",
+    "Phase",
+    "Critical",
+    "Performed",
+    "Completed",
+    "FirstHelpTime_sec",
+    "HelpCount",
+    "FirstOverlayTargets",
+    "LastOverlayTargets",
+    "FirstFusedStepID",
+    "LastFusedStepID",
+    "EvidenceRefs",
+    "Error_OM",
+    "Error_CO",
+    "Error_OR",
+    "Error_PA",
+    "Error_SV",
+    "CoderNotes",
+    "AutoCodingNotes",
+]
+
+TRIAL_SUMMARY_CSV_FIELDS = [
+    "ParticipantID",
+    "Condition",
+    "TrialID",
+    "Completed",
+    "TaskTime_sec",
+    "HelpRequests",
+    "LLMTriggers",
+    "VLMCalls",
+    "OverlayExecuted",
+    "OverlayRejected",
+    "FallbackCount",
+    "CriticalStepsCompleted",
+    "TotalStepsCompleted",
+    "StepCompletionAccuracy",
 ]
 
 CRITICAL_EXPORT_META_FIELDS = [
@@ -434,6 +478,57 @@ class HelpCycleRecord:
         return asdict(self)
 
 
+@dataclass
+class StepCodingRecord:
+    ParticipantID: str = ""
+    Condition: str = ""
+    TrialID: str = ""
+    StepID: str = ""
+    StepTitle: str = ""
+    Phase: str = ""
+    Critical: str = ""
+    Performed: str = ""
+    Completed: str = ""
+    FirstHelpTime_sec: float | None = None
+    HelpCount: int = 0
+    FirstOverlayTargets: str = ""
+    LastOverlayTargets: str = ""
+    FirstFusedStepID: str = ""
+    LastFusedStepID: str = ""
+    EvidenceRefs: str = ""
+    Error_OM: str = ""
+    Error_CO: str = ""
+    Error_OR: str = ""
+    Error_PA: str = ""
+    Error_SV: str = ""
+    CoderNotes: str = ""
+    AutoCodingNotes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class TrialSummaryRecord:
+    ParticipantID: str = ""
+    Condition: str = ""
+    TrialID: str = ""
+    Completed: str = ""
+    TaskTime_sec: float | None = None
+    HelpRequests: int = 0
+    LLMTriggers: int = 0
+    VLMCalls: int = 0
+    OverlayExecuted: int = 0
+    OverlayRejected: int = 0
+    FallbackCount: int = 0
+    CriticalStepsCompleted: int = 0
+    TotalStepsCompleted: int = 0
+    StepCompletionAccuracy: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
 # ── session timeline snapshot ──────────────────────────────────────────
 
 
@@ -458,6 +553,8 @@ class ExperimentExport:
     meta: SessionMeta = field(default_factory=SessionMeta)
     summary: InteractionMetrics = field(default_factory=InteractionMetrics)
     help_cycles: list[HelpCycleRecord] = field(default_factory=list)
+    step_coding: list[StepCodingRecord] = field(default_factory=list)
+    trial_summary: list[TrialSummaryRecord] = field(default_factory=list)
     scoring: dict[str, Any] | None = None
     timeline: list[TimelineSnapshot] = field(default_factory=list)
     quality_gate: ExportQualityReport | None = None
@@ -467,6 +564,8 @@ class ExperimentExport:
             "meta": self.meta.to_dict(),
             "summary": self.summary.to_dict(),
             "help_cycles": [c.to_dict() for c in self.help_cycles],
+            "step_coding": [c.to_dict() for c in self.step_coding],
+            "trial_summary": [s.to_dict() for s in self.trial_summary],
             "scoring": self.scoring,
             "timeline": [t.to_dict() for t in self.timeline],
             "quality_gate": self.quality_gate.to_dict() if self.quality_gate is not None else None,
@@ -726,6 +825,258 @@ def _build_timeline(events: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]
     return snapshots
 
 
+def _load_pack_steps_for_export(pack_path: str | Path | None) -> list[Mapping[str, Any]]:
+    if pack_path is None:
+        return []
+    try:
+        pack = _load_yaml_mapping(pack_path)
+    except Exception:
+        return []
+    steps = pack.get("steps")
+    if not isinstance(steps, list):
+        return []
+    return [step for step in steps if isinstance(step, Mapping)]
+
+
+def _step_title(step: Mapping[str, Any]) -> str:
+    for key in ("title", "name", "short_title", "label"):
+        value = _opt_str(step.get(key))
+        if value:
+            return value
+    conditions = step.get("completion_conditions")
+    if isinstance(conditions, list):
+        titles = [item.strip() for item in conditions if isinstance(item, str) and item.strip()]
+        if titles:
+            return " ".join(titles)
+    prompts = step.get("tutor_prompts")
+    if isinstance(prompts, list):
+        for prompt in prompts:
+            value = _opt_str(prompt)
+            if value:
+                return value
+    return _opt_str(step.get("id")) or ""
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _event_step_id(ev: Mapping[str, Any]) -> str | None:
+    payload = ev.get("payload")
+    if isinstance(payload, Mapping):
+        step_id = _opt_str(payload.get("step_id"))
+        if step_id:
+            return step_id
+    return _opt_str(ev.get("step_id"))
+
+
+def _event_wall_time(ev: Mapping[str, Any]) -> float | None:
+    payload = ev.get("payload")
+    if isinstance(payload, Mapping):
+        t_wall = _opt_float(payload.get("t_wall"))
+        if t_wall is not None:
+            return t_wall
+    return _opt_float(ev.get("t_wall"))
+
+
+def _join_csv_values(values: Sequence[str]) -> str:
+    return ";".join(value for value in values if value)
+
+
+def _record_text(value: str | None) -> str:
+    return value or ""
+
+
+def _help_cycle_matches_step(cycle: HelpCycleRecord, step_id: str) -> bool:
+    cycle_step_id = cycle.fused_step_id or cycle.model_next_step_id
+    return cycle_step_id == step_id
+
+
+def _build_step_coding(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    meta: SessionMeta,
+    help_cycles: Sequence[HelpCycleRecord],
+    pack_steps: Sequence[Mapping[str, Any]],
+) -> list[StepCodingRecord]:
+    completed_steps: set[str] = set()
+    activated_steps: set[str] = set()
+    completed_event_seen: set[str] = set()
+    activated_event_seen: set[str] = set()
+
+    for ev in events:
+        kind = ev.get("kind") or ev.get("type") or ""
+        sid = _event_step_id(ev)
+        if not sid:
+            continue
+        if kind == "step_activated":
+            activated_steps.add(sid)
+            activated_event_seen.add(sid)
+        elif kind == "step_completed":
+            completed_steps.add(sid)
+            completed_event_seen.add(sid)
+
+    rows: list[StepCodingRecord] = []
+    for step in pack_steps:
+        step_id = _opt_str(step.get("id"))
+        if not step_id:
+            continue
+        cycles = [cycle for cycle in help_cycles if _help_cycle_matches_step(cycle, step_id)]
+        completed = step_id in completed_steps
+        performed = completed or step_id in activated_steps or bool(cycles)
+
+        evidence_refs: list[str] = []
+        if step_id in activated_event_seen:
+            evidence_refs.append("step_activated")
+        if step_id in completed_event_seen:
+            evidence_refs.append("step_completed")
+        for cycle in cycles:
+            evidence_refs.append(f"help_cycle:{cycle.help_cycle_id}")
+            if cycle.frame_ids:
+                evidence_refs.append("frames:" + _join_csv_values(cycle.frame_ids))
+
+        auto_notes: list[str] = ["human_error_columns_blank"]
+        if completed:
+            auto_notes.append("completed_from_step_completed")
+        elif performed:
+            auto_notes.append("performed_inferred_from_step_or_help_evidence")
+        else:
+            auto_notes.append("no_step_evidence_found")
+
+        first_cycle = cycles[0] if cycles else None
+        last_cycle = cycles[-1] if cycles else None
+
+        rows.append(
+            StepCodingRecord(
+                ParticipantID=meta.participant_id,
+                Condition=meta.condition,
+                TrialID=meta.trial_id,
+                StepID=step_id,
+                StepTitle=_step_title(step),
+                Phase=_opt_str(step.get("phase")) or "",
+                Critical=_yes_no(_opt_bool(step.get("critical")) is True),
+                Performed=_yes_no(performed),
+                Completed=_yes_no(completed),
+                FirstHelpTime_sec=first_cycle.trigger_wall_s if first_cycle is not None else None,
+                HelpCount=len(cycles),
+                FirstOverlayTargets=_join_csv_values(first_cycle.overlay_targets) if first_cycle is not None else "",
+                LastOverlayTargets=_join_csv_values(last_cycle.overlay_targets) if last_cycle is not None else "",
+                FirstFusedStepID=_record_text(first_cycle.fused_step_id) if first_cycle is not None else "",
+                LastFusedStepID=_record_text(last_cycle.fused_step_id) if last_cycle is not None else "",
+                EvidenceRefs=_join_csv_values(evidence_refs),
+                AutoCodingNotes=_join_csv_values(auto_notes),
+            )
+        )
+    return rows
+
+
+def _task_time_seconds(events: Sequence[Mapping[str, Any]]) -> float | None:
+    times = [t for ev in events if (t := _event_wall_time(ev)) is not None]
+    if not times:
+        return None
+    return max(times) - min(times)
+
+
+def _merged_event_metadata(ev: Mapping[str, Any]) -> dict[str, Any]:
+    metadata = ev.get("metadata") if isinstance(ev.get("metadata"), Mapping) else {}
+    payload = ev.get("payload")
+    payload_metadata = (
+        payload.get("metadata")
+        if isinstance(payload, Mapping) and isinstance(payload.get("metadata"), Mapping)
+        else {}
+    )
+    return {**metadata, **payload_metadata}
+
+
+def _event_help_cycle_id(ev: Mapping[str, Any], metadata: Mapping[str, Any]) -> str | None:
+    help_cycle_id = _opt_str(metadata.get("help_cycle_id"))
+    if help_cycle_id:
+        return help_cycle_id
+    payload = ev.get("payload")
+    if isinstance(payload, Mapping):
+        help_cycle_id = _opt_str(payload.get("help_cycle_id"))
+        if help_cycle_id:
+            return help_cycle_id
+    return _opt_str(ev.get("related_id"))
+
+
+def _count_vlm_calls(
+    events: Sequence[Mapping[str, Any]],
+    help_cycles: Sequence[HelpCycleRecord],
+) -> int:
+    saw_vlm_status = False
+    called_cycle_ids: set[str] = set()
+    called_without_cycle_id = 0
+    for ev in events:
+        metadata = _merged_event_metadata(ev)
+        status = metadata.get("vlm_call_status")
+        if not isinstance(status, str):
+            continue
+        saw_vlm_status = True
+        if status != "called":
+            continue
+        help_cycle_id = _event_help_cycle_id(ev, metadata)
+        if help_cycle_id:
+            called_cycle_ids.add(help_cycle_id)
+        else:
+            called_without_cycle_id += 1
+
+    if saw_vlm_status:
+        return len(called_cycle_ids) + called_without_cycle_id
+
+    vision_fact_observations = sum(
+        1
+        for ev in events
+        if _merged_event_metadata(ev).get("observation_kind") == "vision_fact"
+    )
+    if vision_fact_observations:
+        return vision_fact_observations
+
+    return sum(1 for cycle in help_cycles if cycle.vision_used is True)
+
+
+def _build_trial_summary(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    meta: SessionMeta,
+    summary: InteractionMetrics,
+    help_cycles: Sequence[HelpCycleRecord],
+    step_coding: Sequence[StepCodingRecord],
+) -> list[TrialSummaryRecord]:
+    if not step_coding:
+        return []
+
+    total_steps_completed = sum(1 for row in step_coding if row.Completed == "yes")
+    critical_steps_completed = sum(
+        1 for row in step_coding if row.Critical == "yes" and row.Completed == "yes"
+    )
+    all_completed = total_steps_completed == len(step_coding)
+    fallback_count = sum(
+        1
+        for cycle in help_cycles
+        if cycle.fallback_overlay_used is True or cycle.generation_mode == "fallback"
+    )
+
+    return [
+        TrialSummaryRecord(
+            ParticipantID=meta.participant_id,
+            Condition=meta.condition,
+            TrialID=meta.trial_id,
+            Completed=_yes_no(all_completed),
+            TaskTime_sec=_task_time_seconds(events),
+            HelpRequests=summary.help_requests,
+            LLMTriggers=summary.llm_triggers,
+            VLMCalls=_count_vlm_calls(events, help_cycles),
+            OverlayExecuted=sum(cycle.overlay_executed for cycle in help_cycles),
+            OverlayRejected=sum(cycle.overlay_rejected for cycle in help_cycles),
+            FallbackCount=fallback_count,
+            CriticalStepsCompleted=critical_steps_completed,
+            TotalStepsCompleted=total_steps_completed,
+            StepCompletionAccuracy=round(total_steps_completed / len(step_coding), 6),
+        )
+    ]
+
+
 # ── main entry point ───────────────────────────────────────────────────
 
 
@@ -734,6 +1085,7 @@ def build_experiment_export(
     *,
     meta_overrides: Mapping[str, Any] | None = None,
     scoring: Mapping[str, Any] | None = None,
+    pack_path: str | Path | None = None,
 ) -> ExperimentExport:
     """Build a complete experiment export from a list of event dicts."""
 
@@ -779,6 +1131,20 @@ def build_experiment_export(
     ]
 
     summary = compute_interaction_metrics(events)
+    pack_steps = _load_pack_steps_for_export(pack_path)
+    step_coding = _build_step_coding(
+        events,
+        meta=meta,
+        help_cycles=help_cycles,
+        pack_steps=pack_steps,
+    )
+    trial_summary = _build_trial_summary(
+        events,
+        meta=meta,
+        summary=summary,
+        help_cycles=help_cycles,
+        step_coding=step_coding,
+    )
 
     raw_timeline = _build_timeline(events)
     timeline = [
@@ -797,6 +1163,8 @@ def build_experiment_export(
         meta=meta,
         summary=summary,
         help_cycles=help_cycles,
+        step_coding=step_coding,
+        trial_summary=trial_summary,
         scoring=dict(scoring) if isinstance(scoring, Mapping) else None,
         timeline=timeline,
     )
@@ -806,9 +1174,13 @@ __all__ = [
     "SessionMeta",
     "ExportQualityReport",
     "HelpCycleRecord",
+    "StepCodingRecord",
+    "TrialSummaryRecord",
     "TimelineSnapshot",
     "ExperimentExport",
     "HELP_CYCLES_CSV_FIELDS",
+    "STEP_CODING_CSV_FIELDS",
+    "TRIAL_SUMMARY_CSV_FIELDS",
     "build_export_quality_report",
     "build_experiment_export",
     "build_file_sha256",

--- a/docs/dev_notes/new_chat_handoff_v0_4_multitarget_overlay.md
+++ b/docs/dev_notes/new_chat_handoff_v0_4_multitarget_overlay.md
@@ -580,6 +580,83 @@ Schema 规则：
 
 除非另做专门转换或重新训练，否则不要把 9B LoRA 直接挂到 27B 上。
 
+### 当前论文 / 实验框架主线（2026-05-20 更新）
+
+当前 master thesis 的主线已经从“实时完整识别 5 类错误”收敛为：
+
+> 构建并评估一个 grounded multimodal VR/DCS procedural tutor：用遥测、VLM facts、LLM 推理、harness validation、overlay guidance 与 replay/export logs，支持复杂冷启动流程中的可执行中文帮助，并评估其对新手任务完成质量的影响。
+
+重要判断：
+
+- 不要把正式实验目标定义成“系统实时完整支持 OM/CO/OR/PA/SV 五类错误”
+- 五类错误可以保留为**实验评分 / 人工编码 / 后验分析框架**
+- runtime tutor 的当前核心能力是：基于当前状态给出正确下一步、正确高亮、帮助用户从卡住状态恢复
+- 正式实验前最缺的是：**实验级数据导出、step-level coding、trial summary、action timeline、版本冻结和分析表**
+- 在没有用户明确要求的情况下，不要再主动扩展 runtime tutor、不要继续做大规模 live loop 重构、不要追求全自动 CO/OR/PA/SV 检测
+
+当前已创建一组实验框架 issue，供接下来快速开发：
+
+1. **#354 Add experiment metadata freeze and export quality gate**
+   - 优先级最高
+   - 目标：保证每次实验 run 都能追溯 participant / condition / trial / git commit / pack hash / model / prompt / DCS setup
+   - 正式实验前必须避免“这条数据到底是哪版系统跑的”这种不可恢复问题
+
+2. **#353 Export study-ready trial and S01-S33 step coding tables**
+   - 核心 issue
+   - 目标：`experiment-export` 输出正式实验主表：
+     - `step_coding.csv`
+     - `trial_summary.csv`
+     - 扩展后的 `help_cycles.csv`
+     - 保留 `session.json` / `summary.json`
+   - `step_coding.csv` 应是 S01-S33 每步一行，给人工评分和统计直接使用
+
+3. **#355 Add experiment-grade participant action timeline export**
+   - 目标：输出 `action_timeline.csv`
+   - 用 DCS-BIOS delta / mapped UI target / nearby help cycle / candidate step 还原用户动作时间线
+   - 主要服务于 OR / CO / PA / SV 的人工复核，而不是声称自动完美识别
+
+4. **#352 Add semi-automatic pre-scoring and human rater workflow**
+   - 目标：自动生成 OM/SV/OR/PA/CO candidate 和 evidence refs，最终仍由 human rater 确认
+   - 不要把 `core/scoring.py` 里 CO/OR/PA 默认为 0 的 v1 scoring 误当成正式评分器
+   - 论文表述应为 “semi-automatic evidence-assisted coding”
+
+5. **#356 Generate thesis-ready experiment analysis tables and figures**
+   - 最后做
+   - 目标：从 exported CSV 生成 `study_summary.csv`、`condition_summary.csv`、step accuracy / help request / completion / task time 图表
+   - 不做复杂 dashboard，不做过度统计框架
+
+建议开发顺序：
+
+```text
+#354 -> #353 -> #355 -> #352 -> #356
+```
+
+最快开发规则：
+
+- 每个 issue 一个短分支 / 一个 Codex session，不混做
+- 先写 synthetic event log 测试，再用一条真实 live log 做回归
+- 不改 runtime tutor，除非导出字段确实缺失
+- CSV 列名一旦定下尽量不要改，实验表最怕 schema 漂移
+- 全量 pytest 不要每次跑；实验框架 issue 优先跑：
+
+```bash
+source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/test_scoring_engine.py
+```
+
+如果遇到本机 pytest capture 问题，使用前文记录的：
+
+```bash
+source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full
+```
+
+当前论文 / 博士申请叙事建议：
+
+- 不要说 “I built a DCS startup helper”
+- 应说：
+  “I built and evaluated a grounded multimodal AI tutor for high-fidelity VR procedural training, integrating simulator telemetry, cockpit vision, LLM reasoning, and harness-based validation to improve reliability and auditability.”
+
+也就是说，DCS/F/A-18C 是高保真任务载体；真正贡献是 multimodal grounding、procedural tutoring、harness reliability、replayable evaluation。
+
 ---
 
 ## 12. Task Selection Rule

--- a/simtutor/__main__.py
+++ b/simtutor/__main__.py
@@ -519,6 +519,8 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
     from core.event_store import JsonlEventStore
     from core.experiment_export import (
         HELP_CYCLES_CSV_FIELDS,
+        STEP_CODING_CSV_FIELDS,
+        TRIAL_SUMMARY_CSV_FIELDS,
         build_export_quality_report,
         build_experiment_export,
         build_file_sha256,
@@ -596,7 +598,12 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
         "experimenter_notes": args.notes,
     }
 
-    export = build_experiment_export(events, meta_overrides=meta_overrides, scoring=scoring)
+    export = build_experiment_export(
+        events,
+        meta_overrides=meta_overrides,
+        scoring=scoring,
+        pack_path=pack_path,
+    )
     out_dir = Path(args.output_dir)
     if args.participant_id:
         try:
@@ -617,6 +624,8 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
         "session.json",
         "summary.json",
         "help_cycles.csv",
+        "step_coding.csv",
+        "trial_summary.csv",
         "raw_events.jsonl",
         "quality_gate.json",
     ]
@@ -659,9 +668,27 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
             for c in export.help_cycles:
                 row = c.to_dict()
                 # flatten list fields for CSV
+                row["frame_ids"] = ";".join(c.frame_ids)
                 row["fused_missing_conditions"] = ";".join(c.fused_missing_conditions)
                 row["overlay_targets"] = ";".join(c.overlay_targets)
+                row["response_mapping_failure_codes"] = ";".join(c.response_mapping_failure_codes)
                 writer.writerow(row)
+
+        # step_coding.csv
+        step_coding_path = staging_dir / "step_coding.csv"
+        with step_coding_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=STEP_CODING_CSV_FIELDS, extrasaction="ignore")
+            writer.writeheader()
+            for row in export.step_coding:
+                writer.writerow(row.to_dict())
+
+        # trial_summary.csv
+        trial_summary_path = staging_dir / "trial_summary.csv"
+        with trial_summary_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=TRIAL_SUMMARY_CSV_FIELDS, extrasaction="ignore")
+            writer.writeheader()
+            for row in export.trial_summary:
+                writer.writerow(row.to_dict())
 
         # summary.json
         summary_path = staging_dir / "summary.json"
@@ -716,6 +743,8 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
     if copy_raw_log:
         print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'raw_events.jsonl'}")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'help_cycles.csv'} ({len(export.help_cycles)} cycles)")
+    print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'step_coding.csv'} ({len(export.step_coding)} steps)")
+    print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'trial_summary.csv'} ({len(export.trial_summary)} trials)")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'summary.json'}")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'quality_gate.json'}")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'session.json'}")

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -11,8 +11,11 @@ from pathlib import Path
 
 import simtutor.__main__ as simtutor_cli
 from core.experiment_export import (
+    HELP_CYCLES_CSV_FIELDS,
     SessionMeta,
     HelpCycleRecord,
+    STEP_CODING_CSV_FIELDS,
+    TRIAL_SUMMARY_CSV_FIELDS,
     build_export_quality_report,
     build_experiment_export,
     build_file_sha256,
@@ -322,13 +325,16 @@ def test_session_meta_from_partial():
 
 def test_build_export_with_help_cycles():
     events = _make_events_with_help_cycles()
+    root = _repo_root()
     export = build_experiment_export(
         events,
         meta_overrides={
+            "trial_id": "T01",
             "participant_id": "P01",
             "condition": "with_tutor",
             "group": "novice",
         },
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
     )
 
     # meta
@@ -391,8 +397,173 @@ def test_build_export_with_help_cycles():
     assert "meta" in d
     assert "summary" in d
     assert "help_cycles" in d
+    assert "step_coding" in d
+    assert "trial_summary" in d
     assert "scoring" in d
     assert "timeline" in d
+
+
+def test_build_export_includes_study_ready_tables():
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_events_with_help_cycles(),
+        meta_overrides={
+            "trial_id": "T01",
+            "participant_id": "P01",
+            "condition": "with_tutor",
+        },
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+    )
+
+    assert len(export.step_coding) == 33
+    assert [row.StepID for row in export.step_coding][:3] == ["S01", "S02", "S03"]
+    assert [row.StepID for row in export.step_coding][-1] == "S33"
+
+    s01 = export.step_coding[0]
+    assert s01.ParticipantID == "P01"
+    assert s01.Condition == "with_tutor"
+    assert s01.TrialID == "T01"
+    assert s01.Phase == "P1"
+    assert s01.Critical == "yes"
+    assert s01.Performed == "yes"
+    assert s01.Completed == "yes"
+    assert s01.FirstHelpTime_sec == 5.0
+    assert s01.HelpCount == 1
+    assert s01.FirstOverlayTargets == "battery_switch"
+    assert s01.LastOverlayTargets == "battery_switch"
+    assert s01.FirstFusedStepID == "S01"
+    assert s01.LastFusedStepID == "S01"
+    assert "help_cycle:cycle-aaa-111" in s01.EvidenceRefs
+    assert s01.Error_OM == ""
+    assert s01.Error_CO == ""
+    assert s01.CoderNotes == ""
+
+    s02 = export.step_coding[1]
+    assert s02.Performed == "yes"
+    assert s02.Completed == "no"
+    assert s02.HelpCount == 1
+    assert s02.FirstHelpTime_sec == 12.0
+    assert s02.FirstOverlayTargets == "left_mdi_brightness_selector"
+
+    s33 = export.step_coding[-1]
+    assert s33.Performed == "no"
+    assert s33.Completed == "no"
+    assert s33.HelpCount == 0
+
+    assert len(export.trial_summary) == 1
+    trial = export.trial_summary[0]
+    assert trial.ParticipantID == "P01"
+    assert trial.Condition == "with_tutor"
+    assert trial.TrialID == "T01"
+    assert trial.Completed == "no"
+    assert trial.TaskTime_sec == 12.5
+    assert trial.HelpRequests == 2
+    assert trial.OverlayExecuted == 1
+    assert trial.OverlayRejected == 1
+    assert trial.FallbackCount == 1
+    assert trial.CriticalStepsCompleted == 1
+    assert trial.TotalStepsCompleted == 1
+    assert trial.StepCompletionAccuracy == 0.030303
+
+
+def test_study_ready_csv_contract_fields_are_frozen():
+    assert HELP_CYCLES_CSV_FIELDS == [
+        "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
+        "vision_used", "vision_status", "vision_fact_status", "vision_fallback_reason", "sync_delta_ms",
+        "frame_ids", "layout_id", "fused_step_id", "fused_missing_conditions", "model_next_step_id",
+        "overlay_targets", "overlay_executed", "overlay_rejected",
+        "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
+        "fallback_overlay_reason", "response_mapping_failure_codes",
+        "observability_status", "requires_visual_confirmation",
+        "scenario_profile",
+    ]
+    assert STEP_CODING_CSV_FIELDS == [
+        "ParticipantID", "Condition", "TrialID", "StepID", "StepTitle", "Phase", "Critical",
+        "Performed", "Completed", "FirstHelpTime_sec", "HelpCount", "FirstOverlayTargets",
+        "LastOverlayTargets", "FirstFusedStepID", "LastFusedStepID", "EvidenceRefs",
+        "Error_OM", "Error_CO", "Error_OR", "Error_PA", "Error_SV", "CoderNotes",
+        "AutoCodingNotes",
+    ]
+    assert TRIAL_SUMMARY_CSV_FIELDS == [
+        "ParticipantID", "Condition", "TrialID", "Completed", "TaskTime_sec", "HelpRequests",
+        "LLMTriggers", "VLMCalls", "OverlayExecuted", "OverlayRejected", "FallbackCount",
+        "CriticalStepsCompleted", "TotalStepsCompleted", "StepCompletionAccuracy",
+    ]
+
+
+def test_step_coding_uses_fused_step_as_help_cycle_owner():
+    events = _make_events_with_help_cycles()
+    first_response = events[4]["payload"]["metadata"]["help_response"]
+    first_response["next"]["step_id"] = "S02"
+    root = _repo_root()
+
+    export = build_experiment_export(
+        events,
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "with_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+    )
+
+    s01 = export.step_coding[0]
+    s02 = export.step_coding[1]
+    assert s01.HelpCount == 1
+    assert s01.FirstHelpTime_sec == 5.0
+    assert s02.HelpCount == 1
+    assert s02.FirstHelpTime_sec == 12.0
+
+
+def test_step_coding_accepts_top_level_step_id_events(tmp_path: Path):
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        "steps:\n"
+        "  - id: S01\n"
+        "    phase: P1\n"
+        "    critical: \"false\"\n"
+        "    completion_conditions: [Battery on.]\n",
+        encoding="utf-8",
+    )
+    export = build_experiment_export(
+        [
+            {"type": "step_activated", "step_id": "S01", "t_wall": 0.0},
+            {"type": "step_completed", "step_id": "S01", "t_wall": 4.0},
+        ],
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "with_tutor"},
+        pack_path=pack,
+    )
+
+    assert len(export.step_coding) == 1
+    assert export.step_coding[0].Performed == "yes"
+    assert export.step_coding[0].Completed == "yes"
+    assert export.step_coding[0].Critical == "no"
+    assert export.trial_summary[0].Completed == "yes"
+
+
+def test_trial_summary_counts_vlm_calls_once_per_help_cycle():
+    events = _make_events_with_help_cycles()
+    events[9]["metadata"]["vlm_call_status"] = "called"
+    events[10]["payload"]["metadata"]["vlm_call_status"] = "called"
+    root = _repo_root()
+
+    export = build_experiment_export(
+        events,
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "with_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+    )
+
+    assert export.trial_summary[0].VLMCalls == 1
+
+
+def test_trial_summary_honors_explicit_non_called_vlm_status():
+    events = _make_events_with_help_cycles()
+    events[4]["payload"]["metadata"]["vlm_call_status"] = "not_required"
+    root = _repo_root()
+
+    export = build_experiment_export(
+        events,
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "with_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+    )
+
+    assert export.trial_summary[0].VLMCalls == 0
 
 
 def test_build_export_no_help_cycles():
@@ -542,15 +713,7 @@ def test_quality_gate_strict_requires_model_prompt_and_dcs_metadata(tmp_path: Pa
         raw_log_copied=True,
         expected_help_cycle_rows=0,
         actual_help_cycle_rows=0,
-        help_cycle_csv_headers=[
-            "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
-            "vision_used", "vision_status", "vision_fallback_reason", "sync_delta_ms",
-            "fused_step_id", "fused_missing_conditions", "model_next_step_id",
-            "overlay_targets", "overlay_executed", "overlay_rejected",
-            "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
-            "observability_status", "requires_visual_confirmation",
-            "scenario_profile",
-        ],
+        help_cycle_csv_headers=HELP_CYCLES_CSV_FIELDS,
     )
 
     assert report.passed is False
@@ -603,15 +766,7 @@ def test_quality_gate_rejects_hash_mismatch():
         raw_log_copied=True,
         expected_help_cycle_rows=0,
         actual_help_cycle_rows=0,
-        help_cycle_csv_headers=[
-            "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
-            "vision_used", "vision_status", "vision_fallback_reason", "sync_delta_ms",
-            "fused_step_id", "fused_missing_conditions", "model_next_step_id",
-            "overlay_targets", "overlay_executed", "overlay_rejected",
-            "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
-            "observability_status", "requires_visual_confirmation",
-            "scenario_profile",
-        ],
+        help_cycle_csv_headers=HELP_CYCLES_CSV_FIELDS,
     )
 
     assert report.passed is False
@@ -686,6 +841,31 @@ def test_experiment_export_cli_freezes_metadata_and_copies_raw_log(tmp_path: Pat
     assert meta["raw_log_sha256"] == build_file_sha256(raw_log)
     assert build_file_sha256(trial_dir / "raw_events.jsonl") == build_file_sha256(raw_log)
     assert session["quality_gate"]["passed"] is True
+    assert (trial_dir / "step_coding.csv").exists()
+    assert (trial_dir / "trial_summary.csv").exists()
+    with (trial_dir / "step_coding.csv").open("r", newline="", encoding="utf-8") as f:
+        step_rows = list(csv.DictReader(f))
+    assert len(step_rows) == 33
+    assert list(step_rows[0].keys()) == STEP_CODING_CSV_FIELDS
+    assert step_rows[0]["StepID"] == "S01"
+    assert step_rows[0]["Completed"] == "yes"
+    assert step_rows[1]["StepID"] == "S02"
+    assert step_rows[1]["HelpCount"] == "1"
+    with (trial_dir / "trial_summary.csv").open("r", newline="", encoding="utf-8") as f:
+        trial_rows = list(csv.DictReader(f))
+    assert len(trial_rows) == 1
+    assert list(trial_rows[0].keys()) == TRIAL_SUMMARY_CSV_FIELDS
+    assert trial_rows[0]["ParticipantID"] == "P01"
+    assert trial_rows[0]["TotalStepsCompleted"] == "1"
+    with (trial_dir / "help_cycles.csv").open("r", newline="", encoding="utf-8") as f:
+        help_rows = list(csv.DictReader(f))
+    assert "vision_fact_status" in help_rows[0]
+    assert "fallback_overlay_reason" in help_rows[0]
+    assert "response_mapping_failure_codes" in help_rows[0]
+    assert "frame_ids" in help_rows[0]
+    assert "layout_id" in help_rows[0]
+    assert help_rows[0]["frame_ids"] == "frame_001.png"
+    assert help_rows[1]["response_mapping_failure_codes"] == "vision_sync_miss"
 
     # A second export to the same participant/trial directory must not
     # silently replace study data unless explicitly allowed.


### PR DESCRIPTION
## Summary
- extend experiment export with study-ready step_coding.csv and trial_summary.csv
- add missing help_cycles.csv audit columns for vision, fallback, mapping, frame, and layout data
- keep session.json/summary.json behavior and staging/overwrite flow backward compatible

## Verification
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/test_scoring_engine.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #353