### PR TITLE
Add semi-automatic pre-scoring workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ python -m simtutor score logs/run_demo.jsonl \
   --taxonomy packs/fa18c_startup/taxonomy.yaml
 ```
 
+`simtutor score` is a legacy OM/SV-only smoke scorer. For experiment scoring,
+use `experiment-export`: `step_coding.csv` contains automatic candidate/prefill
+columns (`Auto_Error_*`, confidence, evidence refs) plus blank final rater
+columns (`Error_*`, `CoderID`, `CoderNotes`). Final five-category scores require
+human rater confirmation.
+
 ## Documentation
 
 Detailed commands are intentionally kept out of the front page:

--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -14,6 +14,7 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+from core.gating import GatingEngine
 from core.help_cycle_audit import normalize_help_cycle_audit_fields
 from core.interaction_metrics import InteractionMetrics, compute_interaction_metrics
 
@@ -112,11 +113,20 @@ STEP_CODING_CSV_FIELDS = [
     "FirstFusedStepID",
     "LastFusedStepID",
     "EvidenceRefs",
+    "Auto_Error_OM",
+    "Auto_Error_CO",
+    "Auto_Error_OR",
+    "Auto_Error_PA",
+    "Auto_Error_SV",
+    "AutoConfidence",
+    "AutoEvidenceRefs",
+    "NeedsHumanReview",
     "Error_OM",
     "Error_CO",
     "Error_OR",
     "Error_PA",
     "Error_SV",
+    "CoderID",
     "CoderNotes",
     "AutoCodingNotes",
 ]
@@ -522,11 +532,20 @@ class StepCodingRecord:
     FirstFusedStepID: str = ""
     LastFusedStepID: str = ""
     EvidenceRefs: str = ""
+    Auto_Error_OM: str = "0"
+    Auto_Error_CO: str = "0"
+    Auto_Error_OR: str = "0"
+    Auto_Error_PA: str = "0"
+    Auto_Error_SV: str = "0"
+    AutoConfidence: str = ""
+    AutoEvidenceRefs: str = ""
+    NeedsHumanReview: str = "no"
     Error_OM: str = ""
     Error_CO: str = ""
     Error_OR: str = ""
     Error_PA: str = ""
     Error_SV: str = ""
+    CoderID: str = ""
     CoderNotes: str = ""
     AutoCodingNotes: str = ""
 
@@ -1378,6 +1397,468 @@ def _build_action_timeline(
     return rows
 
 
+_AUTO_CONFIDENCE_RANK = {"": 0, "low": 1, "medium": 2, "high": 3}
+
+
+def _split_csv_values(value: str) -> list[str]:
+    return [item for item in value.split(";") if item]
+
+
+def _append_unique_ref(existing: str, ref: str) -> str:
+    refs = _split_csv_values(existing)
+    if ref not in refs:
+        refs.append(ref)
+    return _join_csv_values(refs)
+
+
+def _set_auto_candidate(
+    row: StepCodingRecord,
+    category: str,
+    evidence_ref: str,
+    *,
+    confidence: str = "medium",
+) -> None:
+    field_name = f"Auto_Error_{category}"
+    if not hasattr(row, field_name):
+        return
+    setattr(row, field_name, "1")
+    row.NeedsHumanReview = "yes"
+    row.AutoEvidenceRefs = _append_unique_ref(row.AutoEvidenceRefs, evidence_ref)
+    if _AUTO_CONFIDENCE_RANK.get(confidence, 0) > _AUTO_CONFIDENCE_RANK.get(row.AutoConfidence, 0):
+        row.AutoConfidence = confidence
+
+
+def _completion_event_indices(events: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    completed: dict[str, int] = {}
+    for event_index, ev in enumerate(events):
+        kind = ev.get("kind") or ev.get("type") or ""
+        if kind != "step_completed":
+            continue
+        step_id = _event_step_id(ev)
+        if step_id and step_id not in completed:
+            completed[step_id] = event_index
+    return completed
+
+
+def _load_gate_config_for_export(
+    pack_path: str | Path | None,
+    *,
+    scenario_profile: str | None,
+) -> dict[str, Mapping[str, Any]]:
+    if pack_path is None:
+        return {"precondition_gates": {}, "completion_gates": {}}
+    try:
+        pack = _load_yaml_mapping(pack_path)
+    except Exception:
+        return {"precondition_gates": {}, "completion_gates": {}}
+
+    config: dict[str, dict[str, Any]] = {"precondition_gates": {}, "completion_gates": {}}
+    for field_name in config:
+        raw = pack.get(field_name)
+        if isinstance(raw, Mapping):
+            config[field_name] = {
+                step_id: list(rules) if isinstance(rules, list) else rules
+                for step_id, rules in raw.items()
+                if isinstance(step_id, str)
+            }
+
+    profile = scenario_profile if isinstance(scenario_profile, str) and scenario_profile else "airfield"
+    overrides_root = pack.get("profile_overrides")
+    if isinstance(overrides_root, Mapping):
+        overrides = overrides_root.get(profile)
+        if isinstance(overrides, Mapping):
+            for field_name in config:
+                raw_overrides = overrides.get(field_name)
+                if not isinstance(raw_overrides, Mapping):
+                    continue
+                for step_id, rules in raw_overrides.items():
+                    if isinstance(step_id, str) and isinstance(rules, list):
+                        config[field_name][step_id] = list(rules)
+
+    return config
+
+
+def _mark_om_candidates(rows: Sequence[StepCodingRecord]) -> None:
+    for row in rows:
+        if row.Completed == "yes":
+            continue
+        evidence = "om:not_completed"
+        _set_auto_candidate(row, "OM", evidence, confidence="high")
+        if row.Performed == "yes":
+            row.AutoEvidenceRefs = _append_unique_ref(row.AutoEvidenceRefs, "om:partial_or_unfinished")
+
+
+def _event_vars(ev: Mapping[str, Any]) -> Mapping[str, Any]:
+    for payload in reversed(_event_payload_layers(ev)):
+        vars_payload = payload.get("vars")
+        if isinstance(vars_payload, Mapping):
+            return vars_payload
+    vars_top = ev.get("vars")
+    return vars_top if isinstance(vars_top, Mapping) else {}
+
+
+def _vars_history_by_event(events: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    current_vars: dict[str, Any] = {}
+    history: list[dict[str, Any]] = []
+    for ev in events:
+        for key, value in _event_vars(ev).items():
+            if isinstance(key, str) and key:
+                current_vars[key] = value
+        snapshot = dict(current_vars)
+        history.append({"vars": snapshot, "payload": {"vars": snapshot}})
+    return history
+
+
+def _gate_failure_has_evidence(reason: str | None) -> bool:
+    if not reason:
+        return False
+    lowered = reason.lower()
+    return "missing" not in lowered and "unknown" not in lowered
+
+
+def _precondition_failure(
+    *,
+    step_id: str,
+    event_index: int,
+    precondition_gates: Mapping[str, Any],
+    vars_history: Sequence[dict[str, Any]],
+) -> tuple[str, str | None, str] | None:
+    raw_rules = precondition_gates.get(step_id)
+    if not isinstance(raw_rules, list) or not raw_rules:
+        return None
+    if event_index < 0 or event_index >= len(vars_history):
+        return None
+    rules = [dict(rule) for rule in raw_rules if isinstance(rule, Mapping)]
+    result, failure_index = GatingEngine(rules).evaluate_with_failure_index(
+        [vars_history[event_index]]
+    )
+    if result.allowed or not _gate_failure_has_evidence(result.reason):
+        return None
+    failed_rule = rules[failure_index] if failure_index is not None and failure_index < len(rules) else {}
+    failed_var = _opt_str(failed_rule.get("var"))
+    reason_code = _opt_str(failed_rule.get("reason_code")) or failed_var or "precondition_unsatisfied"
+    return result.reason or "precondition_unsatisfied", failed_var, reason_code
+
+
+def _dependency_step_for_failed_var(
+    *,
+    step_id: str,
+    event_index: int,
+    failed_var: str | None,
+    step_order: Mapping[str, int],
+    completion_indices: Mapping[str, int],
+    completion_gates: Mapping[str, Any],
+) -> str | None:
+    if not failed_var:
+        return None
+    candidate_order = step_order.get(step_id)
+    if candidate_order is None:
+        return None
+    ordered_prior = sorted(
+        (
+            (prior_order, prior_step)
+            for prior_step, prior_order in step_order.items()
+            if prior_order < candidate_order
+        )
+    )
+    for _, prior_step in ordered_prior:
+        raw_rules = completion_gates.get(prior_step)
+        if not isinstance(raw_rules, list):
+            continue
+        if not any(isinstance(rule, Mapping) and rule.get("var") == failed_var for rule in raw_rules):
+            continue
+        completed_at = completion_indices.get(prior_step)
+        if completed_at is None or completed_at > event_index:
+            return prior_step
+    return None
+
+
+def _mark_action_candidates(
+    *,
+    rows_by_step: Mapping[str, StepCodingRecord],
+    step_order: Mapping[str, int],
+    action_timeline: Sequence[ActionTimelineRecord],
+    completion_indices: Mapping[str, int],
+    precondition_gates: Mapping[str, Any],
+    completion_gates: Mapping[str, Any],
+    vars_history: Sequence[dict[str, Any]],
+) -> None:
+    for action in action_timeline:
+        candidate_steps = _split_csv_values(action.CandidateStepID)
+        active_step = action.ActiveStepID or action.FusedStepID
+        blocked_candidate_seen = False
+
+        for step_id in candidate_steps:
+            row = rows_by_step.get(step_id)
+            if row is None:
+                continue
+            failure_reason = _precondition_failure(
+                step_id=step_id,
+                event_index=action.EventIndex,
+                precondition_gates=precondition_gates,
+                vars_history=vars_history,
+            )
+            if failure_reason is None:
+                continue
+            _failure_text, failed_var, reason_code = failure_reason
+            blocked_candidate_seen = True
+            _set_auto_candidate(
+                row,
+                "SV",
+                f"action:{action.EventIndex}:precondition_gate:{reason_code}",
+                confidence="medium",
+            )
+            missing_prior = _dependency_step_for_failed_var(
+                step_id=step_id,
+                event_index=action.EventIndex,
+                failed_var=failed_var,
+                step_order=step_order,
+                completion_indices=completion_indices,
+                completion_gates=completion_gates,
+            )
+            if missing_prior is not None:
+                _set_auto_candidate(
+                    row,
+                    "OR",
+                    f"action:{action.EventIndex}:out_of_order_before:{missing_prior}",
+                    confidence="medium",
+                )
+
+        hints = set(_split_csv_values(action.AutoCodingHint))
+        if "unmapped_raw_key" in hints and active_step:
+            row = rows_by_step.get(active_step)
+            if row is not None:
+                _set_auto_candidate(
+                    row,
+                    "CO",
+                    f"action:{action.EventIndex}:unmapped_raw_key",
+                    confidence="low",
+                )
+        if (
+            "unexpected_for_active_step" in hints
+            or "mapped_target_without_candidate_step" in hints
+        ) and active_step and not blocked_candidate_seen:
+            row = rows_by_step.get(active_step)
+            if row is not None:
+                _set_auto_candidate(
+                    row,
+                    "CO",
+                    f"action:{action.EventIndex}:unexpected_for_active_step",
+                    confidence="medium",
+                )
+
+
+def _payload_tags(ev: Mapping[str, Any]) -> list[str]:
+    for payload in _event_payload_layers(ev):
+        tags = payload.get("tags")
+        if isinstance(tags, list):
+            return [tag for tag in tags if isinstance(tag, str) and tag]
+    tags = ev.get("tags")
+    if isinstance(tags, list):
+        return [tag for tag in tags if isinstance(tag, str) and tag]
+    return []
+
+
+def _payload_procedure_hint(ev: Mapping[str, Any]) -> str | None:
+    for payload in _event_payload_layers(ev):
+        hint = _opt_str(payload.get("procedure_hint"))
+        if hint:
+            return hint
+    return _opt_str(ev.get("procedure_hint"))
+
+
+def _mark_explicit_sv_candidates(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    rows_by_step: Mapping[str, StepCodingRecord],
+) -> None:
+    active_step = ""
+    for event_index, ev in enumerate(events):
+        kind = ev.get("kind") or ev.get("type") or ""
+        step_id = _event_step_id(ev)
+        if kind == "step_activated" and step_id:
+            active_step = step_id
+        elif kind in ("step_completed", "step_blocked") and step_id == active_step:
+            active_step = ""
+
+        if kind != "observation" or "state_violation" not in _payload_tags(ev):
+            continue
+        target_step = _payload_procedure_hint(ev) or active_step or step_id
+        row = rows_by_step.get(target_step or "")
+        if row is not None:
+            _set_auto_candidate(
+                row,
+                "SV",
+                f"observation:{event_index}:state_violation",
+                confidence="medium",
+            )
+
+
+def _vars_by_event(events: Sequence[Mapping[str, Any]]) -> dict[int, dict[str, Any]]:
+    by_event: dict[int, dict[str, Any]] = {}
+    for event_index, ev in enumerate(events):
+        event_vars: dict[str, Any] = {}
+        for key, value in _event_vars(ev).items():
+            if isinstance(key, str) and key:
+                event_vars[key] = value
+                event_vars[f"vars.{key}"] = value
+        if event_vars:
+            by_event[event_index] = event_vars
+    return by_event
+
+
+def _is_numeric(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _mark_pa_candidates(
+    *,
+    rows_by_step: Mapping[str, StepCodingRecord],
+    completion_gates: Mapping[str, Any],
+    action_timeline: Sequence[ActionTimelineRecord],
+    completion_indices: Mapping[str, int],
+    step_order: Mapping[str, int],
+    vars_by_event: Mapping[int, Mapping[str, Any]],
+) -> None:
+    candidate_actions_by_step: dict[str, list[int]] = {}
+    for action in action_timeline:
+        for step_id in _split_csv_values(action.CandidateStepID):
+            candidate_actions_by_step.setdefault(step_id, []).append(action.EventIndex)
+
+    for step_id, raw_rules in completion_gates.items():
+        if not isinstance(step_id, str) or not isinstance(raw_rules, list):
+            continue
+        row = rows_by_step.get(step_id)
+        if row is None:
+            continue
+        for rule in raw_rules:
+            if not isinstance(rule, Mapping) or rule.get("op") != "arg_in_range":
+                continue
+            var_path = _opt_str(rule.get("var"))
+            min_value = rule.get("min")
+            max_value = rule.get("max")
+            if not var_path or not _is_numeric(min_value) or not _is_numeric(max_value):
+                continue
+            values: list[Any] = []
+            relevant_indices = _pa_relevant_event_indices(
+                step_id=step_id,
+                var_path=var_path,
+                candidate_actions_by_step=candidate_actions_by_step,
+                completion_indices=completion_indices,
+                step_order=step_order,
+                vars_by_event=vars_by_event,
+            )
+            for event_index in relevant_indices:
+                event_vars = vars_by_event.get(event_index, {})
+                value = event_vars.get(var_path)
+                if value is None and var_path.startswith("vars."):
+                    value = event_vars.get(var_path[len("vars.") :])
+                if _is_numeric(value):
+                    values.append(value)
+            if not values:
+                continue
+            if any(min_value <= value <= max_value for value in values):
+                continue
+            final_value = values[-1]
+            _set_auto_candidate(
+                row,
+                "PA",
+                f"pa:{var_path}={final_value} not_in:[{min_value},{max_value}]",
+                confidence="high",
+            )
+
+
+def _pa_relevant_event_indices(
+    *,
+    step_id: str,
+    var_path: str,
+    candidate_actions_by_step: Mapping[str, Sequence[int]],
+    completion_indices: Mapping[str, int],
+    step_order: Mapping[str, int],
+    vars_by_event: Mapping[int, Mapping[str, Any]],
+) -> list[int]:
+    action_indices = sorted(set(candidate_actions_by_step.get(step_id, ())))
+    completed_at = completion_indices.get(step_id)
+    previous_completed_at: int | None = None
+    current_order = step_order.get(step_id)
+    if current_order is not None:
+        prior_completion_indices = [
+            completed
+            for prior_step, prior_order in step_order.items()
+            if prior_order < current_order
+            if (completed := completion_indices.get(prior_step)) is not None
+        ]
+        if prior_completion_indices:
+            previous_completed_at = max(prior_completion_indices)
+
+    start_at = previous_completed_at if previous_completed_at is not None else -1
+    end_at = completed_at
+    if end_at is None and action_indices:
+        end_at = max(max(vars_by_event.keys(), default=action_indices[-1]), action_indices[-1])
+
+    relevant = []
+    for event_index in action_indices:
+        if event_index <= start_at:
+            continue
+        if completed_at is not None and event_index > completed_at:
+            continue
+        relevant.append(event_index)
+    for event_index, event_vars in vars_by_event.items():
+        if event_index <= start_at:
+            continue
+        if end_at is not None and event_index > end_at:
+            continue
+        has_var = var_path in event_vars or (
+            var_path.startswith("vars.") and var_path[len("vars.") :] in event_vars
+        )
+        if has_var:
+            relevant.append(event_index)
+    if completed_at is not None:
+        relevant.append(completed_at)
+    return sorted(set(relevant))
+
+
+def _apply_pre_scoring_candidates(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    step_coding: Sequence[StepCodingRecord],
+    action_timeline: Sequence[ActionTimelineRecord],
+    pack_steps: Sequence[Mapping[str, Any]],
+    pack_path: str | Path | None,
+    scenario_profile: str | None,
+) -> None:
+    rows_by_step = {row.StepID: row for row in step_coding if row.StepID}
+    step_order = {
+        step_id: idx
+        for idx, step in enumerate(pack_steps)
+        if (step_id := _opt_str(step.get("id"))) is not None
+    }
+    completion_indices = _completion_event_indices(events)
+    gate_config = _load_gate_config_for_export(pack_path, scenario_profile=scenario_profile)
+    vars_history = _vars_history_by_event(events)
+    vars_by_event = _vars_by_event(events)
+
+    _mark_om_candidates(step_coding)
+    _mark_action_candidates(
+        rows_by_step=rows_by_step,
+        step_order=step_order,
+        action_timeline=action_timeline,
+        completion_indices=completion_indices,
+        precondition_gates=gate_config["precondition_gates"],
+        completion_gates=gate_config["completion_gates"],
+        vars_history=vars_history,
+    )
+    _mark_explicit_sv_candidates(events=events, rows_by_step=rows_by_step)
+    _mark_pa_candidates(
+        rows_by_step=rows_by_step,
+        completion_gates=gate_config["completion_gates"],
+        action_timeline=action_timeline,
+        completion_indices=completion_indices,
+        step_order=step_order,
+        vars_by_event=vars_by_event,
+    )
+
+
 def _task_time_seconds(events: Sequence[Mapping[str, Any]]) -> float | None:
     times = [t for ev in events if (t := _event_wall_time(ev)) is not None]
     if not times:
@@ -1555,6 +2036,14 @@ def build_experiment_export(
         meta=meta,
         help_cycles=help_cycles,
         pack_steps=pack_steps,
+    )
+    _apply_pre_scoring_candidates(
+        events,
+        step_coding=step_coding,
+        action_timeline=action_timeline,
+        pack_steps=pack_steps,
+        pack_path=pack_path,
+        scenario_profile=meta.scenario_profile,
     )
     trial_summary = _build_trial_summary(
         events,

--- a/core/scoring.py
+++ b/core/scoring.py
@@ -1,10 +1,10 @@
 """
-Simple scoring engine v1.
+Legacy scoring engine v1.
 
 Rules:
 - Omission (OM): any canonical step up to the max observed step not completed.
 - State Violation (SV): observation tags containing 'state_violation'.
-- Other categories default to 0 in this version.
+- CO/OR/PA are not automatically detected by this legacy scorer.
 - Critical multiplier applied to omissions when step critical=True.
 """
 
@@ -95,6 +95,13 @@ def score_log(log_events: List[dict], pack_path: str, taxonomy_path: str) -> dic
         "Error_PA": errors["PA"],
         "Error_SV": errors["SV"],
         "TotalErrorScore": total,
+        "ScoringMode": "legacy_om_sv_only",
+        "FinalScoreRequiresHumanCoding": True,
+        "UndetectedErrorCategories": ["CO", "OR", "PA"],
+        "ScoringNotes": [
+            "CO/OR/PA zeros mean not detected by the legacy scorer, not verified absence.",
+            "Use experiment-export step_coding auto candidate columns as prefill for human raters.",
+        ],
         "completed_steps": sorted(list(completed)),
         "max_observed_step_index": max_seen_idx,
     }

--- a/docs/wiki/quickstart.md
+++ b/docs/wiki/quickstart.md
@@ -41,6 +41,13 @@ python -m simtutor score logs/run_demo.jsonl \
   --taxonomy packs/fa18c_startup/taxonomy.yaml
 ```
 
+`simtutor score` is a legacy OM/SV-only smoke scorer. For experiment work, run
+`experiment-export` and use `step_coding.csv`: the `Auto_Error_*`,
+`AutoConfidence`, `AutoEvidenceRefs`, and `NeedsHumanReview` columns are
+candidate prefill for raters, while `Error_*`, `CoderID`, and `CoderNotes` are
+the editable final coding fields. Final five-category scores require human
+rater confirmation.
+
 ## Replay DCS-BIOS Offline
 
 Offline replay is the safest way to iterate because overlay commands can remain dry-run.

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -367,6 +367,90 @@ def _make_events_with_action_timeline() -> list[dict]:
     ]
 
 
+def _make_events_for_prescoring_candidates() -> list[dict]:
+    t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)
+
+    def ts(offset: int) -> str:
+        return t0.replace(second=offset).isoformat()
+
+    return [
+        {
+            "kind": "step_activated",
+            "payload": {"step_id": "S01"},
+            "t_wall": 0.0,
+            "timestamp": ts(0),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 1.0,
+                "source": "dcs_bios",
+                "bios": {"APU_CONTROL_SW": 1},
+                "delta": {"APU_CONTROL_SW": 1},
+                "vars": {"power_available": False},
+            },
+            "t_wall": 1.0,
+            "timestamp": ts(1),
+        },
+        {
+            "kind": "step_completed",
+            "payload": {"step_id": "S01"},
+            "t_wall": 2.0,
+            "timestamp": ts(2),
+        },
+        {
+            "kind": "step_activated",
+            "payload": {"step_id": "S02"},
+            "t_wall": 3.0,
+            "timestamp": ts(3),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 2,
+                "t_wall": 4.0,
+                "source": "dcs_bios",
+                "bios": {"EXPERIMENTAL_RAW_KEY": 7},
+                "delta": {"EXPERIMENTAL_RAW_KEY": 7},
+            },
+            "t_wall": 4.0,
+            "timestamp": ts(4),
+        },
+        {
+            "kind": "step_completed",
+            "payload": {"step_id": "S03"},
+            "t_wall": 5.0,
+            "timestamp": ts(5),
+        },
+        {
+            "kind": "observation",
+            "payload": {
+                "procedure_hint": "S05",
+                "tags": ["state_violation"],
+            },
+            "t_wall": 6.0,
+            "timestamp": ts(6),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 3,
+                "t_wall": 7.0,
+                "source": "dcs_bios",
+                "bios": {"RADALT_MIN_HEIGHT_PTR": 50000},
+                "delta": {"RADALT_MIN_HEIGHT_PTR": 50000},
+                "vars": {"radar_altimeter_bug_value": 500},
+            },
+            "t_wall": 7.0,
+            "timestamp": ts(7),
+        },
+    ]
+
+
 # ── tests ───────────────────────────────────────────────────────────────
 
 def test_session_meta_roundtrip():
@@ -598,14 +682,274 @@ def test_study_ready_csv_contract_fields_are_frozen():
         "ParticipantID", "Condition", "TrialID", "StepID", "StepTitle", "Phase", "Critical",
         "Performed", "Completed", "FirstHelpTime_sec", "HelpCount", "FirstOverlayTargets",
         "LastOverlayTargets", "FirstFusedStepID", "LastFusedStepID", "EvidenceRefs",
-        "Error_OM", "Error_CO", "Error_OR", "Error_PA", "Error_SV", "CoderNotes",
-        "AutoCodingNotes",
+        "Auto_Error_OM", "Auto_Error_CO", "Auto_Error_OR", "Auto_Error_PA", "Auto_Error_SV",
+        "AutoConfidence", "AutoEvidenceRefs", "NeedsHumanReview",
+        "Error_OM", "Error_CO", "Error_OR", "Error_PA", "Error_SV", "CoderID",
+        "CoderNotes", "AutoCodingNotes",
     ]
     assert TRIAL_SUMMARY_CSV_FIELDS == [
         "ParticipantID", "Condition", "TrialID", "Completed", "TaskTime_sec", "HelpRequests",
         "LLMTriggers", "VLMCalls", "OverlayExecuted", "OverlayRejected", "FallbackCount",
         "CriticalStepsCompleted", "TotalStepsCompleted", "StepCompletionAccuracy",
     ]
+
+
+def test_step_coding_prefills_error_candidates_for_human_review():
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_events_for_prescoring_candidates(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "with_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+    by_step = {row.StepID: row for row in export.step_coding}
+
+    assert by_step["S02"].Auto_Error_OM == "1"
+    assert by_step["S02"].Auto_Error_CO == "1"
+    assert by_step["S02"].NeedsHumanReview == "yes"
+    assert "om:not_completed" in by_step["S02"].AutoEvidenceRefs
+    assert "action:4:unmapped_raw_key" in by_step["S02"].AutoEvidenceRefs
+
+    assert by_step["S03"].Completed == "yes"
+    assert by_step["S03"].Auto_Error_OR == "0"
+    assert by_step["S03"].Auto_Error_SV == "1"
+    assert "action:1:precondition_gate:s03_requires_power_available" in by_step["S03"].AutoEvidenceRefs
+
+    assert by_step["S05"].Auto_Error_SV == "1"
+    assert "observation:6:state_violation" in by_step["S05"].AutoEvidenceRefs
+
+    assert by_step["S31"].Auto_Error_PA == "1"
+    assert "vars.radar_altimeter_bug_value=500" in by_step["S31"].AutoEvidenceRefs
+
+    assert by_step["S01"].Auto_Error_OM == "0"
+    assert by_step["S01"].NeedsHumanReview == "no"
+    assert by_step["S01"].Error_OM == ""
+    assert by_step["S01"].CoderID == ""
+
+
+def test_order_prefill_requires_failed_gate_dependency(tmp_path: Path):
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        "steps:\n"
+        "  - id: S01\n"
+        "    phase: P1\n"
+        "    critical: false\n"
+        "    completion_conditions: [Ready set.]\n"
+        "    ui_targets: [ready_switch]\n"
+        "  - id: S02\n"
+        "    phase: P1\n"
+        "    critical: false\n"
+        "    completion_conditions: [Next set.]\n"
+        "    ui_targets: [next_switch]\n"
+        "precondition_gates:\n"
+        "  S01: []\n"
+        "  S02:\n"
+        "    - op: flag_true\n"
+        "      var: vars.ready\n"
+        "      reason_code: s02_requires_ready\n"
+        "completion_gates:\n"
+        "  S01:\n"
+        "    - op: flag_true\n"
+        "      var: vars.ready\n"
+        "      reason_code: s01_requires_ready\n"
+        "  S02: []\n",
+        encoding="utf-8",
+    )
+    ui_map = tmp_path / "ui_map.yaml"
+    ui_map.write_text(
+        "cockpit_elements:\n"
+        "  ready_switch: {}\n"
+        "  next_switch: {}\n",
+        encoding="utf-8",
+    )
+    bios_to_ui = tmp_path / "bios_to_ui.yaml"
+    bios_to_ui.write_text(
+        "mappings:\n"
+        "  NEXT_SW:\n"
+        "    - next_switch\n",
+        encoding="utf-8",
+    )
+
+    export = build_experiment_export(
+        [
+            {"kind": "step_activated", "payload": {"step_id": "S01"}, "t_wall": 0.0},
+            {
+                "kind": "observation",
+                "source": "dcs_bios",
+                "payload": {
+                    "source": "dcs_bios",
+                    "bios": {"NEXT_SW": 1},
+                    "delta": {"NEXT_SW": 1},
+                    "vars": {"ready": False},
+                },
+                "t_wall": 1.0,
+            },
+        ],
+        pack_path=pack,
+        bios_to_ui_path=bios_to_ui,
+        ui_map_path=ui_map,
+    )
+    by_step = {row.StepID: row for row in export.step_coding}
+
+    assert by_step["S02"].Auto_Error_SV == "1"
+    assert by_step["S02"].Auto_Error_OR == "1"
+    assert "action:1:out_of_order_before:S01" in by_step["S02"].AutoEvidenceRefs
+
+
+def test_active_step_mismatch_without_blocked_gate_is_not_sv_or_order():
+    t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)
+    events = [
+        {"kind": "step_completed", "payload": {"step_id": "S01"}, "t_wall": 0.0, "timestamp": t0.isoformat()},
+        {"kind": "step_activated", "payload": {"step_id": "S02"}, "t_wall": 1.0, "timestamp": t0.isoformat()},
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 2.0,
+                "source": "dcs_bios",
+                "bios": {"APU_CONTROL_SW": 1},
+                "delta": {"APU_CONTROL_SW": 1},
+                "vars": {"power_available": True},
+            },
+            "t_wall": 2.0,
+            "timestamp": t0.isoformat(),
+        },
+    ]
+    root = _repo_root()
+    export = build_experiment_export(
+        events,
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+    by_step = {row.StepID: row for row in export.step_coding}
+
+    assert by_step["S03"].Auto_Error_SV == "0"
+    assert by_step["S03"].Auto_Error_OR == "0"
+    assert by_step["S02"].Auto_Error_CO == "1"
+
+
+def test_parameter_prefill_uses_step_scoped_values_for_reversible_controls():
+    t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)
+    events = [
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 1.0,
+                "source": "dcs_bios",
+                "bios": {"PROBE_SW": 0},
+                "delta": {"PROBE_SW": 0},
+                "vars": {"ext_refuel_probe_value": 65000},
+            },
+            "t_wall": 1.0,
+            "timestamp": t0.isoformat(),
+        },
+        {"kind": "step_completed", "payload": {"step_id": "S20"}, "t_wall": 2.0, "timestamp": t0.isoformat()},
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 2,
+                "t_wall": 3.0,
+                "source": "dcs_bios",
+                "bios": {"PROBE_SW": 1},
+                "delta": {"PROBE_SW": 1},
+                "vars": {"ext_refuel_probe_value": 0},
+            },
+            "t_wall": 3.0,
+            "timestamp": t0.isoformat(),
+        },
+        {"kind": "step_completed", "payload": {"step_id": "S21"}, "t_wall": 4.0, "timestamp": t0.isoformat()},
+    ]
+    root = _repo_root()
+    export = build_experiment_export(
+        events,
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+    by_step = {row.StepID: row for row in export.step_coding}
+
+    assert by_step["S20"].Auto_Error_PA == "0"
+    assert by_step["S21"].Auto_Error_PA == "0"
+
+
+def test_parameter_prefill_reads_vars_only_telemetry_inside_step_window():
+    t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)
+    events = [
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 1.0,
+                "source": "dcs_bios",
+                "bios": {"RADALT_MIN_HEIGHT_PTR": 50000},
+                "delta": {"RADALT_MIN_HEIGHT_PTR": 50000},
+            },
+            "t_wall": 1.0,
+            "timestamp": t0.isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 2,
+                "t_wall": 2.0,
+                "source": "dcs_bios",
+                "vars": {"radar_altimeter_bug_value": 500},
+            },
+            "t_wall": 2.0,
+            "timestamp": t0.isoformat(),
+        },
+        {"kind": "step_completed", "payload": {"step_id": "S31"}, "t_wall": 3.0, "timestamp": t0.isoformat()},
+    ]
+    root = _repo_root()
+    export = build_experiment_export(
+        events,
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+    by_step = {row.StepID: row for row in export.step_coding}
+
+    assert by_step["S31"].Auto_Error_PA == "1"
+    assert "vars.radar_altimeter_bug_value=500" in by_step["S31"].AutoEvidenceRefs
+
+
+def test_parameter_prefill_honors_carrier_profile_overrides():
+    t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)
+    events = [
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 1.0,
+                "source": "dcs_bios",
+                "bios": {"RADALT_MIN_HEIGHT_PTR": 4000},
+                "delta": {"RADALT_MIN_HEIGHT_PTR": 4000},
+                "vars": {"radar_altimeter_bug_value": 40},
+            },
+            "t_wall": 1.0,
+            "timestamp": t0.isoformat(),
+        },
+    ]
+    root = _repo_root()
+    export = build_experiment_export(
+        events,
+        meta_overrides={"scenario_profile": "carrier"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+    by_step = {row.StepID: row for row in export.step_coding}
+
+    assert by_step["S31"].Auto_Error_PA == "0"
 
 
 def test_action_timeline_links_dcs_deltas_to_steps_and_help_cycles():

--- a/tests/test_scoring_engine.py
+++ b/tests/test_scoring_engine.py
@@ -47,6 +47,9 @@ def test_scoring_distinguishes_scenarios():
         assert score_prem["TotalErrorScore"] > score_good["TotalErrorScore"]
         assert score_prem["Count_SV"] > 0
         assert score_missing["Count_OM"] > score_good["Count_OM"]
+        assert score_good["ScoringMode"] == "legacy_om_sv_only"
+        assert score_good["FinalScoreRequiresHumanCoding"] is True
+        assert score_good["UndetectedErrorCategories"] == ["CO", "OR", "PA"]
     finally:
         cleanup_path(Path(log_good))
         cleanup_path(Path(log_missing))


### PR DESCRIPTION
## Summary
- add semi-automatic Auto_Error_* candidate columns, confidence, evidence refs, NeedsHumanReview, and rater fields to step_coding.csv
- prefill OM/SV/OR/PA/CO candidates from step completion, explicit state_violation tags, precondition-gate evidence, dependency-based order checks, scoped parameter telemetry, and unmapped/unexpected actions
- mark legacy simtutor score output as OM/SV-only and document that final five-category scores require human rater confirmation

## Validation
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/test_scoring_engine.py tests/test_runner_batch.py tests/test_pack_gates.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full
- subagent review-fix loop completed; high/medium findings closed

Closes #352