### PR TITLE
Add Windows experiment launcher MVP

### DIFF
--- a/simtutor/launcher.py
+++ b/simtutor/launcher.py
@@ -1,0 +1,289 @@
+"""Tkinter MVP launcher for local SimTutor experiment sessions."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Callable
+
+try:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox, ttk
+except ModuleNotFoundError as exc:
+    tk = None  # type: ignore[assignment]
+    filedialog = None  # type: ignore[assignment]
+    messagebox = None  # type: ignore[assignment]
+    ttk = None  # type: ignore[assignment]
+    _TK_IMPORT_ERROR: ModuleNotFoundError | None = exc
+else:
+    _TK_IMPORT_ERROR = None
+
+from simtutor.launcher_processes import LauncherProcess, ProcessState
+from simtutor.launcher_settings import (
+    LauncherSettings,
+    LauncherSettingsError,
+    load_profile,
+    load_settings,
+    save_profile,
+    save_settings,
+    validate_settings,
+)
+
+
+NORMAL_FIELDS = (
+    ("saved_games_path", "Saved Games path"),
+    ("dcs_variant", "DCS variant"),
+    ("monitor_mode", "Monitor mode"),
+    ("language", "Language"),
+    ("scenario_profile", "Scenario profile"),
+    ("output_log_directory", "Output log directory"),
+    ("participant_id", "Participant id"),
+    ("condition", "Condition"),
+    ("trial_id", "Trial id"),
+)
+
+ADVANCED_FIELDS = (
+    ("model_provider", "Model provider"),
+    ("model_base_url", "Model base URL"),
+    ("text_model_name", "Text model name"),
+    ("vision_model_name", "Vision model name"),
+    ("model_timeout_s", "Model timeout"),
+    ("max_overlay_targets", "Max overlay targets"),
+    ("ssh_tunnel_profile", "SSH tunnel profile"),
+    ("preflight_profile", "Preflight profile"),
+    ("export_profile", "Export profile"),
+)
+
+
+ProcessFactory = Callable[..., LauncherProcess]
+CommandBuilder = Callable[[LauncherSettings], list[str]]
+
+
+class LauncherApp(ttk.Frame if ttk is not None else object):
+    def __init__(
+        self,
+        master: tk.Tk,
+        *,
+        settings: LauncherSettings | None = None,
+        process_factory: ProcessFactory = LauncherProcess,
+        command_builder: CommandBuilder | None = None,
+    ) -> None:
+        _require_tk()
+        super().__init__(master, padding=12)
+        self.master = master
+        self.settings = settings or load_settings()
+        self.process_factory = process_factory
+        self.command_builder = command_builder or _fake_process_command
+        self.variables: dict[str, tk.StringVar] = {}
+        self.status_variables = {
+            name: tk.StringVar(value="stopped")
+            for name in ("DCS", "model", "tunnel", "tutor", "vision")
+        }
+        self.process: LauncherProcess | None = None
+
+        master.title("SimTutor Experiment Launcher")
+        master.minsize(860, 620)
+        self.grid(row=0, column=0, sticky="nsew")
+        master.columnconfigure(0, weight=1)
+        master.rowconfigure(0, weight=1)
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(0, weight=1)
+
+        self._build_settings_tabs()
+        self._build_status_area()
+        self._build_buttons()
+        self._build_log_area()
+        self._poll_process()
+
+    def _build_settings_tabs(self) -> None:
+        notebook = ttk.Notebook(self)
+        notebook.grid(row=0, column=0, sticky="nsew")
+        notebook.columnconfigure(0, weight=1)
+        notebook.rowconfigure(0, weight=1)
+        self._add_settings_tab(notebook, "Normal", NORMAL_FIELDS)
+        self._add_settings_tab(notebook, "Advanced", ADVANCED_FIELDS)
+
+    def _add_settings_tab(self, notebook: ttk.Notebook, title: str, field_defs: tuple[tuple[str, str], ...]) -> None:
+        frame = ttk.Frame(notebook, padding=10)
+        notebook.add(frame, text=title)
+        frame.columnconfigure(1, weight=1)
+        for row, (name, label) in enumerate(field_defs):
+            ttk.Label(frame, text=label).grid(row=row, column=0, sticky="w", padx=(0, 8), pady=3)
+            var = tk.StringVar(value=str(getattr(self.settings, name)))
+            self.variables[name] = var
+            entry = ttk.Entry(frame, textvariable=var)
+            entry.grid(row=row, column=1, sticky="ew", pady=3)
+            if name in {"saved_games_path", "output_log_directory"}:
+                button = ttk.Button(frame, text="Browse", command=lambda key=name: self._browse_directory(key))
+                button.grid(row=row, column=2, sticky="e", padx=(8, 0), pady=3)
+
+    def _build_status_area(self) -> None:
+        frame = ttk.LabelFrame(self, text="Status", padding=10)
+        frame.grid(row=1, column=0, sticky="ew", pady=(10, 0))
+        for column, (name, var) in enumerate(self.status_variables.items()):
+            ttk.Label(frame, text=name).grid(row=0, column=column, sticky="w", padx=(0, 18))
+            ttk.Label(frame, textvariable=var).grid(row=1, column=column, sticky="w", padx=(0, 18))
+
+    def _build_buttons(self) -> None:
+        frame = ttk.Frame(self)
+        frame.grid(row=2, column=0, sticky="ew", pady=(10, 0))
+        frame.columnconfigure(8, weight=1)
+        ttk.Button(frame, text="Load", command=self._load).grid(row=0, column=0, padx=(0, 6))
+        ttk.Button(frame, text="Save", command=self._save).grid(row=0, column=1, padx=(0, 6))
+        ttk.Button(frame, text="Save Profile", command=self._save_profile).grid(row=0, column=2, padx=(0, 6))
+        ttk.Button(frame, text="Load Profile", command=self._load_profile).grid(row=0, column=3, padx=(0, 18))
+        ttk.Button(frame, text="Start", command=self._start).grid(row=0, column=4, padx=(0, 6))
+        ttk.Button(frame, text="Stop", command=self._stop).grid(row=0, column=5, padx=(0, 18))
+        ttk.Button(frame, text="Preflight", command=self._placeholder_preflight).grid(row=0, column=6, padx=(0, 6))
+        ttk.Button(frame, text="Export", command=self._placeholder_export).grid(row=0, column=7, padx=(0, 6))
+
+    def _build_log_area(self) -> None:
+        frame = ttk.LabelFrame(self, text="Process log", padding=10)
+        frame.grid(row=3, column=0, sticky="nsew", pady=(10, 0))
+        frame.columnconfigure(0, weight=1)
+        frame.rowconfigure(0, weight=1)
+        self.rowconfigure(3, weight=1)
+        self.log_text = tk.Text(frame, height=12, wrap="word")
+        self.log_text.grid(row=0, column=0, sticky="nsew")
+        scrollbar = ttk.Scrollbar(frame, command=self.log_text.yview)
+        scrollbar.grid(row=0, column=1, sticky="ns")
+        self.log_text.configure(yscrollcommand=scrollbar.set)
+
+    def _browse_directory(self, key: str) -> None:
+        assert filedialog is not None
+        selected = filedialog.askdirectory()
+        if selected:
+            self.variables[key].set(selected)
+
+    def _collect_settings(self) -> LauncherSettings:
+        values = {name: var.get() for name, var in self.variables.items()}
+        return LauncherSettings.from_dict(values)
+
+    def _apply_settings(self, settings: LauncherSettings) -> None:
+        self.settings = settings
+        for name, var in self.variables.items():
+            var.set(str(getattr(settings, name)))
+
+    def _load(self) -> None:
+        try:
+            self._apply_settings(load_settings())
+        except LauncherSettingsError as exc:
+            assert messagebox is not None
+            messagebox.showerror("Load failed", str(exc))
+
+    def _save(self) -> None:
+        try:
+            settings = self._collect_settings()
+            save_settings(settings)
+            self.settings = settings
+        except LauncherSettingsError as exc:
+            assert messagebox is not None
+            messagebox.showerror("Save failed", str(exc))
+
+    def _save_profile(self) -> None:
+        try:
+            settings = self._collect_settings()
+            validate_settings(settings)
+            name = f"{settings.participant_id}_{settings.trial_id}"
+            path = save_profile(name, settings)
+            self._append_log(f"saved profile: {path}")
+        except LauncherSettingsError as exc:
+            assert messagebox is not None
+            messagebox.showerror("Profile save failed", str(exc))
+
+    def _load_profile(self) -> None:
+        try:
+            settings = self._collect_settings()
+            name = f"{settings.participant_id}_{settings.trial_id}"
+            self._apply_settings(load_profile(name))
+        except LauncherSettingsError as exc:
+            assert messagebox is not None
+            messagebox.showerror("Profile load failed", str(exc))
+
+    def _start(self) -> None:
+        try:
+            settings = self._collect_settings()
+            save_settings(settings)
+        except LauncherSettingsError as exc:
+            assert messagebox is not None
+            messagebox.showerror("Start failed", str(exc))
+            return
+        self.settings = settings
+        if self.process is None or self.process.snapshot().state != ProcessState.RUNNING:
+            self.process = self.process_factory(name="simtutor-fake-session", command=self.command_builder(settings))
+        try:
+            self.process.start()
+        except Exception as exc:
+            assert messagebox is not None
+            messagebox.showerror("Start failed", str(exc))
+            return
+        self.status_variables["DCS"].set("external")
+        self.status_variables["model"].set(settings.model_provider)
+        self.status_variables["tunnel"].set("placeholder")
+        self.status_variables["tutor"].set("running")
+        self.status_variables["vision"].set("placeholder")
+
+    def _stop(self) -> None:
+        if self.process is not None:
+            self.process.stop()
+        self.status_variables["tutor"].set("stopped")
+
+    def _poll_process(self) -> None:
+        if self.process is not None:
+            snapshot = self.process.snapshot()
+            self.log_text.delete("1.0", "end")
+            self.log_text.insert("end", "\n".join(snapshot.log_lines))
+            self.log_text.see("end")
+            if snapshot.state == ProcessState.EXITED:
+                self.status_variables["tutor"].set(f"exited ({snapshot.returncode})")
+        self.after(250, self._poll_process)
+
+    def _append_log(self, text: str) -> None:
+        self.log_text.insert("end", text + "\n")
+        self.log_text.see("end")
+
+    def _placeholder_preflight(self) -> None:
+        self._append_log("preflight placeholder: installer/preflight is out of scope for this MVP")
+
+    def _placeholder_export(self) -> None:
+        self._append_log("export placeholder: experiment export implementation is out of scope for this MVP")
+
+
+def _fake_process_command(settings: LauncherSettings) -> list[str]:
+    participant = json.dumps(settings.participant_id)
+    trial = json.dumps(settings.trial_id)
+    script = (
+        "import time; "
+        "print('SimTutor fake session starting', flush=True); "
+        f"participant = {participant}; "
+        f"trial = {trial}; "
+        "print(f'participant={participant} trial={trial}', flush=True); "
+        "time.sleep(0.2); "
+        "print('DCS/model/tutor process shell ready', flush=True); "
+        "time.sleep(0.2)"
+    )
+    return [sys.executable, "-u", "-c", script]
+
+
+def main() -> int:
+    if _TK_IMPORT_ERROR is not None:
+        print(f"[SIMTUTOR_LAUNCHER] tkinter is required for the Windows GUI launcher: {_TK_IMPORT_ERROR}", file=sys.stderr)
+        return 1
+    try:
+        assert tk is not None
+        root = tk.Tk()
+        LauncherApp(root)
+        root.mainloop()
+    except Exception as exc:
+        print(f"[SIMTUTOR_LAUNCHER] failed to start GUI: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _require_tk() -> None:
+    if _TK_IMPORT_ERROR is not None or tk is None or ttk is None:
+        raise RuntimeError(f"tkinter is required for the Windows GUI launcher: {_TK_IMPORT_ERROR}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/simtutor/launcher_processes.py
+++ b/simtutor/launcher_processes.py
@@ -1,0 +1,137 @@
+"""Child process shell for the SimTutor experiment launcher."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+import subprocess
+import threading
+from typing import Any, Callable, Mapping, Sequence
+
+
+class ProcessState(str, Enum):
+    STOPPED = "stopped"
+    RUNNING = "running"
+    EXITED = "exited"
+
+
+class LauncherProcessError(RuntimeError):
+    """Raised when a managed launcher process cannot be started or stopped."""
+
+
+@dataclass(frozen=True)
+class ProcessSnapshot:
+    name: str
+    command: tuple[str, ...]
+    state: ProcessState
+    returncode: int | None
+    log_lines: tuple[str, ...]
+
+
+PopenFactory = Callable[..., Any]
+
+
+class LauncherProcess:
+    def __init__(
+        self,
+        *,
+        name: str,
+        command: Sequence[str],
+        popen_factory: PopenFactory = subprocess.Popen,
+        cwd: str | Path | None = None,
+        env: Mapping[str, str] | None = None,
+        max_log_lines: int = 200,
+    ) -> None:
+        if not name.strip():
+            raise LauncherProcessError("process name is required")
+        if not command:
+            raise LauncherProcessError("process command is required")
+        self.name = name
+        self.command = tuple(str(part) for part in command)
+        self.popen_factory = popen_factory
+        self.cwd = Path(cwd) if cwd is not None else None
+        self.env = dict(env) if env is not None else None
+        self.max_log_lines = max_log_lines
+        self.process: Any | None = None
+        self._state = ProcessState.STOPPED
+        self._log_lines: deque[str] = deque(maxlen=max_log_lines)
+        self._lock = threading.Lock()
+        self._reader: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            raise LauncherProcessError(f"process already running: {self.name}")
+        self.process = self.popen_factory(
+            list(self.command),
+            cwd=str(self.cwd) if self.cwd is not None else None,
+            env=self.env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        self._state = ProcessState.RUNNING
+        self._reader = threading.Thread(target=self._read_stdout, name=f"{self.name}-stdout", daemon=True)
+        self._reader.start()
+
+    def stop(self, *, timeout_s: float = 5.0) -> None:
+        if self.process is None:
+            self._state = ProcessState.STOPPED
+            return
+        if self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=timeout_s)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=timeout_s)
+        self.wait_for_output(timeout_s=0.2)
+        self._state = ProcessState.STOPPED
+
+    def drain_output(self) -> None:
+        self.wait_for_output(timeout_s=0.0)
+
+    def wait_for_output(self, *, timeout_s: float = 1.0) -> None:
+        if self._reader is not None:
+            self._reader.join(timeout=max(0.0, timeout_s))
+
+    def snapshot(self) -> ProcessSnapshot:
+        returncode = self.process.poll() if self.process is not None else None
+        state = self._state
+        if state == ProcessState.RUNNING and returncode is not None:
+            state = ProcessState.EXITED
+            self._state = state
+        with self._lock:
+            log_lines = tuple(self._log_lines)
+        return ProcessSnapshot(
+            name=self.name,
+            command=self.command,
+            state=state,
+            returncode=returncode,
+            log_lines=log_lines,
+        )
+
+    def _read_stdout(self) -> None:
+        if self.process is None or self.process.stdout is None:
+            return
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                break
+            self._append_line(line)
+
+    def _append_line(self, line: str) -> None:
+        clean = line.rstrip("\r\n")
+        with self._lock:
+            self._log_lines.append(clean)
+
+
+__all__ = [
+    "LauncherProcess",
+    "LauncherProcessError",
+    "ProcessSnapshot",
+    "ProcessState",
+]

--- a/simtutor/launcher_settings.py
+++ b/simtutor/launcher_settings.py
@@ -1,0 +1,225 @@
+"""Settings persistence for the Windows SimTutor experiment launcher."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields
+import json
+import math
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any, Mapping
+
+
+APP_DIR_NAME = "SimTutor"
+SETTINGS_FILENAME = "settings.json"
+PROFILES_DIR_NAME = "profiles"
+
+SUPPORTED_LANGUAGES = ("zh", "en")
+SUPPORTED_MODEL_PROVIDERS = ("stub", "openai_compat", "ollama")
+
+_SECRET_KEY_FRAGMENTS = ("api_key", "token", "password", "secret")
+
+
+class LauncherSettingsError(ValueError):
+    """Raised when launcher settings cannot be loaded, saved, or validated."""
+
+
+@dataclass
+class LauncherSettings:
+    saved_games_path: str = ""
+    dcs_variant: str = "DCS"
+    monitor_mode: str = "single-monitor"
+    language: str = "zh"
+    scenario_profile: str = "airfield"
+    output_log_directory: str = "logs"
+    participant_id: str = ""
+    condition: str = ""
+    trial_id: str = ""
+    model_provider: str = "stub"
+    model_base_url: str = ""
+    text_model_name: str = "Qwen3-8B-Instruct"
+    vision_model_name: str = "simtutor-vision"
+    model_timeout_s: float = 20.0
+    max_overlay_targets: int = 1
+    ssh_tunnel_profile: str = ""
+    preflight_profile: str = ""
+    export_profile: str = ""
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "LauncherSettings":
+        _reject_secret_keys(payload)
+        known = {field.name for field in fields(cls)}
+        values = {key: value for key, value in payload.items() if key in known}
+        settings = cls(**values)
+        try:
+            settings.model_timeout_s = float(settings.model_timeout_s)
+            settings.max_overlay_targets = int(settings.max_overlay_targets)
+        except (TypeError, ValueError) as exc:
+            raise LauncherSettingsError("model_timeout_s and max_overlay_targets must be numeric") from exc
+        if not math.isfinite(settings.model_timeout_s):
+            raise LauncherSettingsError("model_timeout_s must be finite")
+        return settings
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        _reject_secret_keys(payload)
+        return payload
+
+
+def settings_dir(
+    *,
+    env: Mapping[str, str] | None = None,
+    platform: str | None = None,
+    home: Path | None = None,
+) -> Path:
+    source = os.environ if env is None else env
+    platform_name = sys.platform if platform is None else platform
+    if platform_name == "win32":
+        base = source.get("LOCALAPPDATA", "").strip()
+        if not base:
+            raise LauncherSettingsError("LOCALAPPDATA is required on Windows")
+        return Path(base) / APP_DIR_NAME
+    if source.get("LOCALAPPDATA"):
+        return Path(source["LOCALAPPDATA"]) / APP_DIR_NAME
+    return (home or Path.home()) / ".simtutor"
+
+
+def settings_path(
+    *,
+    env: Mapping[str, str] | None = None,
+    platform: str | None = None,
+    home: Path | None = None,
+) -> Path:
+    return settings_dir(env=env, platform=platform, home=home) / SETTINGS_FILENAME
+
+
+def profiles_dir(
+    *,
+    env: Mapping[str, str] | None = None,
+    platform: str | None = None,
+    home: Path | None = None,
+) -> Path:
+    return settings_dir(env=env, platform=platform, home=home) / PROFILES_DIR_NAME
+
+
+def load_settings(path: str | Path | None = None) -> LauncherSettings:
+    resolved = Path(path) if path is not None else settings_path()
+    if not resolved.exists():
+        return LauncherSettings()
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"), parse_constant=_reject_json_constant)
+    except json.JSONDecodeError as exc:
+        raise LauncherSettingsError(f"invalid launcher settings JSON: {resolved}") from exc
+    if not isinstance(payload, dict):
+        raise LauncherSettingsError(f"launcher settings must be a JSON object: {resolved}")
+    return LauncherSettings.from_dict(payload)
+
+
+def save_settings(settings: LauncherSettings, path: str | Path | None = None) -> Path:
+    validate_settings(settings)
+    resolved = Path(path) if path is not None else settings_path()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_text(
+        json.dumps(settings.to_dict(), ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return resolved
+
+
+def validate_settings(settings: LauncherSettings) -> None:
+    errors: list[str] = []
+    required = (
+        "saved_games_path",
+        "dcs_variant",
+        "monitor_mode",
+        "language",
+        "scenario_profile",
+        "output_log_directory",
+        "participant_id",
+        "condition",
+        "trial_id",
+        "model_provider",
+        "text_model_name",
+        "vision_model_name",
+    )
+    for name in required:
+        value = getattr(settings, name)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(name)
+
+    if settings.language not in SUPPORTED_LANGUAGES:
+        errors.append("language")
+    if settings.model_provider not in SUPPORTED_MODEL_PROVIDERS:
+        errors.append("model_provider")
+    if settings.model_provider in {"openai_compat", "ollama"} and (
+        not isinstance(settings.model_base_url, str) or not settings.model_base_url.strip()
+    ):
+        errors.append("model_base_url")
+    try:
+        timeout_s = float(settings.model_timeout_s)
+    except (TypeError, ValueError):
+        errors.append("model_timeout_s")
+        timeout_s = 0.0
+    try:
+        max_overlay_targets = int(settings.max_overlay_targets)
+    except (TypeError, ValueError):
+        errors.append("max_overlay_targets")
+        max_overlay_targets = -1
+
+    if timeout_s <= 0 or not math.isfinite(timeout_s):
+        errors.append("model_timeout_s")
+    if max_overlay_targets < 0:
+        errors.append("max_overlay_targets")
+
+    if errors:
+        raise LauncherSettingsError("invalid launcher settings: " + ", ".join(sorted(set(errors))))
+
+
+def save_profile(name: str, settings: LauncherSettings, *, directory: str | Path | None = None) -> Path:
+    resolved_dir = Path(directory) if directory is not None else profiles_dir()
+    return save_settings(settings, resolved_dir / f"{_profile_slug(name)}.json")
+
+
+def load_profile(name: str, *, directory: str | Path | None = None) -> LauncherSettings:
+    resolved_dir = Path(directory) if directory is not None else profiles_dir()
+    path = resolved_dir / f"{_profile_slug(name)}.json"
+    if not path.exists():
+        raise LauncherSettingsError(f"profile not found: {name}")
+    return load_settings(path)
+
+
+def _profile_slug(name: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", name.strip()).strip("._-")
+    if not slug:
+        raise LauncherSettingsError("profile name is required")
+    return slug
+
+
+def _reject_secret_keys(payload: Mapping[str, Any]) -> None:
+    for key in payload:
+        normalized = str(key).lower()
+        if any(fragment in normalized for fragment in _SECRET_KEY_FRAGMENTS):
+            raise LauncherSettingsError(f"launcher settings must not store secret field: {key}")
+
+
+def _reject_json_constant(value: str) -> None:
+    raise LauncherSettingsError(f"invalid non-finite JSON number: {value}")
+
+
+__all__ = [
+    "APP_DIR_NAME",
+    "LauncherSettings",
+    "LauncherSettingsError",
+    "PROFILES_DIR_NAME",
+    "SETTINGS_FILENAME",
+    "load_profile",
+    "load_settings",
+    "profiles_dir",
+    "save_profile",
+    "save_settings",
+    "settings_dir",
+    "settings_path",
+    "validate_settings",
+]

--- a/tests/test_launcher_entry.py
+++ b/tests/test_launcher_entry.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+
+from simtutor.launcher import _fake_process_command
+from simtutor.launcher_settings import LauncherSettings
+
+
+def test_fake_process_command_escapes_profile_values() -> None:
+    settings = LauncherSettings(participant_id="P'01", trial_id="T\"01")
+    command = _fake_process_command(settings)
+
+    result = subprocess.run(command, capture_output=True, check=False, text=True, timeout=5)
+
+    assert result.returncode == 0
+    assert "participant=P'01 trial=T\"01" in result.stdout

--- a/tests/test_launcher_processes.py
+++ b/tests/test_launcher_processes.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import subprocess
+from collections import deque
+
+import pytest
+
+from simtutor.launcher_processes import LauncherProcess, LauncherProcessError, ProcessState
+
+
+class FakeStdout:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = deque(lines)
+
+    def readline(self) -> str:
+        if self._lines:
+            return self._lines.popleft()
+        return ""
+
+
+class FakePopen:
+    def __init__(self, command: list[str], **kwargs: object) -> None:
+        self.command = command
+        self.kwargs = kwargs
+        self.stdout = FakeStdout(["booting\n", "ready\n"])
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+def test_launcher_process_starts_and_captures_log_tail() -> None:
+    proc = LauncherProcess(
+        name="fake",
+        command=["fake.exe", "--demo"],
+        popen_factory=FakePopen,
+        max_log_lines=10,
+    )
+
+    proc.start()
+    proc.wait_for_output(timeout_s=1.0)
+    snapshot = proc.snapshot()
+
+    assert snapshot.name == "fake"
+    assert snapshot.command == ("fake.exe", "--demo")
+    assert snapshot.state == ProcessState.RUNNING
+    assert snapshot.returncode is None
+    assert snapshot.log_lines == ("booting", "ready")
+
+
+def test_launcher_process_stop_terminates_running_child() -> None:
+    proc = LauncherProcess(name="fake", command=["fake.exe"], popen_factory=FakePopen)
+
+    proc.start()
+    proc.stop()
+    snapshot = proc.snapshot()
+
+    assert snapshot.state == ProcessState.STOPPED
+    assert snapshot.returncode == 0
+    assert proc.process is not None
+    assert proc.process.terminated is True
+
+
+def test_launcher_process_rejects_double_start() -> None:
+    proc = LauncherProcess(name="fake", command=["fake.exe"], popen_factory=FakePopen)
+
+    proc.start()
+
+    with pytest.raises(LauncherProcessError, match="already running"):
+        proc.start()
+
+
+def test_launcher_process_uses_safe_subprocess_defaults() -> None:
+    captured: dict[str, object] = {}
+
+    def factory(command: list[str], **kwargs: object) -> FakePopen:
+        captured.update(kwargs)
+        return FakePopen(command, **kwargs)
+
+    proc = LauncherProcess(name="fake", command=["fake.exe"], popen_factory=factory)
+
+    proc.start()
+
+    assert captured["stdout"] == subprocess.PIPE
+    assert captured["stderr"] == subprocess.STDOUT
+    assert captured["stdin"] == subprocess.DEVNULL
+    assert captured["text"] is True

--- a/tests/test_launcher_settings.py
+++ b/tests/test_launcher_settings.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from simtutor.launcher_settings import (
+    LauncherSettings,
+    LauncherSettingsError,
+    load_profile,
+    load_settings,
+    profiles_dir,
+    save_profile,
+    save_settings,
+    settings_path,
+    validate_settings,
+)
+
+
+def _valid_settings() -> LauncherSettings:
+    return LauncherSettings(
+        saved_games_path="C:/Users/test/Saved Games/DCS",
+        dcs_variant="DCS",
+        monitor_mode="single-monitor",
+        language="zh",
+        scenario_profile="airfield",
+        output_log_directory="C:/SimTutor/logs",
+        participant_id="P01",
+        condition="with_tutor",
+        trial_id="T01",
+        model_provider="openai_compat",
+        model_base_url="http://127.0.0.1:8000/v1",
+        text_model_name="qwen36_27b",
+        vision_model_name="simtutor-vision",
+        model_timeout_s=30.0,
+        max_overlay_targets=2,
+    )
+
+
+def test_settings_path_uses_windows_localappdata() -> None:
+    env = {"LOCALAPPDATA": "C:/Users/test/AppData/Local"}
+
+    assert settings_path(env=env, platform="win32") == Path("C:/Users/test/AppData/Local") / "SimTutor" / "settings.json"
+    assert profiles_dir(env=env, platform="win32") == Path("C:/Users/test/AppData/Local") / "SimTutor" / "profiles"
+
+
+def test_settings_round_trip_json(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    settings = _valid_settings()
+
+    save_settings(settings, path)
+    loaded = load_settings(path)
+
+    assert loaded == settings
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["participant_id"] == "P01"
+    assert "api_key" not in payload
+    assert "password" not in payload
+    assert "secret" not in payload
+
+
+def test_load_settings_returns_defaults_when_missing(tmp_path: Path) -> None:
+    loaded = load_settings(tmp_path / "missing.json")
+
+    assert loaded == LauncherSettings()
+
+
+def test_validate_settings_reports_required_fields() -> None:
+    settings = LauncherSettings()
+
+    with pytest.raises(LauncherSettingsError) as exc:
+        validate_settings(settings)
+
+    message = str(exc.value)
+    assert "saved_games_path" in message
+    assert "participant_id" in message
+    assert "trial_id" in message
+
+
+def test_validate_settings_rejects_invalid_numbers() -> None:
+    settings = _valid_settings()
+    settings.model_timeout_s = 0
+    settings.max_overlay_targets = -1
+
+    with pytest.raises(LauncherSettingsError) as exc:
+        validate_settings(settings)
+
+    assert "model_timeout_s" in str(exc.value)
+    assert "max_overlay_targets" in str(exc.value)
+
+
+@pytest.mark.parametrize("timeout", [float("nan"), float("inf")])
+def test_validate_settings_rejects_non_finite_timeout(timeout: float) -> None:
+    settings = _valid_settings()
+    settings.model_timeout_s = timeout
+
+    with pytest.raises(LauncherSettingsError, match="model_timeout_s"):
+        validate_settings(settings)
+
+
+def test_load_settings_rejects_non_finite_timeout_constant(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    path.write_text('{"model_timeout_s": NaN}', encoding="utf-8")
+
+    with pytest.raises(LauncherSettingsError, match="non-finite"):
+        load_settings(path)
+
+
+def test_validate_settings_reports_non_numeric_numbers() -> None:
+    settings = _valid_settings()
+    settings.model_timeout_s = "slow"  # type: ignore[assignment]
+    settings.max_overlay_targets = "many"  # type: ignore[assignment]
+
+    with pytest.raises(LauncherSettingsError) as exc:
+        validate_settings(settings)
+
+    message = str(exc.value)
+    assert "model_timeout_s" in message
+    assert "max_overlay_targets" in message
+
+
+def test_openai_compat_requires_model_base_url() -> None:
+    settings = _valid_settings()
+    settings.model_base_url = ""
+
+    with pytest.raises(LauncherSettingsError, match="model_base_url"):
+        validate_settings(settings)
+
+
+def test_openai_compat_rejects_non_string_base_url() -> None:
+    settings = _valid_settings()
+    settings.model_base_url = 123  # type: ignore[assignment]
+
+    with pytest.raises(LauncherSettingsError, match="model_base_url"):
+        validate_settings(settings)
+
+
+def test_load_settings_rejects_secret_fields(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    payload = _valid_settings().to_dict()
+    payload["api_key"] = "sk-secret"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(LauncherSettingsError, match="must not store secret field"):
+        load_settings(path)
+
+
+def test_profile_round_trip_uses_sanitized_profile_name(tmp_path: Path) -> None:
+    settings = _valid_settings()
+
+    path = save_profile("Pilot 01 / baseline", settings, directory=tmp_path)
+    loaded = load_profile("Pilot 01 / baseline", directory=tmp_path)
+
+    assert path.name == "Pilot_01_baseline.json"
+    assert loaded == settings
+
+
+def test_load_profile_reports_missing_profile(tmp_path: Path) -> None:
+    with pytest.raises(LauncherSettingsError, match="profile not found"):
+        load_profile("missing", directory=tmp_path)

--- a/tools/simtutor_launcher.py
+++ b/tools/simtutor_launcher.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from simtutor.launcher import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a Tkinter/ttk SimTutor experiment launcher entry point with normal/advanced settings, status area, Start/Stop, profile buttons, and fake process log tail.
- Add launcher settings persistence under LOCALAPPDATA/SimTutor with profile save/load, required-field validation, finite numeric checks, and secret-field rejection.
- Add a child process abstraction with safe subprocess defaults and tested fake subprocess behavior.

## Verification
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_launcher_settings.py tests/test_launcher_processes.py tests/test_launcher_entry.py
- source ~/venvs/iefmmq-wsl/bin/activate && python -m py_compile simtutor/launcher.py tools/simtutor_launcher.py simtutor/launcher_settings.py simtutor/launcher_processes.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

## Review
- Reviewed with two Codex subagents.
- Fixed review findings around stdout blocking, non-finite timeout JSON, missing profiles, tools entry path, tkinter failure mode, fake process escaping, and GUI process injection.

Closes #364