### PR TITLE
Fix live-help experiment export semantics

### DIFF
--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -1056,6 +1056,137 @@ def _help_cycle_matches_step(cycle: HelpCycleRecord, step_id: str) -> bool:
     return cycle_step_id == step_id
 
 
+def _step_order_index(pack_steps: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    order: dict[str, int] = {}
+    for idx, step in enumerate(pack_steps):
+        step_id = _opt_str(step.get("id"))
+        if step_id:
+            order[step_id] = idx
+    return order
+
+
+def _help_cycle_step_id(cycle: HelpCycleRecord) -> str | None:
+    return cycle.fused_step_id or cycle.model_next_step_id
+
+
+def _metadata_step_id(metadata: Mapping[str, Any]) -> str | None:
+    step_id = _opt_str(metadata.get("fused_step_id")) or _opt_str(metadata.get("model_next_step_id"))
+    if step_id:
+        return step_id
+    help_response = metadata.get("help_response")
+    if isinstance(help_response, Mapping):
+        next_payload = help_response.get("next")
+        if isinstance(next_payload, Mapping):
+            step_id = _opt_str(next_payload.get("step_id"))
+            if step_id:
+                return step_id
+        diagnosis = help_response.get("diagnosis")
+        if isinstance(diagnosis, Mapping):
+            step_id = _opt_str(diagnosis.get("step_id"))
+            if step_id:
+                return step_id
+    final_public = metadata.get("final_public_response")
+    if isinstance(final_public, Mapping):
+        next_payload = final_public.get("next")
+        if isinstance(next_payload, Mapping):
+            step_id = _opt_str(next_payload.get("step_id"))
+            if step_id:
+                return step_id
+    return None
+
+
+def _terminal_completion_event(
+    ev: Mapping[str, Any],
+    *,
+    terminal_step_id: str | None = None,
+) -> tuple[str, str] | None:
+    kind = ev.get("kind") or ev.get("type") or ""
+    if kind != "tutor_response":
+        return None
+    metadata = _merged_event_metadata(ev)
+    step_id = _metadata_step_id(metadata)
+    if step_id is None or (terminal_step_id is not None and step_id != terminal_step_id):
+        return None
+
+    payload = ev.get("payload") if isinstance(ev.get("payload"), Mapping) else {}
+    category = _opt_str(metadata.get("final_public_instruction_category"))
+    final_public = metadata.get("final_public_response")
+    if isinstance(final_public, Mapping):
+        category = category or _opt_str(final_public.get("instruction_category"))
+    reasons = _str_list(metadata.get("harness_validation_reasons"))
+
+    completed = (
+        category == "completed"
+        or f"completion_gate_already_satisfied:{step_id}" in reasons
+    )
+    if not completed:
+        return None
+
+    help_cycle_id = _event_help_cycle_id(ev, metadata) or ""
+    return step_id, help_cycle_id
+
+
+def _inferred_step_completion_notes(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    help_cycles: Sequence[HelpCycleRecord],
+    pack_steps: Sequence[Mapping[str, Any]],
+    explicit_completed: set[str],
+) -> dict[str, tuple[str, str]]:
+    order = _step_order_index(pack_steps)
+    ordered_steps = [
+        _opt_str(step.get("id"))
+        for step in pack_steps
+        if _opt_str(step.get("id")) in order
+    ]
+    inferred: dict[str, tuple[str, str]] = {}
+
+    previous_idx: int | None = None
+    for cycle in help_cycles:
+        step_id = _help_cycle_step_id(cycle)
+        current_idx = order.get(step_id or "")
+        if current_idx is None:
+            continue
+        if previous_idx is None:
+            previous_idx = current_idx
+            continue
+        progression_gap = current_idx - previous_idx
+        if not 0 < progression_gap <= 3:
+            previous_idx = current_idx
+            continue
+        for prior_step in ordered_steps[previous_idx:current_idx]:
+            if prior_step is None or prior_step in explicit_completed or prior_step in inferred:
+                continue
+            inferred[prior_step] = (
+                f"progression_to:{step_id}",
+                "completed_inferred_from_progression",
+            )
+        previous_idx = current_idx
+
+    terminal_step_id = next((step_id for step_id in reversed(ordered_steps) if step_id), None)
+    terminal = None
+    for ev in events:
+        terminal = _terminal_completion_event(ev, terminal_step_id=terminal_step_id) or terminal
+    if terminal is None:
+        return inferred
+
+    terminal_step_id, terminal_help_cycle_id = terminal
+    terminal_idx = order.get(terminal_step_id)
+    if terminal_idx is None:
+        return inferred
+    terminal_ref = (
+        f"terminal_s33:{terminal_help_cycle_id}"
+        if terminal_help_cycle_id
+        else "terminal_s33"
+    )
+    for step_id in ordered_steps[: terminal_idx + 1]:
+        if step_id is None or step_id in explicit_completed or step_id in inferred:
+            continue
+        inferred[step_id] = (terminal_ref, "completed_inferred_from_terminal_s33")
+
+    return inferred
+
+
 def _build_step_coding(
     events: Sequence[Mapping[str, Any]],
     *,
@@ -1080,6 +1211,13 @@ def _build_step_coding(
             completed_steps.add(sid)
             completed_event_seen.add(sid)
 
+    inferred_completion_notes = _inferred_step_completion_notes(
+        events,
+        help_cycles=help_cycles,
+        pack_steps=pack_steps,
+        explicit_completed=completed_event_seen,
+    )
+
     rows: list[StepCodingRecord] = []
     for step in pack_steps:
         step_id = _opt_str(step.get("id"))
@@ -1087,6 +1225,9 @@ def _build_step_coding(
             continue
         cycles = [cycle for cycle in help_cycles if _help_cycle_matches_step(cycle, step_id)]
         completed = step_id in completed_steps
+        inferred_completion = inferred_completion_notes.get(step_id)
+        if not completed and inferred_completion is not None:
+            completed = True
         performed = completed or step_id in activated_steps or bool(cycles)
 
         evidence_refs: list[str] = []
@@ -1098,10 +1239,14 @@ def _build_step_coding(
             evidence_refs.append(f"help_cycle:{cycle.help_cycle_id}")
             if cycle.frame_ids:
                 evidence_refs.append("frames:" + _join_csv_values(cycle.frame_ids))
+        if inferred_completion is not None:
+            evidence_refs.append(inferred_completion[0])
 
         auto_notes: list[str] = ["human_error_columns_blank"]
-        if completed:
+        if step_id in completed_event_seen:
             auto_notes.append("completed_from_step_completed")
+        elif inferred_completion is not None:
+            auto_notes.append(inferred_completion[1])
         elif performed:
             auto_notes.append("performed_inferred_from_step_or_help_evidence")
         else:
@@ -1192,6 +1337,67 @@ def _event_bios_map(ev: Mapping[str, Any]) -> Mapping[str, Any]:
         if isinstance(bios, Mapping):
             return bios
     return {}
+
+
+_PASSIVE_TIMELINE_KEYS = {
+    "COMM1",
+    "COMM2",
+    "EXT_HOOK",
+    "EXT_REFUEL_PROBE",
+    "EXT_NOZZLE_POS_L",
+    "EXT_NOZZLE_POS_R",
+    "HMD_OFF_BRT",
+    "HUD_BLACK_LVL",
+    "HUD_LTDR",
+    "HYD_IND_BRAKE",
+    "HYD_IND_LEFT",
+    "HYD_IND_RIGHT",
+    "IFEI_BINGO",
+    "IFEI_TIME_SET_MODE",
+    "LANDING_GEAR_HANDLE_LT",
+    "LOW_ALT_WARN_LT",
+    "MASTER_CAUTION_LT",
+    "RADALT_ALT_PTR",
+    "RADALT_HEIGHT",
+    "RADALT_OFF_FLAG",
+    "SAI_BANK",
+    "SAI_MAN_PITCH_ADJ",
+    "SAI_POINTER_HOR",
+    "SAI_POINTER_VER",
+    "SAI_SET",
+    "SAI_SLIP_BALL",
+}
+
+_PASSIVE_TIMELINE_PREFIXES = (
+    "AOA_INDEXER",
+    "CLIP_",
+    "EMERG_INSTR_",
+    "ENG_INSTR_",
+    "FIRE_",
+    "FLP_LG_",
+    "IFEI_DD_",
+    "IFEI_DISP_",
+    "IFEI_TEMP_",
+    "IFEI_RPM_",
+    "IFEI_FF_",
+    "IFEI_FUEL_",
+    "IFEI_OIL_PRESS_",
+    "LH_ADV_",
+    "LS_",
+    "SAI_ATT_",
+    "UFC_OPTION_CUEING_",
+    "VOLT_",
+)
+
+
+def _is_passive_timeline_key(raw_key: str) -> bool:
+    if raw_key in _PASSIVE_TIMELINE_KEYS:
+        return True
+    if raw_key.endswith("_LT"):
+        return True
+    if raw_key.endswith("_DISPLAY") or "_DISPLAY_" in raw_key:
+        return True
+    return any(raw_key.startswith(prefix) for prefix in _PASSIVE_TIMELINE_PREFIXES)
 
 
 def _candidate_steps_for_targets(
@@ -1324,6 +1530,8 @@ def _build_action_timeline(
 
             mapped_targets = list(bios_to_ui.get(raw_key, ()))
             candidate_step_ids = _candidate_steps_for_targets(mapped_targets, step_ids_by_target)
+            if _is_passive_timeline_key(raw_key):
+                continue
             expected_for_step = ""
             if active_step_id and candidate_step_ids:
                 expected_for_step = _yes_no(active_step_id in candidate_step_ids)
@@ -1862,11 +2070,61 @@ def _apply_pre_scoring_candidates(
     )
 
 
-def _task_time_seconds(events: Sequence[Mapping[str, Any]]) -> float | None:
-    times = [t for ev in events if (t := _event_wall_time(ev)) is not None]
+def _is_task_time_event(ev: Mapping[str, Any]) -> bool:
+    kind = ev.get("kind") or ev.get("type") or ""
+    if kind in (
+        "step_activated",
+        "step_completed",
+        "step_blocked",
+        "tutor_request",
+        "tutor_response",
+        "overlay_requested",
+        "overlay_dry_run",
+        "overlay_rejected",
+    ):
+        return True
+    if kind != "observation":
+        return False
+
+    source = _event_source(ev)
+    if source == "vision_frame_manifest":
+        return False
+    return bool(_event_bios_map(ev) or _event_vars(ev) or _extract_event_delta_items(ev))
+
+
+def _terminal_task_end_time(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    terminal_step_id: str | None,
+) -> float | None:
+    end_time = None
+    for ev in events:
+        if _terminal_completion_event(ev, terminal_step_id=terminal_step_id) is None:
+            continue
+        end_time = _event_wall_time(ev) or end_time
+    return end_time
+
+
+def _task_time_seconds(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    terminal_step_id: str | None = None,
+) -> float | None:
+    times = [
+        t
+        for ev in events
+        if _is_task_time_event(ev)
+        if (t := _event_wall_time(ev)) is not None
+    ]
     if not times:
         return None
-    return max(times) - min(times)
+    start_time = min(times)
+    end_time = _terminal_task_end_time(events, terminal_step_id=terminal_step_id)
+    if end_time is None:
+        end_time = max(times)
+    if end_time < start_time:
+        return None
+    return end_time - start_time
 
 
 def _merged_event_metadata(ev: Mapping[str, Any]) -> dict[str, Any]:
@@ -1955,7 +2213,7 @@ def _build_trial_summary(
             Condition=meta.condition,
             TrialID=meta.trial_id,
             Completed=_yes_no(all_completed),
-            TaskTime_sec=_task_time_seconds(events),
+            TaskTime_sec=_task_time_seconds(events, terminal_step_id=step_coding[-1].StepID),
             HelpRequests=summary.help_requests,
             LLMTriggers=summary.llm_triggers,
             VLMCalls=_count_vlm_calls(events, help_cycles),

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -6,8 +6,10 @@ import argparse
 import csv
 import hashlib
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+import pytest
 
 import simtutor.__main__ as simtutor_cli
 from core.experiment_export import (
@@ -364,6 +366,140 @@ def _make_events_with_action_timeline() -> list[dict]:
             "t_wall": 24.0,
             "timestamp": t7.isoformat(),
         },
+    ]
+
+
+def _make_live_help_only_completion_events() -> list[dict]:
+    t0 = datetime(2026, 5, 20, 14, 56, 0, tzinfo=timezone.utc)
+
+    def ts(offset: int) -> str:
+        return (t0 + timedelta(seconds=offset)).isoformat()
+
+    def request(cycle_id: str, step_id: str, t_wall: float, missing: list[str]) -> dict:
+        return {
+            "kind": "tutor_request",
+            "payload": {
+                "intent": "help",
+                "metadata": {
+                    "help_cycle_id": cycle_id,
+                    "fused_step_id": step_id,
+                    "fused_missing_conditions": missing,
+                },
+            },
+            "metadata": {
+                "help_cycle_id": cycle_id,
+                "fused_step_id": step_id,
+                "fused_missing_conditions": missing,
+            },
+            "related_id": cycle_id,
+            "t_wall": t_wall,
+            "timestamp": ts(int(t_wall - 100.0)),
+        }
+
+    def response(
+        cycle_id: str,
+        fused_step_id: str,
+        t_wall: float,
+        *,
+        message: str,
+        category: str = "actionable",
+        validation_reasons: list[str] | None = None,
+    ) -> dict:
+        return {
+            "kind": "tutor_response",
+            "payload": {
+                "status": "ok",
+                "message": message,
+                "actions": [],
+                "metadata": {
+                    "help_cycle_id": cycle_id,
+                    "generation_mode": "model",
+                    "fused_step_id": fused_step_id,
+                    "fused_missing_conditions": [],
+                    "help_response": {
+                        "diagnosis": {"step_id": fused_step_id, "error_category": "OM"},
+                        "next": {"step_id": fused_step_id},
+                        "overlay": {"targets": [], "evidence": []},
+                    },
+                    "final_public_instruction_category": category,
+                    "harness_validation_reasons": validation_reasons or [],
+                },
+            },
+            "metadata": {
+                "help_cycle_id": cycle_id,
+                "generation_mode": "model",
+                "fused_step_id": fused_step_id,
+                "fused_missing_conditions": [],
+            },
+            "related_id": cycle_id,
+            "t_wall": t_wall,
+            "timestamp": ts(int(t_wall - 100.0)),
+        }
+
+    return [
+        {
+            "kind": "observation",
+            "source": "vision_frame_manifest",
+            "payload": {
+                "source": "vision_frame_manifest",
+                "payload": {"source": "vision_frame_manifest"},
+            },
+            "t_wall": 10.0,
+            "timestamp": ts(0),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios_raw",
+            "payload": {
+                "seq": 1,
+                "t_wall": 100.0,
+                "source": "dcs_bios_raw",
+                "bios": {
+                    "BATTERY_SW": 2,
+                    "HOOK_LEVER": 1,
+                    "HYD_IND_BRAKE": 42000,
+                    "EXT_HOOK": 1000,
+                },
+                "delta": {
+                    "BATTERY_SW": 2,
+                    "HOOK_LEVER": 1,
+                    "HYD_IND_BRAKE": 42000,
+                    "EXT_HOOK": 1000,
+                },
+                "vars": {"battery_on": True},
+            },
+            "t_wall": 100.0,
+            "timestamp": ts(0),
+        },
+        request("cycle-s01", "S01", 101.0, ["vars.battery_on==true"]),
+        response("cycle-s01", "S01", 104.0, message="BATT 到 ON。"),
+        request("cycle-s02", "S02", 120.0, ["vars.fire_test_a_complete==true"]),
+        response("cycle-s02", "S02", 124.0, message="当前处于 S02。"),
+        {
+            "kind": "observation",
+            "source": "dcs_bios_raw",
+            "payload": {
+                "seq": 2,
+                "t_wall": 140.0,
+                "source": "dcs_bios_raw",
+                "bios": {"HYD_IND_BRAKE": 42001, "EXT_HOOK": 2000},
+                "delta": {"HYD_IND_BRAKE": 42001, "EXT_HOOK": 2000},
+            },
+            "t_wall": 140.0,
+            "timestamp": ts(40),
+        },
+        request("cycle-s33", "S32", 180.0, ["vars.standby_attitude_uncaged==true"]),
+        response(
+            "cycle-s33",
+            "S33",
+            184.0,
+            message="姿态源选择器已经在 AUTO，S33 检查已满足；冷启动流程已完成，无需继续操作。",
+            category="completed",
+            validation_reasons=[
+                "completion_gate_already_satisfied:S32",
+                "completion_gate_already_satisfied:S33",
+            ],
+        ),
     ]
 
 
@@ -1007,6 +1143,104 @@ def test_action_timeline_links_dcs_deltas_to_steps_and_help_cycles():
     assert "unmapped_raw_key" in set(unmapped.AutoCodingHint.split(";"))
 
 
+def test_live_help_only_terminal_s33_infers_completion_and_task_time():
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_live_help_only_completion_events(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+    by_step = {row.StepID: row for row in export.step_coding}
+
+    assert export.trial_summary[0].Completed == "yes"
+    assert export.trial_summary[0].TotalStepsCompleted == 33
+    assert export.trial_summary[0].StepCompletionAccuracy == 1.0
+    assert export.trial_summary[0].TaskTime_sec == 84.0
+
+    assert by_step["S01"].Completed == "yes"
+    assert "completed_inferred_from_progression" in by_step["S01"].AutoCodingNotes
+    assert "progression_to:S02" in by_step["S01"].EvidenceRefs
+
+    assert by_step["S33"].Completed == "yes"
+    assert "completed_inferred_from_terminal_s33" in by_step["S33"].AutoCodingNotes
+    assert "terminal_s33:cycle-s33" in by_step["S33"].EvidenceRefs
+
+
+def test_task_time_does_not_stop_at_intermediate_completed_response():
+    root = _repo_root()
+    events = [
+        {
+            "kind": "observation",
+            "source": "dcs_bios_raw",
+            "payload": {
+                "seq": 1,
+                "t_wall": 0.0,
+                "source": "dcs_bios_raw",
+                "bios": {"BATTERY_SW": 2},
+                "delta": {"BATTERY_SW": 2},
+            },
+            "t_wall": 0.0,
+        },
+        {
+            "kind": "tutor_response",
+            "payload": {
+                "status": "ok",
+                "message": "S08 already satisfied.",
+                "metadata": {
+                    "help_cycle_id": "cycle-s08",
+                    "fused_step_id": "S08",
+                    "help_response": {"next": {"step_id": "S08"}},
+                    "final_public_instruction_category": "completed",
+                },
+            },
+            "metadata": {"help_cycle_id": "cycle-s08", "fused_step_id": "S08"},
+            "t_wall": 5.0,
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios_raw",
+            "payload": {
+                "seq": 2,
+                "t_wall": 20.0,
+                "source": "dcs_bios_raw",
+                "bios": {"APU_CONTROL_SW": 1},
+                "delta": {"APU_CONTROL_SW": 1},
+            },
+            "t_wall": 20.0,
+        },
+    ]
+
+    export = build_experiment_export(
+        events,
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    assert export.trial_summary[0].TaskTime_sec == 20.0
+
+
+def test_action_timeline_filters_passive_live_telemetry_but_keeps_mapped_actions():
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_live_help_only_completion_events(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P01", "condition": "tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    raw_keys = [row.RawKey for row in export.action_timeline]
+    assert raw_keys == ["BATTERY_SW", "HOOK_LEVER"]
+    assert export.action_timeline[0].MappedTarget == "battery_switch"
+    assert export.action_timeline[0].CandidateStepID == "S01"
+    assert export.action_timeline[1].MappedTarget == "arresting_hook_handle"
+    assert export.action_timeline[1].CandidateStepID == "S24;S25"
+
+
 def test_action_timeline_rejects_bios_mapping_with_unknown_ui_target():
     root = _repo_root()
     export_events = _make_events_with_action_timeline()
@@ -1483,6 +1717,92 @@ def test_experiment_export_cli_writes_action_timeline_rows(tmp_path: Path):
     assert rows[2]["RawValueAfter"] == "7"
     assert rows[2]["MappedTarget"] == ""
     assert "unmapped_raw_key" in set(rows[2]["AutoCodingHint"].split(";"))
+
+
+def test_real_smoke_live_help_log_export_and_analysis_regression(tmp_path: Path):
+    root = _repo_root()
+    raw_log = root / "logs/live_help_harness_smoke_20260520_145436.jsonl"
+    if not raw_log.exists():
+        pytest.skip(f"smoke regression log not available: {raw_log}")
+
+    output_dir = tmp_path / "exports"
+    args = argparse.Namespace(
+        file=str(raw_log),
+        participant_id="P_SMOKE_20260520",
+        trial_id="T01",
+        study_id="smoke_validation_20260520",
+        condition="tutor",
+        group="internal_smoke",
+        experimenter_id="yz",
+        questionnaire="questionnaires/smoke_placeholder.json",
+        recording_ref=str(raw_log),
+        notes=None,
+        output_dir=str(output_dir),
+        scoring=None,
+        pack=str(root / "packs/fa18c_startup/pack.yaml"),
+        taxonomy=str(root / "packs/fa18c_startup/taxonomy.yaml"),
+        ui_map=str(root / "packs/fa18c_startup/ui_map.yaml"),
+        bios_to_ui=str(root / "packs/fa18c_startup/bios_to_ui.yaml"),
+        model_provider="openai_compat",
+        model_name="qwen36_27b",
+        vision_model_name="simtutor-vision",
+        prompt_version="harness_v04",
+        prompt_hash=None,
+        scenario_profile="airfield",
+        dcs_mission="live_smoke",
+        dcs_aircraft="FA-18C_hornet",
+        vr_setup="live_dcs_vr_or_composite",
+        monitor_setup="fa18c_composite_panel_v2",
+        git_commit="abc123",
+        git_dirty=False,
+        strict=True,
+        overwrite=False,
+        copy_raw_log=True,
+    )
+
+    assert _run_experiment_export(args) == 0
+
+    trial_dir = output_dir / "P_SMOKE_20260520" / "T01"
+    quality_gate = json.loads((trial_dir / "quality_gate.json").read_text(encoding="utf-8"))
+    assert quality_gate["passed"] is True
+
+    with (trial_dir / "trial_summary.csv").open("r", newline="", encoding="utf-8") as f:
+        trial = list(csv.DictReader(f))[0]
+    assert trial["Completed"] == "yes"
+    assert int(trial["TotalStepsCompleted"]) >= 30
+    assert float(trial["StepCompletionAccuracy"]) >= 0.9
+    assert 0 < float(trial["TaskTime_sec"]) < 3600
+
+    with (trial_dir / "step_coding.csv").open("r", newline="", encoding="utf-8") as f:
+        steps = {row["StepID"]: row for row in csv.DictReader(f)}
+    assert steps["S20"]["Completed"] == "yes"
+    assert "completed_inferred_from_progression" in steps["S20"]["AutoCodingNotes"]
+    assert steps["S33"]["Completed"] == "yes"
+    assert "completed_inferred_from_terminal_s33" in steps["S33"]["AutoCodingNotes"]
+
+    with (trial_dir / "action_timeline.csv").open("r", newline="", encoding="utf-8") as f:
+        action_rows = list(csv.DictReader(f))
+    action_keys = {row["RawKey"] for row in action_rows}
+    assert len(action_rows) < 1000
+    assert "BATTERY_SW" in action_keys
+    assert "HYD_IND_BRAKE" not in action_keys
+    assert "HYD_IND_LEFT" not in action_keys
+    assert "EXT_REFUEL_PROBE" not in action_keys
+    assert "EXT_HOOK" not in action_keys
+    assert "IFEI_TEMP_R" not in action_keys
+
+    analysis_dir = tmp_path / "analysis"
+    analyze_args = argparse.Namespace(
+        input_dir=str(output_dir),
+        output_dir=str(analysis_dir),
+        no_figures=True,
+    )
+    assert simtutor_cli._run_experiment_analyze(analyze_args) == 0
+    with (analysis_dir / "condition_summary.csv").open("r", newline="", encoding="utf-8") as f:
+        condition = list(csv.DictReader(f))[0]
+    assert condition["CompletionRate"] == "1.0"
+    assert float(condition["MeanStepCompletionAccuracy"]) >= 0.9
+    assert 0 < float(condition["MeanTaskTime_sec"]) < 3600
 
 
 def test_experiment_export_cli_overwrite_replaces_stale_managed_outputs(tmp_path: Path):


### PR DESCRIPTION
## Summary
- infer live-help-only step completion from conservative help-cycle progression and terminal completed evidence while recording EvidenceRefs/AutoCodingNotes
- compute TaskTime_sec from relevant live-run events and terminal step completion instead of stale vision manifests or intermediate completed responses
- filter passive telemetry noise from action_timeline.csv while preserving mapped cockpit controls
- add compact and real-smoke regression coverage, including experiment-analyze summaries

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/test_experiment_analysis.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #362