### PR TITLE
Add action timeline experiment export

### DIFF
--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -898,16 +898,24 @@ def _load_pack_steps_for_export(pack_path: str | Path | None) -> list[Mapping[st
 
 def _load_bios_to_ui_rules_for_export(
     bios_to_ui_path: str | Path | None,
+    ui_map_path: str | Path | None,
 ) -> dict[str, tuple[str, ...]]:
     if bios_to_ui_path is None:
         return {}
-    try:
-        bios_to_ui = _load_yaml_mapping(bios_to_ui_path)
-    except Exception:
-        return {}
+    allowed_targets: set[str] | None = None
+    if ui_map_path is not None:
+        ui_map = _load_yaml_mapping(ui_map_path)
+        cockpit_elements = ui_map.get("cockpit_elements")
+        if not isinstance(cockpit_elements, Mapping):
+            raise ValueError("ui_map.yaml missing cockpit_elements mapping")
+        allowed_targets = {
+            key for key in cockpit_elements.keys() if isinstance(key, str) and key
+        }
+
+    bios_to_ui = _load_yaml_mapping(bios_to_ui_path)
     mappings = bios_to_ui.get("mappings")
     if not isinstance(mappings, Mapping):
-        return {}
+        raise ValueError("bios_to_ui.yaml missing mappings")
 
     rules: dict[str, tuple[str, ...]] = {}
     for raw_key, raw_value in mappings.items():
@@ -929,6 +937,10 @@ def _load_bios_to_ui_rules_for_export(
         for target in targets:
             if target in seen:
                 continue
+            if allowed_targets is not None and target not in allowed_targets:
+                raise ValueError(
+                    f"bios_to_ui key {raw_key!r} references unknown ui target {target!r}"
+                )
             seen.add(target)
             ordered.append(target)
         rules[raw_key] = tuple(ordered)
@@ -1104,8 +1116,7 @@ def _event_source(ev: Mapping[str, Any]) -> str:
     source = _opt_str(ev.get("source"))
     if source:
         return source
-    payload = ev.get("payload")
-    if isinstance(payload, Mapping):
+    for payload in _event_payload_layers(ev):
         source = _opt_str(payload.get("source"))
         if source:
             return source
@@ -1117,30 +1128,48 @@ def _event_source(ev: Mapping[str, Any]) -> str:
     return ""
 
 
-def _extract_event_delta_items(ev: Mapping[str, Any]) -> list[tuple[str, Any]]:
+def _event_payload_layers(ev: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     payload = ev.get("payload")
     if not isinstance(payload, Mapping):
         return []
+    layers: list[Mapping[str, Any]] = [payload]
+    nested = payload.get("payload")
+    if isinstance(nested, Mapping):
+        layers.append(nested)
+    return layers
 
-    delta = payload.get("delta")
-    if isinstance(delta, Mapping):
-        return [(key, value) for key, value in delta.items() if isinstance(key, str) and key]
 
-    delta_summary = payload.get("delta_summary")
-    if not isinstance(delta_summary, Mapping):
-        return []
-    recent = delta_summary.get("recent_key_changes_topk")
-    if not isinstance(recent, list):
-        return []
+def _extract_event_delta_items(ev: Mapping[str, Any]) -> list[tuple[str, Any]]:
+    for payload in reversed(_event_payload_layers(ev)):
+        delta = payload.get("delta")
+        if isinstance(delta, Mapping):
+            return [(key, value) for key, value in delta.items() if isinstance(key, str) and key]
 
-    items: list[tuple[str, Any]] = []
-    for row in recent:
-        if not isinstance(row, Mapping):
+        delta_summary = payload.get("delta_summary")
+        if not isinstance(delta_summary, Mapping):
             continue
-        key = row.get("key")
-        if isinstance(key, str) and key:
-            items.append((key, row.get("value")))
-    return items
+        recent = delta_summary.get("recent_key_changes_topk")
+        if not isinstance(recent, list):
+            continue
+
+        items: list[tuple[str, Any]] = []
+        for row in recent:
+            if not isinstance(row, Mapping):
+                continue
+            key = row.get("key")
+            if isinstance(key, str) and key:
+                items.append((key, row.get("value")))
+        if items:
+            return items
+    return []
+
+
+def _event_bios_map(ev: Mapping[str, Any]) -> Mapping[str, Any]:
+    for payload in reversed(_event_payload_layers(ev)):
+        bios = payload.get("bios")
+        if isinstance(bios, Mapping):
+            return bios
+    return {}
 
 
 def _candidate_steps_for_targets(
@@ -1231,8 +1260,9 @@ def _build_action_timeline(
     help_cycles: Sequence[HelpCycleRecord],
     pack_steps: Sequence[Mapping[str, Any]],
     bios_to_ui_path: str | Path | None,
+    ui_map_path: str | Path | None,
 ) -> list[ActionTimelineRecord]:
-    bios_to_ui = _load_bios_to_ui_rules_for_export(bios_to_ui_path)
+    bios_to_ui = _load_bios_to_ui_rules_for_export(bios_to_ui_path, ui_map_path)
     step_ids_by_target = _build_step_targets_index(pack_steps)
     rows: list[ActionTimelineRecord] = []
     active_step_id = ""
@@ -1240,8 +1270,6 @@ def _build_action_timeline(
 
     for event_index, ev in enumerate(events):
         kind = ev.get("kind") or ev.get("type") or ""
-        payload = ev.get("payload")
-        payload_map = payload if isinstance(payload, Mapping) else {}
 
         if kind == "step_activated":
             active_step_id = _event_step_id(ev) or active_step_id
@@ -1252,11 +1280,9 @@ def _build_action_timeline(
 
         delta_items = _extract_event_delta_items(ev)
         if not delta_items:
-            bios = payload_map.get("bios")
-            if isinstance(bios, Mapping):
-                for key, value in bios.items():
-                    if isinstance(key, str) and key:
-                        last_values[key] = value
+            for key, value in _event_bios_map(ev).items():
+                if isinstance(key, str) and key:
+                    last_values[key] = value
             continue
 
         t_wall = _event_wall_time(ev)
@@ -1267,8 +1293,7 @@ def _build_action_timeline(
         source = _event_source(ev)
         timestamp = _opt_str(ev.get("timestamp")) or ""
 
-        bios = payload_map.get("bios")
-        bios_map = bios if isinstance(bios, Mapping) else {}
+        bios_map = _event_bios_map(ev)
 
         for raw_key, raw_after in delta_items:
             raw_before = last_values.get(raw_key)
@@ -1523,6 +1548,7 @@ def build_experiment_export(
         help_cycles=help_cycles,
         pack_steps=pack_steps,
         bios_to_ui_path=bios_to_ui_path,
+        ui_map_path=ui_map_path,
     )
     step_coding = _build_step_coding(
         events,

--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -69,6 +69,32 @@ HELP_CYCLES_CSV_FIELDS = [
     "scenario_profile",
 ]
 
+ACTION_TIMELINE_CSV_FIELDS = [
+    "ParticipantID",
+    "Condition",
+    "TrialID",
+    "EventIndex",
+    "Timestamp",
+    "TWall",
+    "Source",
+    "RawKey",
+    "RawValueBefore",
+    "RawValueAfter",
+    "Delta",
+    "MappedTarget",
+    "CandidateStepID",
+    "ActiveStepID",
+    "FusedStepID",
+    "ExpectedForStep",
+    "BeforeHelpCycleID",
+    "AfterHelpCycleID",
+    "NearestHelpCycleID",
+    "SecondsSinceLastHelp",
+    "StepCompletedByThisEvent",
+    "GateViolationCandidate",
+    "AutoCodingHint",
+]
+
 STEP_CODING_CSV_FIELDS = [
     "ParticipantID",
     "Condition",
@@ -509,6 +535,36 @@ class StepCodingRecord:
 
 
 @dataclass
+class ActionTimelineRecord:
+    ParticipantID: str = ""
+    Condition: str = ""
+    TrialID: str = ""
+    EventIndex: int = 0
+    Timestamp: str = ""
+    TWall: float | None = None
+    Source: str = ""
+    RawKey: str = ""
+    RawValueBefore: str = ""
+    RawValueAfter: str = ""
+    Delta: str = ""
+    MappedTarget: str = ""
+    CandidateStepID: str = ""
+    ActiveStepID: str = ""
+    FusedStepID: str = ""
+    ExpectedForStep: str = ""
+    BeforeHelpCycleID: str = ""
+    AfterHelpCycleID: str = ""
+    NearestHelpCycleID: str = ""
+    SecondsSinceLastHelp: float | None = None
+    StepCompletedByThisEvent: str = ""
+    GateViolationCandidate: str = ""
+    AutoCodingHint: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
 class TrialSummaryRecord:
     ParticipantID: str = ""
     Condition: str = ""
@@ -553,6 +609,7 @@ class ExperimentExport:
     meta: SessionMeta = field(default_factory=SessionMeta)
     summary: InteractionMetrics = field(default_factory=InteractionMetrics)
     help_cycles: list[HelpCycleRecord] = field(default_factory=list)
+    action_timeline: list[ActionTimelineRecord] = field(default_factory=list)
     step_coding: list[StepCodingRecord] = field(default_factory=list)
     trial_summary: list[TrialSummaryRecord] = field(default_factory=list)
     scoring: dict[str, Any] | None = None
@@ -564,6 +621,7 @@ class ExperimentExport:
             "meta": self.meta.to_dict(),
             "summary": self.summary.to_dict(),
             "help_cycles": [c.to_dict() for c in self.help_cycles],
+            "action_timeline": [a.to_dict() for a in self.action_timeline],
             "step_coding": [c.to_dict() for c in self.step_coding],
             "trial_summary": [s.to_dict() for s in self.trial_summary],
             "scoring": self.scoring,
@@ -838,6 +896,63 @@ def _load_pack_steps_for_export(pack_path: str | Path | None) -> list[Mapping[st
     return [step for step in steps if isinstance(step, Mapping)]
 
 
+def _load_bios_to_ui_rules_for_export(
+    bios_to_ui_path: str | Path | None,
+) -> dict[str, tuple[str, ...]]:
+    if bios_to_ui_path is None:
+        return {}
+    try:
+        bios_to_ui = _load_yaml_mapping(bios_to_ui_path)
+    except Exception:
+        return {}
+    mappings = bios_to_ui.get("mappings")
+    if not isinstance(mappings, Mapping):
+        return {}
+
+    rules: dict[str, tuple[str, ...]] = {}
+    for raw_key, raw_value in mappings.items():
+        if not isinstance(raw_key, str) or not raw_key:
+            continue
+        targets: list[str] = []
+        if isinstance(raw_value, str):
+            targets = [raw_value]
+        elif isinstance(raw_value, list):
+            targets = [item for item in raw_value if isinstance(item, str) and item]
+        elif isinstance(raw_value, Mapping):
+            raw_targets = raw_value.get("targets")
+            if isinstance(raw_targets, list):
+                targets = [item for item in raw_targets if isinstance(item, str) and item]
+        if not targets:
+            continue
+        ordered: list[str] = []
+        seen: set[str] = set()
+        for target in targets:
+            if target in seen:
+                continue
+            seen.add(target)
+            ordered.append(target)
+        rules[raw_key] = tuple(ordered)
+    return rules
+
+
+def _build_step_targets_index(pack_steps: Sequence[Mapping[str, Any]]) -> dict[str, list[str]]:
+    by_target: dict[str, list[str]] = {}
+    for step in pack_steps:
+        step_id = _opt_str(step.get("id"))
+        if not step_id:
+            continue
+        targets = step.get("ui_targets")
+        if not isinstance(targets, list):
+            continue
+        for target in targets:
+            if not isinstance(target, str) or not target:
+                continue
+            by_target.setdefault(target, [])
+            if step_id not in by_target[target]:
+                by_target[target].append(step_id)
+    return by_target
+
+
 def _step_title(step: Mapping[str, Any]) -> str:
     for key in ("title", "name", "short_title", "label"):
         value = _opt_str(step.get(key))
@@ -881,6 +996,21 @@ def _event_wall_time(ev: Mapping[str, Any]) -> float | None:
 
 def _join_csv_values(values: Sequence[str]) -> str:
     return ";".join(value for value in values if value)
+
+
+def _stringify_csv_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    try:
+        return yaml.safe_dump(value, default_flow_style=True, sort_keys=True).strip()
+    except Exception:
+        return str(value)
 
 
 def _record_text(value: str | None) -> str:
@@ -967,6 +1097,259 @@ def _build_step_coding(
                 AutoCodingNotes=_join_csv_values(auto_notes),
             )
         )
+    return rows
+
+
+def _event_source(ev: Mapping[str, Any]) -> str:
+    source = _opt_str(ev.get("source"))
+    if source:
+        return source
+    payload = ev.get("payload")
+    if isinstance(payload, Mapping):
+        source = _opt_str(payload.get("source"))
+        if source:
+            return source
+    metadata = ev.get("metadata")
+    if isinstance(metadata, Mapping):
+        source = _opt_str(metadata.get("source")) or _opt_str(metadata.get("observation_kind"))
+        if source:
+            return source
+    return ""
+
+
+def _extract_event_delta_items(ev: Mapping[str, Any]) -> list[tuple[str, Any]]:
+    payload = ev.get("payload")
+    if not isinstance(payload, Mapping):
+        return []
+
+    delta = payload.get("delta")
+    if isinstance(delta, Mapping):
+        return [(key, value) for key, value in delta.items() if isinstance(key, str) and key]
+
+    delta_summary = payload.get("delta_summary")
+    if not isinstance(delta_summary, Mapping):
+        return []
+    recent = delta_summary.get("recent_key_changes_topk")
+    if not isinstance(recent, list):
+        return []
+
+    items: list[tuple[str, Any]] = []
+    for row in recent:
+        if not isinstance(row, Mapping):
+            continue
+        key = row.get("key")
+        if isinstance(key, str) and key:
+            items.append((key, row.get("value")))
+    return items
+
+
+def _candidate_steps_for_targets(
+    targets: Sequence[str],
+    step_ids_by_target: Mapping[str, Sequence[str]],
+) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for target in targets:
+        for step_id in step_ids_by_target.get(target, ()):
+            if step_id in seen:
+                continue
+            seen.add(step_id)
+            candidates.append(step_id)
+    return candidates
+
+
+def _help_cycle_links(
+    t_wall: float | None,
+    help_cycles: Sequence[HelpCycleRecord],
+) -> tuple[str, str, str, float | None, str]:
+    if t_wall is None:
+        return "", "", "", None, ""
+
+    timed_cycles = [
+        cycle
+        for cycle in help_cycles
+        if cycle.trigger_wall_s is not None and cycle.help_cycle_id
+    ]
+    if not timed_cycles:
+        return "", "", "", None, ""
+
+    before_candidates = [cycle for cycle in timed_cycles if cycle.trigger_wall_s is not None and cycle.trigger_wall_s > t_wall]
+    after_candidates = [cycle for cycle in timed_cycles if cycle.trigger_wall_s is not None and cycle.trigger_wall_s <= t_wall]
+
+    before = min(before_candidates, key=lambda cycle: float(cycle.trigger_wall_s)) if before_candidates else None
+    after = max(after_candidates, key=lambda cycle: float(cycle.trigger_wall_s)) if after_candidates else None
+    nearest = min(timed_cycles, key=lambda cycle: abs(float(cycle.trigger_wall_s) - t_wall))
+    seconds_since = None if after is None else round(t_wall - float(after.trigger_wall_s), 6)
+    fused_step_id = nearest.fused_step_id or nearest.model_next_step_id or ""
+
+    return (
+        before.help_cycle_id if before is not None else "",
+        after.help_cycle_id if after is not None else "",
+        nearest.help_cycle_id,
+        seconds_since,
+        fused_step_id,
+    )
+
+
+def _completed_by_action_event(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    event_index: int,
+    event_wall: float | None,
+    candidate_step_ids: Sequence[str],
+) -> bool:
+    if not candidate_step_ids:
+        return False
+    candidate_set = set(candidate_step_ids)
+
+    current_step = _event_step_id(events[event_index])
+    current_kind = events[event_index].get("kind") or events[event_index].get("type") or ""
+    if current_kind == "step_completed" and current_step in candidate_set:
+        return True
+
+    for next_ev in events[event_index + 1:event_index + 4]:
+        kind = next_ev.get("kind") or next_ev.get("type") or ""
+        if kind not in ("step_completed", "step_blocked", "step_activated", "observation"):
+            continue
+        if kind == "observation":
+            break
+        next_step = _event_step_id(next_ev)
+        if kind == "step_completed" and next_step in candidate_set:
+            next_wall = _event_wall_time(next_ev)
+            if event_wall is None or next_wall is None or 0 <= next_wall - event_wall <= 3.0:
+                return True
+            return False
+        if kind in ("step_blocked", "step_activated"):
+            break
+    return False
+
+
+def _build_action_timeline(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    meta: SessionMeta,
+    help_cycles: Sequence[HelpCycleRecord],
+    pack_steps: Sequence[Mapping[str, Any]],
+    bios_to_ui_path: str | Path | None,
+) -> list[ActionTimelineRecord]:
+    bios_to_ui = _load_bios_to_ui_rules_for_export(bios_to_ui_path)
+    step_ids_by_target = _build_step_targets_index(pack_steps)
+    rows: list[ActionTimelineRecord] = []
+    active_step_id = ""
+    last_values: dict[str, Any] = {}
+
+    for event_index, ev in enumerate(events):
+        kind = ev.get("kind") or ev.get("type") or ""
+        payload = ev.get("payload")
+        payload_map = payload if isinstance(payload, Mapping) else {}
+
+        if kind == "step_activated":
+            active_step_id = _event_step_id(ev) or active_step_id
+        elif kind in ("step_completed", "step_blocked"):
+            sid = _event_step_id(ev)
+            if sid and active_step_id == sid:
+                active_step_id = ""
+
+        delta_items = _extract_event_delta_items(ev)
+        if not delta_items:
+            bios = payload_map.get("bios")
+            if isinstance(bios, Mapping):
+                for key, value in bios.items():
+                    if isinstance(key, str) and key:
+                        last_values[key] = value
+            continue
+
+        t_wall = _event_wall_time(ev)
+        before_help, after_help, nearest_help, seconds_since_help, fused_step_id = _help_cycle_links(
+            t_wall,
+            help_cycles,
+        )
+        source = _event_source(ev)
+        timestamp = _opt_str(ev.get("timestamp")) or ""
+
+        bios = payload_map.get("bios")
+        bios_map = bios if isinstance(bios, Mapping) else {}
+
+        for raw_key, raw_after in delta_items:
+            raw_before = last_values.get(raw_key)
+            if raw_after is None and raw_key in bios_map:
+                raw_after = bios_map.get(raw_key)
+
+            mapped_targets = list(bios_to_ui.get(raw_key, ()))
+            candidate_step_ids = _candidate_steps_for_targets(mapped_targets, step_ids_by_target)
+            expected_for_step = ""
+            if active_step_id and candidate_step_ids:
+                expected_for_step = _yes_no(active_step_id in candidate_step_ids)
+            elif active_step_id and not candidate_step_ids:
+                expected_for_step = "no"
+
+            gate_violation = bool(
+                active_step_id
+                and mapped_targets
+                and candidate_step_ids
+                and active_step_id not in candidate_step_ids
+            )
+            completed_by_event = _completed_by_action_event(
+                events,
+                event_index=event_index,
+                event_wall=t_wall,
+                candidate_step_ids=candidate_step_ids,
+            )
+
+            hints: list[str] = []
+            if not mapped_targets:
+                hints.append("unmapped_raw_key")
+            if mapped_targets and not candidate_step_ids:
+                hints.append("mapped_target_without_candidate_step")
+            if active_step_id and candidate_step_ids and active_step_id not in candidate_step_ids:
+                hints.append("unexpected_for_active_step")
+            if active_step_id and candidate_step_ids and active_step_id in candidate_step_ids:
+                hints.append("expected_for_active_step")
+            if seconds_since_help is not None:
+                hints.append("after_help")
+            if completed_by_event:
+                hints.append("completed_step")
+
+            delta_text = ""
+            if raw_before is not None and isinstance(raw_before, (int, float)) and isinstance(raw_after, (int, float)):
+                delta_text = _stringify_csv_value(raw_after - raw_before)
+            elif raw_after is not None:
+                delta_text = _stringify_csv_value(raw_after)
+
+            rows.append(
+                ActionTimelineRecord(
+                    ParticipantID=meta.participant_id,
+                    Condition=meta.condition,
+                    TrialID=meta.trial_id,
+                    EventIndex=event_index,
+                    Timestamp=timestamp,
+                    TWall=t_wall,
+                    Source=source,
+                    RawKey=raw_key,
+                    RawValueBefore=_stringify_csv_value(raw_before),
+                    RawValueAfter=_stringify_csv_value(raw_after),
+                    Delta=delta_text,
+                    MappedTarget=_join_csv_values(mapped_targets),
+                    CandidateStepID=_join_csv_values(candidate_step_ids),
+                    ActiveStepID=active_step_id,
+                    FusedStepID=fused_step_id,
+                    ExpectedForStep=expected_for_step,
+                    BeforeHelpCycleID=before_help,
+                    AfterHelpCycleID=after_help,
+                    NearestHelpCycleID=nearest_help,
+                    SecondsSinceLastHelp=seconds_since_help,
+                    StepCompletedByThisEvent=_yes_no(completed_by_event),
+                    GateViolationCandidate=_yes_no(gate_violation),
+                    AutoCodingHint=_join_csv_values(hints),
+                )
+            )
+
+        for key, value in delta_items:
+            last_values[key] = value
+        for key, value in bios_map.items():
+            if isinstance(key, str) and key:
+                last_values[key] = value
+
     return rows
 
 
@@ -1086,6 +1469,8 @@ def build_experiment_export(
     meta_overrides: Mapping[str, Any] | None = None,
     scoring: Mapping[str, Any] | None = None,
     pack_path: str | Path | None = None,
+    bios_to_ui_path: str | Path | None = None,
+    ui_map_path: str | Path | None = None,
 ) -> ExperimentExport:
     """Build a complete experiment export from a list of event dicts."""
 
@@ -1132,6 +1517,13 @@ def build_experiment_export(
 
     summary = compute_interaction_metrics(events)
     pack_steps = _load_pack_steps_for_export(pack_path)
+    action_timeline = _build_action_timeline(
+        events,
+        meta=meta,
+        help_cycles=help_cycles,
+        pack_steps=pack_steps,
+        bios_to_ui_path=bios_to_ui_path,
+    )
     step_coding = _build_step_coding(
         events,
         meta=meta,
@@ -1163,6 +1555,7 @@ def build_experiment_export(
         meta=meta,
         summary=summary,
         help_cycles=help_cycles,
+        action_timeline=action_timeline,
         step_coding=step_coding,
         trial_summary=trial_summary,
         scoring=dict(scoring) if isinstance(scoring, Mapping) else None,
@@ -1174,11 +1567,13 @@ __all__ = [
     "SessionMeta",
     "ExportQualityReport",
     "HelpCycleRecord",
+    "ActionTimelineRecord",
     "StepCodingRecord",
     "TrialSummaryRecord",
     "TimelineSnapshot",
     "ExperimentExport",
     "HELP_CYCLES_CSV_FIELDS",
+    "ACTION_TIMELINE_CSV_FIELDS",
     "STEP_CODING_CSV_FIELDS",
     "TRIAL_SUMMARY_CSV_FIELDS",
     "build_export_quality_report",

--- a/simtutor/__main__.py
+++ b/simtutor/__main__.py
@@ -518,6 +518,7 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
 
     from core.event_store import JsonlEventStore
     from core.experiment_export import (
+        ACTION_TIMELINE_CSV_FIELDS,
         HELP_CYCLES_CSV_FIELDS,
         STEP_CODING_CSV_FIELDS,
         TRIAL_SUMMARY_CSV_FIELDS,
@@ -603,6 +604,8 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
         meta_overrides=meta_overrides,
         scoring=scoring,
         pack_path=pack_path,
+        bios_to_ui_path=bios_to_ui_path,
+        ui_map_path=ui_map_path,
     )
     out_dir = Path(args.output_dir)
     if args.participant_id:
@@ -624,6 +627,7 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
         "session.json",
         "summary.json",
         "help_cycles.csv",
+        "action_timeline.csv",
         "step_coding.csv",
         "trial_summary.csv",
         "raw_events.jsonl",
@@ -673,6 +677,14 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
                 row["overlay_targets"] = ";".join(c.overlay_targets)
                 row["response_mapping_failure_codes"] = ";".join(c.response_mapping_failure_codes)
                 writer.writerow(row)
+
+        # action_timeline.csv
+        action_timeline_path = staging_dir / "action_timeline.csv"
+        with action_timeline_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=ACTION_TIMELINE_CSV_FIELDS, extrasaction="ignore")
+            writer.writeheader()
+            for row in export.action_timeline:
+                writer.writerow(row.to_dict())
 
         # step_coding.csv
         step_coding_path = staging_dir / "step_coding.csv"
@@ -743,6 +755,7 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
     if copy_raw_log:
         print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'raw_events.jsonl'}")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'help_cycles.csv'} ({len(export.help_cycles)} cycles)")
+    print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'action_timeline.csv'} ({len(export.action_timeline)} actions)")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'step_coding.csv'} ({len(export.step_coding)} steps)")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'trial_summary.csv'} ({len(export.trial_summary)} trials)")
     print(f"[EXPERIMENT_EXPORT] wrote {out_dir / 'summary.json'}")

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -11,8 +11,10 @@ from pathlib import Path
 
 import simtutor.__main__ as simtutor_cli
 from core.experiment_export import (
+    ACTION_TIMELINE_CSV_FIELDS,
     HELP_CYCLES_CSV_FIELDS,
     SessionMeta,
+    ActionTimelineRecord,
     HelpCycleRecord,
     STEP_CODING_CSV_FIELDS,
     TRIAL_SUMMARY_CSV_FIELDS,
@@ -53,7 +55,15 @@ def _make_events_with_help_cycles() -> list[dict]:
         # --- observation 1 ---
         {
             "kind": "observation",
-            "payload": {"seq": 1, "t_wall": 0.5, "source": "telemetry"},
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 0.5,
+                "source": "dcs_bios",
+                "bios": {"BATTERY_SW": 2},
+                "delta": {"BATTERY_SW": 2},
+            },
+            "metadata": {"seq": 1, "delta_count": 1},
             "t_wall": 0.5,
             "session_id": session_id,
             "timestamp": t0.isoformat(),
@@ -258,6 +268,97 @@ def _make_events_with_help_cycles() -> list[dict]:
     ]
 
 
+def _make_events_with_action_timeline() -> list[dict]:
+    t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2026, 5, 9, 10, 0, 2, tzinfo=timezone.utc)
+    t2 = datetime(2026, 5, 9, 10, 0, 4, tzinfo=timezone.utc)
+    t3 = datetime(2026, 5, 9, 10, 0, 9, tzinfo=timezone.utc)
+    t4 = datetime(2026, 5, 9, 10, 0, 12, tzinfo=timezone.utc)
+    t5 = datetime(2026, 5, 9, 10, 0, 14, tzinfo=timezone.utc)
+    t6 = datetime(2026, 5, 9, 10, 0, 20, tzinfo=timezone.utc)
+    t7 = datetime(2026, 5, 9, 10, 0, 24, tzinfo=timezone.utc)
+
+    return [
+        {
+            "kind": "step_activated",
+            "payload": {"step_id": "S01"},
+            "t_wall": 0.0,
+            "timestamp": t0.isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 2.0,
+                "source": "dcs_bios",
+                "bios": {"BATTERY_SW": 2},
+                "delta": {"BATTERY_SW": 2},
+            },
+            "metadata": {"seq": 1, "delta_count": 1},
+            "t_wall": 2.0,
+            "timestamp": t1.isoformat(),
+        },
+        {
+            "kind": "step_completed",
+            "payload": {"step_id": "S01"},
+            "t_wall": 4.0,
+            "timestamp": t2.isoformat(),
+        },
+        {
+            "kind": "step_activated",
+            "payload": {"step_id": "S02"},
+            "t_wall": 9.0,
+            "timestamp": t3.isoformat(),
+        },
+        {
+            "kind": "tutor_request",
+            "payload": {
+                "intent": "ask_help",
+                "metadata": {"help_cycle_id": "cycle-s02", "fused_step_id": "S02"},
+            },
+            "metadata": {"help_cycle_id": "cycle-s02", "fused_step_id": "S02"},
+            "related_id": "cycle-s02",
+            "t_wall": 12.0,
+            "timestamp": t4.isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 2,
+                "t_wall": 14.0,
+                "source": "dcs_bios",
+                "bios": {"BATTERY_SW": 2, "APU_CONTROL_SW": 1},
+                "delta": {"APU_CONTROL_SW": 1},
+            },
+            "metadata": {"seq": 2, "delta_count": 1},
+            "t_wall": 14.0,
+            "timestamp": t5.isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 3,
+                "t_wall": 20.0,
+                "source": "dcs_bios",
+                "bios": {"BATTERY_SW": 2, "APU_CONTROL_SW": 1, "EXPERIMENTAL_RAW_KEY": 7},
+                "delta": {"EXPERIMENTAL_RAW_KEY": 7},
+            },
+            "metadata": {"seq": 3, "delta_count": 1},
+            "t_wall": 20.0,
+            "timestamp": t6.isoformat(),
+        },
+        {
+            "kind": "step_completed",
+            "payload": {"step_id": "S03"},
+            "t_wall": 24.0,
+            "timestamp": t7.isoformat(),
+        },
+    ]
+
+
 # ── tests ───────────────────────────────────────────────────────────────
 
 def test_session_meta_roundtrip():
@@ -397,6 +498,7 @@ def test_build_export_with_help_cycles():
     assert "meta" in d
     assert "summary" in d
     assert "help_cycles" in d
+    assert "action_timeline" in d
     assert "step_coding" in d
     assert "trial_summary" in d
     assert "scoring" in d
@@ -467,6 +569,13 @@ def test_build_export_includes_study_ready_tables():
 
 
 def test_study_ready_csv_contract_fields_are_frozen():
+    assert ACTION_TIMELINE_CSV_FIELDS == [
+        "ParticipantID", "Condition", "TrialID", "EventIndex", "Timestamp", "TWall", "Source",
+        "RawKey", "RawValueBefore", "RawValueAfter", "Delta", "MappedTarget",
+        "CandidateStepID", "ActiveStepID", "FusedStepID", "ExpectedForStep",
+        "BeforeHelpCycleID", "AfterHelpCycleID", "NearestHelpCycleID", "SecondsSinceLastHelp",
+        "StepCompletedByThisEvent", "GateViolationCandidate", "AutoCodingHint",
+    ]
     assert HELP_CYCLES_CSV_FIELDS == [
         "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
         "vision_used", "vision_status", "vision_fact_status", "vision_fallback_reason", "sync_delta_ms",
@@ -489,6 +598,74 @@ def test_study_ready_csv_contract_fields_are_frozen():
         "LLMTriggers", "VLMCalls", "OverlayExecuted", "OverlayRejected", "FallbackCount",
         "CriticalStepsCompleted", "TotalStepsCompleted", "StepCompletionAccuracy",
     ]
+
+
+def test_action_timeline_links_dcs_deltas_to_steps_and_help_cycles():
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_events_with_action_timeline(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "with_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    assert [row.RawKey for row in export.action_timeline] == [
+        "BATTERY_SW",
+        "APU_CONTROL_SW",
+        "EXPERIMENTAL_RAW_KEY",
+    ]
+
+    expected = export.action_timeline[0]
+    assert expected.ParticipantID == "P01"
+    assert expected.Condition == "with_tutor"
+    assert expected.TrialID == "T01"
+    assert expected.EventIndex == 1
+    assert expected.Source == "dcs_bios"
+    assert expected.RawValueAfter == "2"
+    assert expected.MappedTarget == "battery_switch"
+    assert expected.CandidateStepID == "S01"
+    assert expected.ActiveStepID == "S01"
+    assert expected.ExpectedForStep == "yes"
+    assert expected.BeforeHelpCycleID == "cycle-s02"
+    assert expected.AfterHelpCycleID == ""
+    assert expected.NearestHelpCycleID == "cycle-s02"
+    assert expected.SecondsSinceLastHelp is None
+    assert expected.StepCompletedByThisEvent == "yes"
+    assert expected.GateViolationCandidate == "no"
+
+    unrelated = export.action_timeline[1]
+    assert unrelated.MappedTarget == "apu_switch"
+    assert unrelated.CandidateStepID == "S03"
+    assert unrelated.ActiveStepID == "S02"
+    assert unrelated.ExpectedForStep == "no"
+    assert unrelated.AfterHelpCycleID == "cycle-s02"
+    assert unrelated.NearestHelpCycleID == "cycle-s02"
+    assert unrelated.SecondsSinceLastHelp == 2.0
+    assert unrelated.StepCompletedByThisEvent == "no"
+    assert unrelated.GateViolationCandidate == "yes"
+    assert "unexpected_for_active_step" in unrelated.AutoCodingHint
+
+    unmapped = export.action_timeline[2]
+    assert unmapped.RawKey == "EXPERIMENTAL_RAW_KEY"
+    assert unmapped.RawValueAfter == "7"
+    assert unmapped.MappedTarget == ""
+    assert unmapped.CandidateStepID == ""
+    assert "unmapped_raw_key" in unmapped.AutoCodingHint
+
+
+def test_action_timeline_record_serialization():
+    rec = ActionTimelineRecord(
+        ParticipantID="P01",
+        Condition="with_tutor",
+        TrialID="T01",
+        EventIndex=3,
+        RawKey="BATTERY_SW",
+        RawValueAfter="2",
+    )
+
+    assert rec.to_dict()["ParticipantID"] == "P01"
+    assert rec.to_dict()["RawKey"] == "BATTERY_SW"
 
 
 def test_step_coding_uses_fused_step_as_help_cycle_owner():
@@ -843,6 +1020,10 @@ def test_experiment_export_cli_freezes_metadata_and_copies_raw_log(tmp_path: Pat
     assert session["quality_gate"]["passed"] is True
     assert (trial_dir / "step_coding.csv").exists()
     assert (trial_dir / "trial_summary.csv").exists()
+    assert (trial_dir / "action_timeline.csv").exists()
+    with (trial_dir / "action_timeline.csv").open("r", newline="", encoding="utf-8") as f:
+        action_rows = list(csv.DictReader(f))
+    assert list(action_rows[0].keys()) == ACTION_TIMELINE_CSV_FIELDS
     with (trial_dir / "step_coding.csv").open("r", newline="", encoding="utf-8") as f:
         step_rows = list(csv.DictReader(f))
     assert len(step_rows) == 33

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -287,13 +287,21 @@ def _make_events_with_action_timeline() -> list[dict]:
         },
         {
             "kind": "observation",
-            "source": "dcs_bios",
             "payload": {
-                "seq": 1,
-                "t_wall": 2.0,
+                "observation_id": "obs-action-001",
+                "timestamp": t1.isoformat(),
                 "source": "dcs_bios",
-                "bios": {"BATTERY_SW": 2},
-                "delta": {"BATTERY_SW": 2},
+                "payload": {
+                    "seq": 1,
+                    "t_wall": 2.0,
+                    "delta_summary": {
+                        "recent_key_changes_topk": [
+                            {"key": "BATTERY_SW", "value": 2, "ui_targets": ["battery_switch"]},
+                        ],
+                    },
+                    "recent_ui_targets": ["battery_switch"],
+                },
+                "metadata": {"seq": 1, "delta_count": 1},
             },
             "metadata": {"seq": 1, "delta_count": 1},
             "t_wall": 2.0,
@@ -644,14 +652,31 @@ def test_action_timeline_links_dcs_deltas_to_steps_and_help_cycles():
     assert unrelated.SecondsSinceLastHelp == 2.0
     assert unrelated.StepCompletedByThisEvent == "no"
     assert unrelated.GateViolationCandidate == "yes"
-    assert "unexpected_for_active_step" in unrelated.AutoCodingHint
+    assert "unexpected_for_active_step" in set(unrelated.AutoCodingHint.split(";"))
 
     unmapped = export.action_timeline[2]
     assert unmapped.RawKey == "EXPERIMENTAL_RAW_KEY"
     assert unmapped.RawValueAfter == "7"
     assert unmapped.MappedTarget == ""
     assert unmapped.CandidateStepID == ""
-    assert "unmapped_raw_key" in unmapped.AutoCodingHint
+    assert "unmapped_raw_key" in set(unmapped.AutoCodingHint.split(";"))
+
+
+def test_action_timeline_rejects_bios_mapping_with_unknown_ui_target():
+    root = _repo_root()
+    export_events = _make_events_with_action_timeline()
+
+    try:
+        build_experiment_export(
+            export_events,
+            pack_path=root / "packs/fa18c_startup/pack.yaml",
+            bios_to_ui_path=root / "tests/adapters/fixtures/bios_to_ui_bad_target.yaml",
+            ui_map_path=root / "tests/adapters/fixtures/ui_map_only_target.yaml",
+        )
+    except ValueError as exc:
+        assert "unknown ui target" in str(exc)
+    else:
+        raise AssertionError("expected invalid bios_to_ui mapping to fail")
 
 
 def test_action_timeline_record_serialization():
@@ -1053,6 +1078,63 @@ def test_experiment_export_cli_freezes_metadata_and_copies_raw_log(tmp_path: Pat
     assert _run_experiment_export(args) == 1
     args.overwrite = True
     assert _run_experiment_export(args) == 0
+
+
+def test_experiment_export_cli_writes_action_timeline_rows(tmp_path: Path):
+    raw_log = tmp_path / "events.jsonl"
+    _write_jsonl(raw_log, _make_events_with_action_timeline())
+    output_dir = tmp_path / "exports"
+    root = _repo_root()
+
+    args = argparse.Namespace(
+        file=str(raw_log),
+        participant_id="P01",
+        trial_id="T01",
+        study_id="study-alpha",
+        condition="with_tutor",
+        group="novice",
+        experimenter_id=None,
+        questionnaire=None,
+        recording_ref=None,
+        notes=None,
+        output_dir=str(output_dir),
+        scoring=None,
+        pack=str(root / "packs/fa18c_startup/pack.yaml"),
+        taxonomy=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map=str(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui=str(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        model_provider=None,
+        model_name=None,
+        vision_model_name=None,
+        prompt_version=None,
+        prompt_hash=None,
+        scenario_profile=None,
+        dcs_mission=None,
+        dcs_aircraft=None,
+        vr_setup=None,
+        monitor_setup=None,
+        git_commit="abc123",
+        git_dirty=False,
+        strict=False,
+        overwrite=False,
+        copy_raw_log=True,
+    )
+
+    assert _run_experiment_export(args) == 0
+
+    trial_dir = output_dir / "P01" / "T01"
+    with (trial_dir / "action_timeline.csv").open("r", newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert [row["RawKey"] for row in rows] == ["BATTERY_SW", "APU_CONTROL_SW", "EXPERIMENTAL_RAW_KEY"]
+    assert rows[0]["MappedTarget"] == "battery_switch"
+    assert rows[0]["CandidateStepID"] == "S01"
+    assert rows[1]["SecondsSinceLastHelp"] == "2.0"
+    assert rows[1]["GateViolationCandidate"] == "yes"
+    assert "unexpected_for_active_step" in set(rows[1]["AutoCodingHint"].split(";"))
+    assert rows[2]["RawValueAfter"] == "7"
+    assert rows[2]["MappedTarget"] == ""
+    assert "unmapped_raw_key" in set(rows[2]["AutoCodingHint"].split(";"))
 
 
 def test_experiment_export_cli_overwrite_replaces_stale_managed_outputs(tmp_path: Path):


### PR DESCRIPTION
## Summary
- add experiment-grade action_timeline.csv export for DCS-BIOS action/state-change rows
- map raw DCS-BIOS keys to UI targets and candidate pack steps when bios_to_ui.yaml can resolve them
- link action rows to active/fused steps and nearby help cycles with conservative auto-coding hints

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/adapters/test_bios_ui_map.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #355