### PR TITLE
Add thesis experiment analysis export

### DIFF
--- a/core/experiment_analysis.py
+++ b/core/experiment_analysis.py
@@ -1,0 +1,567 @@
+"""
+Lightweight post-export analysis for thesis-ready experiment tables.
+
+This module consumes the CSV artifacts produced by ``experiment-export`` and
+keeps the aggregation deliberately boring: deterministic rows, no pandas, and
+optional figures only when matplotlib is available.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from statistics import mean, median
+from typing import Any, Iterable, Mapping, Sequence
+
+
+STUDY_SUMMARY_CSV_FIELDS = [
+    "StudyID",
+    "ParticipantCount",
+    "TrialCount",
+    "ConditionCount",
+    "CompletionRate",
+    "MeanTaskTime_sec",
+    "MedianTaskTime_sec",
+    "MeanStepCompletionAccuracy",
+    "CriticalStepSuccessRate",
+    "HelpRequestsPerTrial",
+    "RecoveryAfterHelpCandidateRate",
+    "OverlayRejectionRate",
+    "FallbackRate",
+    "VLMCalls",
+    "VLMNotRequiredLeakageCount",
+]
+
+CONDITION_SUMMARY_CSV_FIELDS = [
+    "StudyID",
+    "Condition",
+    "ParticipantCount",
+    "TrialCount",
+    "CompletionRate",
+    "MeanTaskTime_sec",
+    "MedianTaskTime_sec",
+    "MeanStepCompletionAccuracy",
+    "CriticalStepSuccessRate",
+    "HelpRequestsPerTrial",
+    "RecoveryAfterHelpCandidateRate",
+    "OverlayRejectionRate",
+    "FallbackRate",
+    "VLMCalls",
+    "VLMNotRequiredLeakageCount",
+]
+
+STEP_ACCURACY_BY_CONDITION_CSV_FIELDS = [
+    "StudyID",
+    "Condition",
+    "StepID",
+    "StepTitle",
+    "Critical",
+    "TrialCount",
+    "PerformedCount",
+    "CompletedCount",
+    "CompletionRate",
+]
+
+HELP_QUALITY_SUMMARY_CSV_FIELDS = [
+    "StudyID",
+    "Condition",
+    "TrialCount",
+    "HelpCycleCount",
+    "HelpRequestsPerTrial",
+    "OverlayExecuted",
+    "OverlayRejected",
+    "OverlayRejectionRate",
+    "FallbackCount",
+    "FallbackRate",
+    "VisionUsedCount",
+    "VisionFactOkRate",
+    "RecoveryAfterHelpCandidateRate",
+    "VLMNotRequiredLeakageCount",
+]
+
+
+@dataclass
+class _TrialExportTables:
+    path: Path
+    study_id: str
+    trial_rows: list[dict[str, str]] = field(default_factory=list)
+    step_rows: list[dict[str, str]] = field(default_factory=list)
+    help_rows: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class ExperimentAnalysis:
+    study_summary: list[dict[str, Any]] = field(default_factory=list)
+    condition_summary: list[dict[str, Any]] = field(default_factory=list)
+    step_accuracy_by_condition: list[dict[str, Any]] = field(default_factory=list)
+    help_quality_summary: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AnalysisWriteResult:
+    csv_paths: list[Path] = field(default_factory=list)
+    figure_paths: list[Path] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _read_csv_dicts(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open("r", newline="", encoding="utf-8") as f:
+        return [dict(row) for row in csv.DictReader(f)]
+
+
+def _read_study_id(path: Path) -> str:
+    session_path = path / "session.json"
+    if not session_path.exists():
+        return ""
+    try:
+        payload = json.loads(session_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    meta = payload.get("meta") if isinstance(payload, Mapping) else None
+    study_id = meta.get("study_id") if isinstance(meta, Mapping) else None
+    return study_id if isinstance(study_id, str) else ""
+
+
+def _discover_trial_exports(input_dir: str | Path) -> list[_TrialExportTables]:
+    root = Path(input_dir)
+    trial_summary_paths = sorted(root.rglob("trial_summary.csv"))
+    exports: list[_TrialExportTables] = []
+    for trial_summary_path in trial_summary_paths:
+        trial_dir = trial_summary_path.parent
+        exports.append(
+            _TrialExportTables(
+                path=trial_dir,
+                study_id=_read_study_id(trial_dir),
+                trial_rows=_read_csv_dicts(trial_summary_path),
+                step_rows=_read_csv_dicts(trial_dir / "step_coding.csv"),
+                help_rows=_read_csv_dicts(trial_dir / "help_cycles.csv"),
+            )
+        )
+    return exports
+
+
+def _nonempty(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _as_float(value: Any) -> float | None:
+    text = _nonempty(value)
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _as_int(value: Any) -> int:
+    number = _as_float(value)
+    return int(number) if number is not None else 0
+
+
+def _is_yes(value: Any) -> bool:
+    return _nonempty(value).lower() in {"1", "true", "yes", "y"}
+
+
+def _safe_rate(numerator: int | float, denominator: int | float) -> float:
+    if not denominator:
+        return 0.0
+    return round(float(numerator) / float(denominator), 6)
+
+
+def _mean(values: Sequence[float]) -> float:
+    return round(mean(values), 6) if values else 0.0
+
+
+def _median(values: Sequence[float]) -> float:
+    return round(median(values), 6) if values else 0.0
+
+
+def _study_id(exports: Sequence[_TrialExportTables], fallback: str) -> str:
+    study_ids = sorted({export.study_id for export in exports if export.study_id})
+    if not study_ids:
+        return fallback
+    return ";".join(study_ids)
+
+
+def _condition(row: Mapping[str, str]) -> str:
+    return _nonempty(row.get("Condition")) or "unknown"
+
+
+def _participant(row: Mapping[str, str]) -> str:
+    return _nonempty(row.get("ParticipantID"))
+
+
+def _step_sort_key(step_id: str) -> tuple[str, int, str]:
+    if len(step_id) >= 2 and step_id[0].upper() == "S" and step_id[1:].isdigit():
+        return ("S", int(step_id[1:]), step_id)
+    return ("", 0, step_id)
+
+
+def _help_cycle_rejected(row: Mapping[str, str]) -> bool:
+    return _as_int(row.get("overlay_rejected")) > 0
+
+
+def _help_cycle_fallback(row: Mapping[str, str]) -> bool:
+    return _is_yes(row.get("fallback_overlay_used")) or _nonempty(row.get("generation_mode")).lower() == "fallback"
+
+
+def _help_cycle_vision_ok(row: Mapping[str, str]) -> bool:
+    return _nonempty(row.get("vision_fact_status")).lower() in {"ok", "available"}
+
+
+def _help_cycle_vlm_leak(row: Mapping[str, str]) -> bool:
+    status = _nonempty(row.get("vlm_call_status")).lower()
+    vision_status = _nonempty(row.get("vision_status")).lower()
+    vision_fact_status = _nonempty(row.get("vision_fact_status")).lower()
+    return status == "called" and (
+        vision_status in {"not_required", "vision_not_required"}
+        or vision_fact_status in {"not_required", "vision_not_required"}
+    )
+
+
+def _rows_for_conditions(rows: Iterable[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
+    grouped: dict[str, list[dict[str, str]]] = {}
+    for row in rows:
+        grouped.setdefault(_condition(row), []).append(row)
+    return grouped
+
+
+def _summary_row(
+    *,
+    study_id: str,
+    condition: str | None,
+    trial_rows: Sequence[dict[str, str]],
+    step_rows: Sequence[dict[str, str]],
+    help_rows: Sequence[dict[str, str]],
+) -> dict[str, Any]:
+    task_times = [
+        value
+        for value in (_as_float(row.get("TaskTime_sec")) for row in trial_rows)
+        if value is not None
+    ]
+    step_accuracies = [
+        value
+        for value in (_as_float(row.get("StepCompletionAccuracy")) for row in trial_rows)
+        if value is not None
+    ]
+    critical_steps = [row for row in step_rows if _is_yes(row.get("Critical"))]
+    helped_steps = [row for row in step_rows if _as_int(row.get("HelpCount")) > 0]
+    completed_helped_steps = [row for row in helped_steps if _is_yes(row.get("Completed"))]
+    rejected_cycles = [row for row in help_rows if _help_cycle_rejected(row)]
+    fallback_cycles = [row for row in help_rows if _help_cycle_fallback(row)]
+    participants = {_participant(row) for row in trial_rows if _participant(row)}
+    conditions = {_condition(row) for row in trial_rows}
+
+    row: dict[str, Any] = {
+        "StudyID": study_id,
+        "ParticipantCount": len(participants),
+        "TrialCount": len(trial_rows),
+        "CompletionRate": _safe_rate(sum(1 for row in trial_rows if _is_yes(row.get("Completed"))), len(trial_rows)),
+        "MeanTaskTime_sec": _mean(task_times),
+        "MedianTaskTime_sec": _median(task_times),
+        "MeanStepCompletionAccuracy": _mean(step_accuracies),
+        "CriticalStepSuccessRate": _safe_rate(
+            sum(1 for row in critical_steps if _is_yes(row.get("Completed"))),
+            len(critical_steps),
+        ),
+        "HelpRequestsPerTrial": _safe_rate(sum(_as_int(row.get("HelpRequests")) for row in trial_rows), len(trial_rows)),
+        "RecoveryAfterHelpCandidateRate": _safe_rate(len(completed_helped_steps), len(helped_steps)),
+        "OverlayRejectionRate": _safe_rate(len(rejected_cycles), len(help_rows)),
+        "FallbackRate": _safe_rate(len(fallback_cycles), len(help_rows)),
+        "VLMCalls": sum(_as_int(row.get("VLMCalls")) for row in trial_rows),
+        "VLMNotRequiredLeakageCount": sum(1 for row in help_rows if _help_cycle_vlm_leak(row)),
+    }
+    if condition is None:
+        row["ConditionCount"] = len(conditions)
+        return {field: row.get(field, "") for field in STUDY_SUMMARY_CSV_FIELDS}
+    row["Condition"] = condition
+    return {field: row.get(field, "") for field in CONDITION_SUMMARY_CSV_FIELDS}
+
+
+def _build_step_accuracy_rows(
+    *,
+    study_id: str,
+    step_rows: Sequence[dict[str, str]],
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
+    for row in step_rows:
+        step_id = _nonempty(row.get("StepID"))
+        if not step_id:
+            continue
+        grouped.setdefault((_condition(row), step_id), []).append(row)
+
+    output: list[dict[str, Any]] = []
+    for (condition, step_id), rows in sorted(grouped.items(), key=lambda item: (item[0][0], _step_sort_key(item[0][1]))):
+        completed_count = sum(1 for row in rows if _is_yes(row.get("Completed")))
+        performed_count = sum(1 for row in rows if _is_yes(row.get("Performed")))
+        row = {
+            "StudyID": study_id,
+            "Condition": condition,
+            "StepID": step_id,
+            "StepTitle": _nonempty(rows[0].get("StepTitle")),
+            "Critical": _nonempty(rows[0].get("Critical")),
+            "TrialCount": len(rows),
+            "PerformedCount": performed_count,
+            "CompletedCount": completed_count,
+            "CompletionRate": _safe_rate(completed_count, len(rows)),
+        }
+        output.append({field: row.get(field, "") for field in STEP_ACCURACY_BY_CONDITION_CSV_FIELDS})
+    return output
+
+
+def _build_help_quality_rows(
+    *,
+    study_id: str,
+    trial_rows: Sequence[dict[str, str]],
+    step_rows: Sequence[dict[str, str]],
+    help_rows: Sequence[dict[str, str]],
+) -> list[dict[str, Any]]:
+    trials_by_condition = _rows_for_conditions(trial_rows)
+    steps_by_condition = _rows_for_conditions(step_rows)
+    help_by_condition: dict[str, list[dict[str, str]]] = {}
+    for row in help_rows:
+        condition = _nonempty(row.get("Condition"))
+        if not condition:
+            condition = _condition_for_trial(
+                trial_rows,
+                participant=_nonempty(row.get("ParticipantID")),
+                trial=_nonempty(row.get("TrialID")),
+            )
+        help_by_condition.setdefault(condition or "unknown", []).append(row)
+
+    conditions = sorted(set(trials_by_condition) | set(help_by_condition))
+    output: list[dict[str, Any]] = []
+    for condition in conditions:
+        condition_trials = trials_by_condition.get(condition, [])
+        condition_steps = steps_by_condition.get(condition, [])
+        condition_help = help_by_condition.get(condition, [])
+        helped_steps = [row for row in condition_steps if _as_int(row.get("HelpCount")) > 0]
+        completed_helped_steps = [row for row in helped_steps if _is_yes(row.get("Completed"))]
+        rejected_cycles = [row for row in condition_help if _help_cycle_rejected(row)]
+        fallback_cycles = [row for row in condition_help if _help_cycle_fallback(row)]
+        vision_used_cycles = [row for row in condition_help if _is_yes(row.get("vision_used"))]
+        vision_ok_cycles = [row for row in condition_help if _help_cycle_vision_ok(row)]
+        row = {
+            "StudyID": study_id,
+            "Condition": condition,
+            "TrialCount": len(condition_trials),
+            "HelpCycleCount": len(condition_help),
+            "HelpRequestsPerTrial": _safe_rate(
+                sum(_as_int(row.get("HelpRequests")) for row in condition_trials),
+                len(condition_trials),
+            ),
+            "OverlayExecuted": sum(_as_int(row.get("overlay_executed")) for row in condition_help),
+            "OverlayRejected": sum(_as_int(row.get("overlay_rejected")) for row in condition_help),
+            "OverlayRejectionRate": _safe_rate(len(rejected_cycles), len(condition_help)),
+            "FallbackCount": len(fallback_cycles),
+            "FallbackRate": _safe_rate(len(fallback_cycles), len(condition_help)),
+            "VisionUsedCount": len(vision_used_cycles),
+            "VisionFactOkRate": _safe_rate(len(vision_ok_cycles), len(vision_used_cycles)),
+            "RecoveryAfterHelpCandidateRate": _safe_rate(len(completed_helped_steps), len(helped_steps)),
+            "VLMNotRequiredLeakageCount": sum(1 for row in condition_help if _help_cycle_vlm_leak(row)),
+        }
+        output.append({field: row.get(field, "") for field in HELP_QUALITY_SUMMARY_CSV_FIELDS})
+    return output
+
+
+def _condition_for_trial(
+    trial_rows: Sequence[dict[str, str]],
+    *,
+    participant: str,
+    trial: str,
+) -> str:
+    for row in trial_rows:
+        if participant and _nonempty(row.get("ParticipantID")) != participant:
+            continue
+        if trial and _nonempty(row.get("TrialID")) != trial:
+            continue
+        return _condition(row)
+    return ""
+
+
+def _copy_condition_to_help_rows(
+    help_rows: Sequence[dict[str, str]],
+    trial_rows: Sequence[dict[str, str]],
+) -> list[dict[str, str]]:
+    if not help_rows:
+        return []
+    default_condition = _condition(trial_rows[0]) if len(trial_rows) == 1 else "unknown"
+    rows: list[dict[str, str]] = []
+    for row in help_rows:
+        copied = dict(row)
+        if not _nonempty(copied.get("Condition")):
+            copied["Condition"] = default_condition
+        if not _nonempty(copied.get("ParticipantID")) and len(trial_rows) == 1:
+            copied["ParticipantID"] = _participant(trial_rows[0])
+        if not _nonempty(copied.get("TrialID")) and len(trial_rows) == 1:
+            copied["TrialID"] = _nonempty(trial_rows[0].get("TrialID"))
+        rows.append(copied)
+    return rows
+
+
+def build_experiment_analysis(input_dir: str | Path) -> ExperimentAnalysis:
+    exports = _discover_trial_exports(input_dir)
+    if not exports:
+        raise ValueError(f"no experiment-export trial_summary.csv files found under {input_dir}")
+
+    study_id = _study_id(exports, fallback=Path(input_dir).name)
+    trial_rows = [row for export in exports for row in export.trial_rows]
+    step_rows = [row for export in exports for row in export.step_rows]
+    help_rows = [
+        row
+        for export in exports
+        for row in _copy_condition_to_help_rows(export.help_rows, export.trial_rows)
+    ]
+
+    condition_summary = [
+        _summary_row(
+            study_id=study_id,
+            condition=condition,
+            trial_rows=rows,
+            step_rows=[row for row in step_rows if _condition(row) == condition],
+            help_rows=[row for row in help_rows if _condition(row) == condition],
+        )
+        for condition, rows in sorted(_rows_for_conditions(trial_rows).items())
+    ]
+
+    return ExperimentAnalysis(
+        study_summary=[
+            _summary_row(
+                study_id=study_id,
+                condition=None,
+                trial_rows=trial_rows,
+                step_rows=step_rows,
+                help_rows=help_rows,
+            )
+        ],
+        condition_summary=condition_summary,
+        step_accuracy_by_condition=_build_step_accuracy_rows(study_id=study_id, step_rows=step_rows),
+        help_quality_summary=_build_help_quality_rows(
+            study_id=study_id,
+            trial_rows=trial_rows,
+            step_rows=step_rows,
+            help_rows=help_rows,
+        ),
+    )
+
+
+def _write_csv(path: Path, fieldnames: Sequence[str], rows: Sequence[Mapping[str, Any]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(fieldnames), extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _bar_chart(path: Path, labels: Sequence[str], values: Sequence[float], *, title: str, ylabel: str) -> None:
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(7, 4))
+    ax.bar(labels, values, color="#4c78a8")
+    ax.set_title(title)
+    ax.set_ylabel(ylabel)
+    ax.set_ylim(bottom=0)
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def _write_figures(analysis: ExperimentAnalysis, output_dir: Path) -> list[Path]:
+    labels = [str(row["Condition"]) for row in analysis.condition_summary]
+    if not labels:
+        return []
+    specs = [
+        (
+            "fig_completion_rate.png",
+            [float(row["CompletionRate"]) for row in analysis.condition_summary],
+            "Completion rate by condition",
+            "completion rate",
+        ),
+        (
+            "fig_task_time.png",
+            [float(row["MeanTaskTime_sec"]) for row in analysis.condition_summary],
+            "Mean task time by condition",
+            "seconds",
+        ),
+        (
+            "fig_step_accuracy.png",
+            [float(row["MeanStepCompletionAccuracy"]) for row in analysis.condition_summary],
+            "Mean step accuracy by condition",
+            "accuracy",
+        ),
+        (
+            "fig_help_requests.png",
+            [float(row["HelpRequestsPerTrial"]) for row in analysis.condition_summary],
+            "Help requests per trial by condition",
+            "requests/trial",
+        ),
+    ]
+    paths: list[Path] = []
+    for filename, values, title, ylabel in specs:
+        path = output_dir / filename
+        _bar_chart(path, labels, values, title=title, ylabel=ylabel)
+        paths.append(path)
+    return paths
+
+
+def write_experiment_analysis(
+    analysis: ExperimentAnalysis,
+    output_dir: str | Path,
+    *,
+    make_figures: bool = True,
+) -> AnalysisWriteResult:
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    outputs = [
+        ("study_summary.csv", STUDY_SUMMARY_CSV_FIELDS, analysis.study_summary),
+        ("condition_summary.csv", CONDITION_SUMMARY_CSV_FIELDS, analysis.condition_summary),
+        ("step_accuracy_by_condition.csv", STEP_ACCURACY_BY_CONDITION_CSV_FIELDS, analysis.step_accuracy_by_condition),
+        ("help_quality_summary.csv", HELP_QUALITY_SUMMARY_CSV_FIELDS, analysis.help_quality_summary),
+    ]
+    csv_paths: list[Path] = []
+    for filename, fieldnames, rows in outputs:
+        path = out_dir / filename
+        _write_csv(path, fieldnames, rows)
+        csv_paths.append(path)
+
+    warnings = list(analysis.warnings)
+    figure_paths: list[Path] = []
+    if make_figures:
+        try:
+            figure_paths = _write_figures(analysis, out_dir)
+        except Exception as exc:
+            message = f"figures skipped: {type(exc).__name__}: {exc}"
+            warnings.append(message)
+            for name in (
+                "fig_completion_rate.png",
+                "fig_task_time.png",
+                "fig_step_accuracy.png",
+                "fig_help_requests.png",
+            ):
+                try:
+                    (out_dir / name).unlink()
+                except FileNotFoundError:
+                    pass
+            (out_dir / "figures_skipped.txt").write_text(message + "\n", encoding="utf-8")
+
+    return AnalysisWriteResult(csv_paths=csv_paths, figure_paths=figure_paths, warnings=warnings)
+
+
+__all__ = [
+    "CONDITION_SUMMARY_CSV_FIELDS",
+    "HELP_QUALITY_SUMMARY_CSV_FIELDS",
+    "STEP_ACCURACY_BY_CONDITION_CSV_FIELDS",
+    "STUDY_SUMMARY_CSV_FIELDS",
+    "AnalysisWriteResult",
+    "ExperimentAnalysis",
+    "build_experiment_analysis",
+    "write_experiment_analysis",
+]

--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -61,7 +61,8 @@ EXPECTED_PACK_STEP_IDS = [f"S{i:02d}" for i in range(1, 34)]
 
 HELP_CYCLES_CSV_FIELDS = [
     "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
-    "vision_used", "vision_status", "vision_fact_status", "vision_fallback_reason", "sync_delta_ms",
+    "vision_used", "vision_status", "vision_fact_status", "vlm_call_status",
+    "vision_fallback_reason", "sync_delta_ms",
     "frame_ids", "layout_id", "fused_step_id", "fused_missing_conditions", "model_next_step_id",
     "overlay_targets", "overlay_executed", "overlay_rejected",
     "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
@@ -509,6 +510,7 @@ class HelpCycleRecord:
     requires_visual_confirmation: bool | None = None
     scenario_profile: str | None = None
     vision_fact_status: str | None = None
+    vlm_call_status: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -809,6 +811,7 @@ def _extract_help_cycles(events: Sequence[Mapping[str, Any]]) -> list[dict[str, 
             "requires_visual_confirmation": _opt_bool(response_meta.get("requires_visual_confirmation")),
             "scenario_profile": response_meta.get("scenario_profile"),
             "vision_fact_status": request_meta.get("vision_fact_status"),
+            "vlm_call_status": audit.get("vlm_call_status"),
         }
         records.append(record)
 
@@ -2017,6 +2020,7 @@ def build_experiment_export(
             requires_visual_confirmation=rc["requires_visual_confirmation"],
             scenario_profile=rc["scenario_profile"],
             vision_fact_status=rc["vision_fact_status"],
+            vlm_call_status=rc["vlm_call_status"],
         )
         for rc in raw_cycles
     ]

--- a/docs/wiki/replay-and-cli-reference.md
+++ b/docs/wiki/replay-and-cli-reference.md
@@ -134,3 +134,57 @@ live request_id -> extract fixture -> inspect expectations/harness trace -> writ
 ```
 
 Malformed JSONL lines do not stop extraction; they are recorded under `source_log.malformed_lines`. If the id is not found, the command exits with an `[EXTRACT_LIVE_FIXTURE] error:` message.
+
+## Experiment Export and Analysis
+
+From a raw live/replay JSONL log, first freeze one participant trial into study-ready CSV artifacts:
+
+```bash
+python -m simtutor experiment-export logs/live_dcs.jsonl \
+  --study-id fa18c-thesis-pilot \
+  --participant-id P01 \
+  --condition with_tutor \
+  --trial-id T01 \
+  --group novice \
+  --experimenter-id E01 \
+  --questionnaire questionnaires/P01_pre.yml \
+  --recording-ref recordings/P01_T01.mp4 \
+  --model-provider openai_compat \
+  --model-name Qwen3-8B-Instruct \
+  --vision-model-name Qwen3.5-VL-9B \
+  --prompt-version v0.4 \
+  --scenario-profile airfield \
+  --dcs-mission cold-start.miz \
+  --dcs-aircraft FA-18C \
+  --monitor-setup native-viewports \
+  --output-dir artifacts/experiments \
+  --strict
+```
+
+Repeat `experiment-export` for each participant/trial. Then combine all exported participant/trial folders into thesis-ready summary tables and optional figures:
+
+```bash
+python -m simtutor experiment-analyze artifacts/experiments \
+  --output-dir artifacts/analysis/fa18c-thesis-pilot
+```
+
+This writes:
+
+```text
+artifacts/analysis/fa18c-thesis-pilot/study_summary.csv
+artifacts/analysis/fa18c-thesis-pilot/condition_summary.csv
+artifacts/analysis/fa18c-thesis-pilot/step_accuracy_by_condition.csv
+artifacts/analysis/fa18c-thesis-pilot/help_quality_summary.csv
+artifacts/analysis/fa18c-thesis-pilot/fig_completion_rate.png
+artifacts/analysis/fa18c-thesis-pilot/fig_task_time.png
+artifacts/analysis/fa18c-thesis-pilot/fig_step_accuracy.png
+artifacts/analysis/fa18c-thesis-pilot/fig_help_requests.png
+```
+
+If `matplotlib` is not installed, the CSV files are still written and the command reports that figures were skipped. Use `--no-figures` when only tables are needed:
+
+```bash
+python -m simtutor experiment-analyze artifacts/experiments \
+  --output-dir artifacts/analysis/fa18c-thesis-pilot \
+  --no-figures
+```

--- a/simtutor/__main__.py
+++ b/simtutor/__main__.py
@@ -765,6 +765,29 @@ def _run_experiment_export(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_experiment_analyze(args: argparse.Namespace) -> int:
+    from core.experiment_analysis import build_experiment_analysis, write_experiment_analysis
+
+    try:
+        analysis = build_experiment_analysis(args.input_dir)
+        result = write_experiment_analysis(
+            analysis,
+            args.output_dir,
+            make_figures=not bool(getattr(args, "no_figures", False)),
+        )
+    except (OSError, ValueError) as exc:
+        print(f"[EXPERIMENT_ANALYZE] error: {exc}")
+        return 1
+
+    for path in result.csv_paths:
+        print(f"[EXPERIMENT_ANALYZE] wrote {path}")
+    for path in result.figure_paths:
+        print(f"[EXPERIMENT_ANALYZE] wrote {path}")
+    for warning in result.warnings:
+        print(f"[EXPERIMENT_ANALYZE] warning: {warning}")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(prog="simtutor", description="SimTutor CLI utilities")
     sub = parser.add_subparsers(dest="command")
@@ -845,6 +868,14 @@ def main() -> int:
         help="Record the raw log reference without copying it into the export directory",
     )
     exp_export.set_defaults(copy_raw_log=True)
+
+    exp_analyze = sub.add_parser(
+        "experiment-analyze",
+        help="Analyze experiment-export folders into thesis-ready tables and optional figures",
+    )
+    exp_analyze.add_argument("input_dir", help="Directory containing experiment-export participant/trial folders")
+    exp_analyze.add_argument("--output-dir", required=True, help="Directory for analysis CSVs and optional figures")
+    exp_analyze.add_argument("--no-figures", action="store_true", help="Only write CSV summaries")
 
     sub.add_parser("model-config", help="Validate model provider env and print non-sensitive startup info")
 
@@ -1091,6 +1122,8 @@ def main() -> int:
         return 0
     if args.command == "experiment-export":
         return _run_experiment_export(args)
+    if args.command == "experiment-analyze":
+        return _run_experiment_analyze(args)
     if args.command == "model-config":
         from simtutor.config import ModelConfigError, load_model_access_config
 

--- a/tests/test_experiment_analysis.py
+++ b/tests/test_experiment_analysis.py
@@ -1,0 +1,365 @@
+"""
+Tests for thesis-ready experiment analysis exports.
+"""
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+import core.experiment_analysis as experiment_analysis
+from core.experiment_analysis import (
+    CONDITION_SUMMARY_CSV_FIELDS,
+    HELP_QUALITY_SUMMARY_CSV_FIELDS,
+    STEP_ACCURACY_BY_CONDITION_CSV_FIELDS,
+    STUDY_SUMMARY_CSV_FIELDS,
+    build_experiment_analysis,
+    write_experiment_analysis,
+)
+from simtutor.__main__ import _run_experiment_analyze
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_trial_export(
+    root: Path,
+    *,
+    participant: str,
+    condition: str,
+    trial: str,
+    completed: str,
+    task_time: float,
+    help_requests: int,
+    vlm_calls: int,
+    overlay_rejected: int,
+    fallback_count: int,
+    step_accuracy: float,
+    s01_completed: str,
+    s02_completed: str,
+) -> None:
+    trial_dir = root / participant / trial
+    trial_dir.mkdir(parents=True, exist_ok=True)
+    (trial_dir / "session.json").write_text(
+        json.dumps(
+            {
+                "meta": {
+                    "study_id": "study-alpha",
+                    "participant_id": participant,
+                    "condition": condition,
+                    "trial_id": trial,
+                }
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_csv(
+        trial_dir / "trial_summary.csv",
+        [
+            "ParticipantID",
+            "Condition",
+            "TrialID",
+            "Completed",
+            "TaskTime_sec",
+            "HelpRequests",
+            "LLMTriggers",
+            "VLMCalls",
+            "OverlayExecuted",
+            "OverlayRejected",
+            "FallbackCount",
+            "CriticalStepsCompleted",
+            "TotalStepsCompleted",
+            "StepCompletionAccuracy",
+        ],
+        [
+            {
+                "ParticipantID": participant,
+                "Condition": condition,
+                "TrialID": trial,
+                "Completed": completed,
+                "TaskTime_sec": task_time,
+                "HelpRequests": help_requests,
+                "LLMTriggers": 1,
+                "VLMCalls": vlm_calls,
+                "OverlayExecuted": 2,
+                "OverlayRejected": overlay_rejected,
+                "FallbackCount": fallback_count,
+                "CriticalStepsCompleted": 1 if s01_completed == "yes" else 0,
+                "TotalStepsCompleted": (1 if s01_completed == "yes" else 0)
+                + (1 if s02_completed == "yes" else 0),
+                "StepCompletionAccuracy": step_accuracy,
+            }
+        ],
+    )
+    _write_csv(
+        trial_dir / "step_coding.csv",
+        [
+            "ParticipantID",
+            "Condition",
+            "TrialID",
+            "StepID",
+            "StepTitle",
+            "Critical",
+            "Performed",
+            "Completed",
+            "HelpCount",
+        ],
+        [
+            {
+                "ParticipantID": participant,
+                "Condition": condition,
+                "TrialID": trial,
+                "StepID": "S01",
+                "StepTitle": "Battery switch",
+                "Critical": "yes",
+                "Performed": "yes",
+                "Completed": s01_completed,
+                "HelpCount": 1,
+            },
+            {
+                "ParticipantID": participant,
+                "Condition": condition,
+                "TrialID": trial,
+                "StepID": "S02",
+                "StepTitle": "Display power",
+                "Critical": "no",
+                "Performed": s02_completed,
+                "Completed": s02_completed,
+                "HelpCount": 0,
+            },
+        ],
+    )
+    _write_csv(
+        trial_dir / "help_cycles.csv",
+        [
+            "help_cycle_id",
+            "vision_used",
+            "vision_fact_status",
+            "overlay_executed",
+            "overlay_rejected",
+            "fallback_overlay_used",
+            "generation_mode",
+            "vlm_call_status",
+        ],
+        [
+            {
+                "help_cycle_id": f"{participant}-{trial}-h1",
+                "vision_used": "True",
+                "vision_fact_status": "ok",
+                "overlay_executed": "1",
+                "overlay_rejected": str(overlay_rejected),
+                "fallback_overlay_used": "False" if fallback_count == 0 else "True",
+                "generation_mode": "model" if fallback_count == 0 else "fallback",
+                "vlm_call_status": "called",
+            }
+        ],
+    )
+
+
+def test_build_experiment_analysis_combines_conditions_and_steps(tmp_path: Path):
+    exports = tmp_path / "experiments"
+    _write_trial_export(
+        exports,
+        participant="P01",
+        condition="with_tutor",
+        trial="T01",
+        completed="yes",
+        task_time=100.0,
+        help_requests=2,
+        vlm_calls=1,
+        overlay_rejected=0,
+        fallback_count=0,
+        step_accuracy=1.0,
+        s01_completed="yes",
+        s02_completed="yes",
+    )
+    _write_trial_export(
+        exports,
+        participant="P02",
+        condition="without_tutor",
+        trial="T01",
+        completed="no",
+        task_time=200.0,
+        help_requests=0,
+        vlm_calls=0,
+        overlay_rejected=1,
+        fallback_count=1,
+        step_accuracy=0.5,
+        s01_completed="yes",
+        s02_completed="no",
+    )
+    _write_csv(
+        exports / "P01" / "T01" / "help_cycles.csv",
+        [
+            "help_cycle_id",
+            "vision_used",
+            "vision_status",
+            "vision_fact_status",
+            "overlay_executed",
+            "overlay_rejected",
+            "fallback_overlay_used",
+            "generation_mode",
+            "vlm_call_status",
+        ],
+        [
+            {
+                "help_cycle_id": "P01-T01-h1",
+                "vision_used": "True",
+                "vision_status": "available",
+                "vision_fact_status": "ok",
+                "overlay_executed": "1",
+                "overlay_rejected": "0",
+                "fallback_overlay_used": "False",
+                "generation_mode": "model",
+                "vlm_call_status": "called",
+            },
+            {
+                "help_cycle_id": "P01-T01-h2",
+                "vision_used": "False",
+                "vision_status": "not_required",
+                "vision_fact_status": "vision_not_required",
+                "overlay_executed": "1",
+                "overlay_rejected": "0",
+                "fallback_overlay_used": "False",
+                "generation_mode": "model",
+                "vlm_call_status": "not_required",
+            },
+        ],
+    )
+
+    analysis = build_experiment_analysis(exports)
+
+    assert list(analysis.study_summary[0].keys()) == STUDY_SUMMARY_CSV_FIELDS
+    assert analysis.study_summary[0]["StudyID"] == "study-alpha"
+    assert analysis.study_summary[0]["ParticipantCount"] == 2
+    assert analysis.study_summary[0]["TrialCount"] == 2
+    assert analysis.study_summary[0]["CompletionRate"] == 0.5
+    assert analysis.study_summary[0]["MeanTaskTime_sec"] == 150.0
+    assert analysis.study_summary[0]["MedianTaskTime_sec"] == 150.0
+    assert analysis.study_summary[0]["MeanStepCompletionAccuracy"] == 0.75
+
+    condition_rows = {row["Condition"]: row for row in analysis.condition_summary}
+    assert list(analysis.condition_summary[0].keys()) == CONDITION_SUMMARY_CSV_FIELDS
+    assert condition_rows["with_tutor"]["ParticipantCount"] == 1
+    assert condition_rows["with_tutor"]["CompletionRate"] == 1.0
+    assert condition_rows["without_tutor"]["CompletionRate"] == 0.0
+    assert condition_rows["without_tutor"]["OverlayRejectionRate"] == 1.0
+    assert condition_rows["without_tutor"]["FallbackRate"] == 1.0
+
+    step_rows = {
+        (row["Condition"], row["StepID"]): row
+        for row in analysis.step_accuracy_by_condition
+    }
+    assert list(analysis.step_accuracy_by_condition[0].keys()) == STEP_ACCURACY_BY_CONDITION_CSV_FIELDS
+    assert step_rows[("with_tutor", "S02")]["CompletionRate"] == 1.0
+    assert step_rows[("without_tutor", "S02")]["CompletionRate"] == 0.0
+
+    help_rows = {row["Condition"]: row for row in analysis.help_quality_summary}
+    assert list(analysis.help_quality_summary[0].keys()) == HELP_QUALITY_SUMMARY_CSV_FIELDS
+    assert help_rows["with_tutor"]["HelpRequestsPerTrial"] == 2.0
+    assert help_rows["with_tutor"]["RecoveryAfterHelpCandidateRate"] == 1.0
+    assert help_rows["with_tutor"]["VisionUsedCount"] == 1
+    assert help_rows["with_tutor"]["VisionFactOkRate"] == 1.0
+    assert help_rows["without_tutor"]["RecoveryAfterHelpCandidateRate"] == 1.0
+
+
+def test_write_experiment_analysis_creates_csvs_even_without_figures(tmp_path: Path):
+    exports = tmp_path / "experiments"
+    output = tmp_path / "analysis"
+    _write_trial_export(
+        exports,
+        participant="P01",
+        condition="with_tutor",
+        trial="T01",
+        completed="yes",
+        task_time=100.0,
+        help_requests=1,
+        vlm_calls=1,
+        overlay_rejected=0,
+        fallback_count=0,
+        step_accuracy=1.0,
+        s01_completed="yes",
+        s02_completed="yes",
+    )
+
+    analysis = build_experiment_analysis(exports)
+    result = write_experiment_analysis(analysis, output, make_figures=False)
+
+    assert result.csv_paths == [
+        output / "study_summary.csv",
+        output / "condition_summary.csv",
+        output / "step_accuracy_by_condition.csv",
+        output / "help_quality_summary.csv",
+    ]
+    assert result.figure_paths == []
+    assert (output / "study_summary.csv").exists()
+    assert (output / "condition_summary.csv").exists()
+    assert not (output / "fig_completion_rate.png").exists()
+
+
+def test_write_experiment_analysis_keeps_csvs_when_figures_fail(tmp_path: Path, monkeypatch):
+    exports = tmp_path / "experiments"
+    output = tmp_path / "analysis"
+    _write_trial_export(
+        exports,
+        participant="P01",
+        condition="with_tutor",
+        trial="T01",
+        completed="yes",
+        task_time=100.0,
+        help_requests=1,
+        vlm_calls=1,
+        overlay_rejected=0,
+        fallback_count=0,
+        step_accuracy=1.0,
+        s01_completed="yes",
+        s02_completed="yes",
+    )
+
+    def _raise_figure_error(*args, **kwargs):
+        raise ImportError("matplotlib missing")
+
+    monkeypatch.setattr(experiment_analysis, "_write_figures", _raise_figure_error)
+    analysis = build_experiment_analysis(exports)
+
+    result = write_experiment_analysis(analysis, output, make_figures=True)
+
+    assert (output / "study_summary.csv").exists()
+    assert (output / "figures_skipped.txt").exists()
+    assert result.figure_paths == []
+    assert result.warnings == ["figures skipped: ImportError: matplotlib missing"]
+
+
+def test_experiment_analyze_cli_writes_analysis_outputs(tmp_path: Path):
+    exports = tmp_path / "experiments"
+    output = tmp_path / "analysis"
+    _write_trial_export(
+        exports,
+        participant="P01",
+        condition="with_tutor",
+        trial="T01",
+        completed="yes",
+        task_time=100.0,
+        help_requests=1,
+        vlm_calls=1,
+        overlay_rejected=0,
+        fallback_count=0,
+        step_accuracy=1.0,
+        s01_completed="yes",
+        s02_completed="yes",
+    )
+
+    args = argparse.Namespace(input_dir=str(exports), output_dir=str(output), no_figures=True)
+
+    assert _run_experiment_analyze(args) == 0
+    assert (output / "study_summary.csv").exists()
+    assert (output / "condition_summary.csv").exists()
+    assert (output / "step_accuracy_by_condition.csv").exists()
+    assert (output / "help_quality_summary.csv").exists()

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -670,7 +670,8 @@ def test_study_ready_csv_contract_fields_are_frozen():
     ]
     assert HELP_CYCLES_CSV_FIELDS == [
         "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
-        "vision_used", "vision_status", "vision_fact_status", "vision_fallback_reason", "sync_delta_ms",
+        "vision_used", "vision_status", "vision_fact_status", "vlm_call_status",
+        "vision_fallback_reason", "sync_delta_ms",
         "frame_ids", "layout_id", "fused_step_id", "fused_missing_conditions", "model_next_step_id",
         "overlay_targets", "overlay_executed", "overlay_rejected",
         "overlay_dropped", "overlay_dry_run_count", "response_status", "fallback_overlay_used",
@@ -1096,6 +1097,7 @@ def test_trial_summary_counts_vlm_calls_once_per_help_cycle():
     )
 
     assert export.trial_summary[0].VLMCalls == 1
+    assert export.help_cycles[1].vlm_call_status == "called"
 
 
 def test_trial_summary_honors_explicit_non_called_vlm_status():
@@ -1110,6 +1112,7 @@ def test_trial_summary_honors_explicit_non_called_vlm_status():
     )
 
     assert export.trial_summary[0].VLMCalls == 0
+    assert export.help_cycles[0].vlm_call_status == "not_required"
 
 
 def test_build_export_no_help_cycles():
@@ -1410,6 +1413,7 @@ def test_experiment_export_cli_freezes_metadata_and_copies_raw_log(tmp_path: Pat
     with (trial_dir / "help_cycles.csv").open("r", newline="", encoding="utf-8") as f:
         help_rows = list(csv.DictReader(f))
     assert "vision_fact_status" in help_rows[0]
+    assert "vlm_call_status" in help_rows[0]
     assert "fallback_overlay_reason" in help_rows[0]
     assert "response_mapping_failure_codes" in help_rows[0]
     assert "frame_ids" in help_rows[0]


### PR DESCRIPTION
## Summary
- add simtutor experiment-analyze to aggregate experiment-export folders into thesis-ready CSV summaries
- generate optional matplotlib figures while keeping CSV output robust when figures fail
- include vlm_call_status in help_cycles.csv so analysis can report VLM-not-required leakage when available
- document raw log -> experiment-export -> experiment-analyze workflow

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_analysis.py tests/test_experiment_export.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #356