### PR TITLE
Add launcher installer preflight validation

### DIFF
--- a/adapters/dcs/installer.py
+++ b/adapters/dcs/installer.py
@@ -1,0 +1,28 @@
+"""DCS installer facade used by application-facing launcher code."""
+
+from __future__ import annotations
+
+from tools.install_dcs_hook import (
+    DEFAULT_OVERLAY_ACK_PORT,
+    DEFAULT_OVERLAY_COMMAND_PORT,
+    DEFAULT_OVERLAY_HILITE_SLOT_COUNT,
+    DEFAULT_TUTOR_TEXT_PORT,
+    MONITOR_SETUP_BASENAME,
+    SIMTUTOR_EXPORT_SNIPPET,
+    InstallResult,
+    resolve_saved_games_dir,
+    run_install,
+)
+
+
+__all__ = [
+    "DEFAULT_OVERLAY_ACK_PORT",
+    "DEFAULT_OVERLAY_COMMAND_PORT",
+    "DEFAULT_OVERLAY_HILITE_SLOT_COUNT",
+    "DEFAULT_TUTOR_TEXT_PORT",
+    "MONITOR_SETUP_BASENAME",
+    "SIMTUTOR_EXPORT_SNIPPET",
+    "InstallResult",
+    "resolve_saved_games_dir",
+    "run_install",
+]

--- a/simtutor/launcher.py
+++ b/simtutor/launcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Callable
+from typing import Any, Callable
 
 try:
     import tkinter as tk
@@ -19,6 +19,7 @@ else:
     _TK_IMPORT_ERROR = None
 
 from simtutor.launcher_processes import LauncherProcess, ProcessState
+from simtutor.launcher_preflight import run_launcher_install, run_preflight
 from simtutor.launcher_settings import (
     LauncherSettings,
     LauncherSettingsError,
@@ -127,15 +128,16 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
     def _build_buttons(self) -> None:
         frame = ttk.Frame(self)
         frame.grid(row=2, column=0, sticky="ew", pady=(10, 0))
-        frame.columnconfigure(8, weight=1)
+        frame.columnconfigure(9, weight=1)
         ttk.Button(frame, text="Load", command=self._load).grid(row=0, column=0, padx=(0, 6))
         ttk.Button(frame, text="Save", command=self._save).grid(row=0, column=1, padx=(0, 6))
         ttk.Button(frame, text="Save Profile", command=self._save_profile).grid(row=0, column=2, padx=(0, 6))
         ttk.Button(frame, text="Load Profile", command=self._load_profile).grid(row=0, column=3, padx=(0, 18))
         ttk.Button(frame, text="Start", command=self._start).grid(row=0, column=4, padx=(0, 6))
         ttk.Button(frame, text="Stop", command=self._stop).grid(row=0, column=5, padx=(0, 18))
-        ttk.Button(frame, text="Preflight", command=self._placeholder_preflight).grid(row=0, column=6, padx=(0, 6))
-        ttk.Button(frame, text="Export", command=self._placeholder_export).grid(row=0, column=7, padx=(0, 6))
+        ttk.Button(frame, text="Install", command=self._install).grid(row=0, column=6, padx=(0, 6))
+        ttk.Button(frame, text="Preflight", command=self._preflight).grid(row=0, column=7, padx=(0, 6))
+        ttk.Button(frame, text="Export", command=self._placeholder_export).grid(row=0, column=8, padx=(0, 6))
 
     def _build_log_area(self) -> None:
         frame = ttk.LabelFrame(self, text="Process log", padding=10)
@@ -242,8 +244,32 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
         self.log_text.insert("end", text + "\n")
         self.log_text.see("end")
 
-    def _placeholder_preflight(self) -> None:
-        self._append_log("preflight placeholder: installer/preflight is out of scope for this MVP")
+    def _install(self) -> None:
+        try:
+            settings = self._collect_settings()
+            summary = _run_install_action(settings)
+        except Exception as exc:
+            assert messagebox is not None
+            messagebox.showerror("Install failed", str(exc))
+            self._append_log(f"install failed: {exc}")
+            return
+        self.settings = settings
+        self._append_log(summary)
+
+    def _preflight(self) -> None:
+        try:
+            settings = self._collect_settings()
+        except LauncherSettingsError as exc:
+            assert messagebox is not None
+            messagebox.showerror("Preflight failed", str(exc))
+            self._append_log(f"preflight failed: {exc}")
+            return
+        self.settings = settings
+        report, text = _run_preflight_action(settings)
+        self._append_log(text)
+        if not report.ok:
+            assert messagebox is not None
+            messagebox.showwarning("Preflight found issues", "See the process log for details.")
 
     def _placeholder_export(self) -> None:
         self._append_log("export placeholder: experiment export implementation is out of scope for this MVP")
@@ -263,6 +289,29 @@ def _fake_process_command(settings: LauncherSettings) -> list[str]:
         "time.sleep(0.2)"
     )
     return [sys.executable, "-u", "-c", script]
+
+
+def _run_install_action(
+    settings: LauncherSettings,
+    installer: Callable[[LauncherSettings], Any] = run_launcher_install,
+) -> str:
+    result = installer(settings)
+    return (
+        "install complete: "
+        f"files_copied={result.files_copied}, "
+        f"export_patched={result.export_patched}, "
+        f"config_written={result.config_written}, "
+        f"monitor_setup_written={result.monitor_setup_written}, "
+        f"vlm_frame_enabled={result.vlm_frame_enabled}"
+    )
+
+
+def _run_preflight_action(
+    settings: LauncherSettings,
+    runner: Callable[[LauncherSettings], Any] = run_preflight,
+) -> tuple[Any, str]:
+    report = runner(settings)
+    return report, "preflight report:\n" + report.to_text()
 
 
 def main() -> int:

--- a/simtutor/launcher_preflight.py
+++ b/simtutor/launcher_preflight.py
@@ -1,0 +1,303 @@
+"""Installer and preflight helpers for the SimTutor experiment launcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import socket
+import tempfile
+from typing import Callable, Iterable
+
+from adapters.dcs.overlay.config import inspect_overlay_config
+from adapters.dcs.installer import (
+    DEFAULT_OVERLAY_ACK_PORT,
+    DEFAULT_OVERLAY_COMMAND_PORT,
+    DEFAULT_OVERLAY_HILITE_SLOT_COUNT,
+    DEFAULT_TUTOR_TEXT_PORT,
+    MONITOR_SETUP_BASENAME,
+    SIMTUTOR_EXPORT_SNIPPET,
+    InstallResult,
+    resolve_saved_games_dir,
+    run_install,
+)
+from adapters.vision_capture_trigger import DEFAULT_VISION_CAPTURE_TRIGGER_PORT
+from simtutor.launcher_settings import LauncherSettings
+
+
+TELEMETRY_PORT = 7780
+HANDSHAKE_PORT = 7793
+
+
+@dataclass(frozen=True)
+class RequiredPort:
+    name: str
+    host: str
+    port: int
+    protocol: str = "udp"
+
+
+REQUIRED_PORTS = (
+    RequiredPort("dcs_telemetry", "127.0.0.1", TELEMETRY_PORT),
+    RequiredPort("overlay_command", "127.0.0.1", DEFAULT_OVERLAY_COMMAND_PORT),
+    RequiredPort("overlay_ack", "127.0.0.1", DEFAULT_OVERLAY_ACK_PORT),
+    RequiredPort("tutor_text", "127.0.0.1", DEFAULT_TUTOR_TEXT_PORT),
+    RequiredPort("dcs_handshake", "127.0.0.1", HANDSHAKE_PORT),
+    RequiredPort("vision_capture_trigger", "127.0.0.1", DEFAULT_VISION_CAPTURE_TRIGGER_PORT),
+)
+
+
+@dataclass(frozen=True)
+class PreflightEntry:
+    status: str
+    code: str
+    message: str
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    entries: tuple[PreflightEntry, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(entry.status != "error" for entry in self.entries)
+
+    def to_text(self) -> str:
+        lines: list[str] = []
+        for entry in self.entries:
+            suffix = f" ({entry.path})" if entry.path is not None else ""
+            lines.append(f"{entry.status.upper()} {entry.code}: {entry.message}{suffix}")
+        return "\n".join(lines)
+
+
+PortChecker = Callable[[RequiredPort], bool]
+
+
+def run_launcher_install(
+    settings: LauncherSettings,
+    *,
+    source_root: str | Path | None = None,
+    main_width: int | None = None,
+    main_height: int | None = None,
+    installer: Callable[..., InstallResult] = run_install,
+) -> InstallResult:
+    saved_games_dir = _saved_games_dir(settings)
+
+    return installer(
+        source_root=Path(source_root).expanduser() if source_root is not None else _repo_root(),
+        saved_games_dir=saved_games_dir,
+        install_export=True,
+        install_composite_panel=True,
+        main_width=main_width,
+        main_height=main_height,
+        monitor_mode=settings.monitor_mode,
+    )
+
+
+def run_preflight(
+    settings: LauncherSettings,
+    *,
+    port_checker: PortChecker | None = None,
+    required_ports: Iterable[RequiredPort] = REQUIRED_PORTS,
+) -> PreflightReport:
+    entries: list[PreflightEntry] = []
+    saved_games_dir = _saved_games_dir(settings)
+
+    _check_directory_exists(entries, "saved_games_exists", saved_games_dir, "Saved Games directory exists")
+    _check_export_snippet(entries, saved_games_dir / "Scripts" / "Export.lua")
+    _check_required_file(
+        entries,
+        "simtutor_lua_exists",
+        saved_games_dir / "Scripts" / "SimTutor" / "SimTutor.lua",
+        "Scripts/SimTutor/SimTutor.lua exists",
+    )
+    _check_required_file(
+        entries,
+        "simtutor_function_lua_exists",
+        saved_games_dir / "Scripts" / "SimTutor" / "SimTutor Function.lua",
+        "Scripts/SimTutor/SimTutor Function.lua exists",
+    )
+    _check_required_file(
+        entries,
+        "simtutor_highlight_lua_exists",
+        saved_games_dir / "Scripts" / "Hooks" / "SimTutorHighlight.lua",
+        "Scripts/Hooks/SimTutorHighlight.lua exists",
+    )
+    config_path = saved_games_dir / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
+    _check_required_file(
+        entries,
+        "simtutor_config_lua_exists",
+        config_path,
+        "Scripts/SimTutor/SimTutorConfig.lua exists",
+    )
+    _check_required_file(
+        entries,
+        "monitor_setup_lua_exists",
+        saved_games_dir / "Config" / "MonitorSetup" / f"{MONITOR_SETUP_BASENAME}.lua",
+        "monitor setup Lua exists",
+    )
+    _check_overlay_slots(entries, config_path)
+    _check_output_directory(entries, settings.output_log_directory)
+    _check_ports(entries, required_ports, port_checker or port_is_available)
+    _check_metadata(entries, settings)
+    return PreflightReport(tuple(entries))
+
+
+def port_is_available(required: RequiredPort) -> bool:
+    protocol = required.protocol.lower()
+    if protocol == "udp":
+        socket_type = socket.SOCK_DGRAM
+    elif protocol == "tcp":
+        socket_type = socket.SOCK_STREAM
+    else:
+        raise ValueError(f"unsupported port protocol: {required.protocol}")
+
+    with socket.socket(socket.AF_INET, socket_type) as sock:
+        try:
+            sock.bind((required.host, required.port))
+        except OSError:
+            return False
+    return True
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _saved_games_dir(settings: LauncherSettings) -> Path:
+    raw = settings.saved_games_path
+    saved_games = raw.strip() if isinstance(raw, str) and raw.strip() else None
+    return resolve_saved_games_dir(saved_games, settings.dcs_variant)
+
+
+def _pass(code: str, message: str, path: Path | None = None) -> PreflightEntry:
+    return PreflightEntry(status="pass", code=code, message=message, path=path)
+
+
+def _warn(code: str, message: str, path: Path | None = None) -> PreflightEntry:
+    return PreflightEntry(status="warn", code=code, message=message, path=path)
+
+
+def _error(code: str, message: str, path: Path | None = None) -> PreflightEntry:
+    return PreflightEntry(status="error", code=code, message=message, path=path)
+
+
+def _check_directory_exists(entries: list[PreflightEntry], code: str, path: Path, pass_message: str) -> None:
+    if path.is_dir():
+        entries.append(_pass(code, pass_message, path))
+    else:
+        entries.append(_error(code, f"missing directory: {path}", path))
+
+
+def _check_required_file(entries: list[PreflightEntry], code: str, path: Path, pass_message: str) -> None:
+    if path.is_file():
+        entries.append(_pass(code, pass_message, path))
+    else:
+        entries.append(_error(code, f"missing file: {path.name}", path))
+
+
+def _check_export_snippet(entries: list[PreflightEntry], export_path: Path) -> None:
+    if not export_path.is_file():
+        entries.append(_error("export_lua_contains_simtutor_snippet", "missing Export.lua", export_path))
+        return
+    try:
+        content = export_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        entries.append(_error("export_lua_contains_simtutor_snippet", "Export.lua is not valid UTF-8", export_path))
+        return
+    if SIMTUTOR_EXPORT_SNIPPET in content:
+        entries.append(
+            _pass(
+                "export_lua_contains_simtutor_snippet",
+                "Scripts/Export.lua contains the SimTutor snippet",
+                export_path,
+            )
+        )
+    else:
+        entries.append(
+            _error(
+                "export_lua_contains_simtutor_snippet",
+                "Scripts/Export.lua does not contain the SimTutor snippet",
+                export_path,
+            )
+        )
+
+
+def _check_overlay_slots(entries: list[PreflightEntry], config_path: Path) -> None:
+    inspection = inspect_overlay_config(config_path)
+    if not inspection.exists:
+        entries.append(_error("overlay_hilite_slots", "SimTutorConfig.lua is missing", config_path))
+        return
+
+    slot_count = inspection.declared_slot_count
+    required_count = DEFAULT_OVERLAY_HILITE_SLOT_COUNT
+    if inspection.hilite_ids_declared and slot_count >= required_count:
+        entries.append(
+            _pass(
+                "overlay_hilite_slots",
+                f"overlay.hilite_ids exposes {slot_count} highlight slots",
+                config_path,
+            )
+        )
+    else:
+        entries.append(
+            _error(
+                "overlay_hilite_slots",
+                f"overlay.hilite_ids exposes {slot_count} highlight slots; at least {required_count} required",
+                config_path,
+            )
+        )
+
+
+def _check_output_directory(entries: list[PreflightEntry], raw_path: str) -> None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        entries.append(_error("output_log_directory_writable", "output log directory is required"))
+        return
+    path = Path(raw_path).expanduser()
+    if not path.is_dir():
+        entries.append(_error("output_log_directory_writable", f"missing output log directory: {path}", path))
+        return
+    try:
+        with tempfile.NamedTemporaryFile(prefix=".simtutor-preflight-", dir=path):
+            pass
+    except OSError as exc:
+        entries.append(_error("output_log_directory_writable", f"output log directory is not writable: {exc}", path))
+        return
+    entries.append(_pass("output_log_directory_writable", "output log directory is writable", path))
+
+
+def _check_ports(entries: list[PreflightEntry], required_ports: Iterable[RequiredPort], checker: PortChecker) -> None:
+    for required in required_ports:
+        code = f"port_{required.name}_available"
+        try:
+            available = checker(required)
+        except Exception as exc:
+            entries.append(_warn(code, f"could not verify {required.protocol.upper()} port {required.port}: {exc}"))
+            continue
+        if available:
+            entries.append(_pass(code, f"{required.protocol.upper()} port {required.port} is available"))
+        else:
+            entries.append(_error(code, f"{required.protocol.upper()} port {required.port} is already occupied"))
+
+
+def _check_metadata(entries: list[PreflightEntry], settings: LauncherSettings) -> None:
+    missing = [
+        name
+        for name in ("participant_id", "condition", "trial_id")
+        if not isinstance(getattr(settings, name), str) or not getattr(settings, name).strip()
+    ]
+    if missing:
+        entries.append(_error("experiment_metadata_filled", "missing formal-run metadata: " + ", ".join(missing)))
+    else:
+        entries.append(_pass("experiment_metadata_filled", "participant, condition, and trial metadata are filled"))
+
+
+__all__ = [
+    "PreflightEntry",
+    "PreflightReport",
+    "REQUIRED_PORTS",
+    "RequiredPort",
+    "port_is_available",
+    "run_launcher_install",
+    "run_preflight",
+]

--- a/tests/test_launcher_preflight.py
+++ b/tests/test_launcher_preflight.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from pathlib import Path
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+from simtutor.launcher import _run_install_action, _run_preflight_action
+from simtutor.launcher_preflight import (
+    PreflightEntry,
+    PreflightReport,
+    REQUIRED_PORTS,
+    RequiredPort,
+    run_launcher_install,
+    run_preflight,
+)
+from simtutor.launcher_settings import LauncherSettings
+from tools.install_dcs_hook import MONITOR_SETUP_BASENAME, SIMTUTOR_EXPORT_SNIPPET
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _settings(tmp_path: Path) -> LauncherSettings:
+    saved_games_dir = tmp_path / "Saved Games" / "DCS"
+    (tmp_path / "logs").mkdir()
+    return LauncherSettings(
+        saved_games_path=str(saved_games_dir),
+        dcs_variant="DCS",
+        monitor_mode="extended-right",
+        output_log_directory=str(tmp_path / "logs"),
+        participant_id="P01",
+        condition="with_tutor",
+        trial_id="T01",
+        max_overlay_targets=2,
+    )
+
+
+def _write_repo_scripting_files(repo_root: Path) -> None:
+    _write(repo_root / "DCS" / "Scripts" / "SimTutor" / "SimTutor.lua", "-- SimTutor main\n")
+    _write(repo_root / "DCS" / "Scripts" / "SimTutor" / "SimTutor Function.lua", "-- functions\n")
+    _write(repo_root / "DCS" / "Scripts" / "Hooks" / "SimTutorHighlight.lua", "-- highlight\n")
+
+
+def _write_installed_tree(saved_games_dir: Path) -> None:
+    _write(saved_games_dir / "Scripts" / "Export.lua", SIMTUTOR_EXPORT_SNIPPET + "\n")
+    _write(saved_games_dir / "Scripts" / "SimTutor" / "SimTutor.lua", "-- SimTutor main\n")
+    _write(saved_games_dir / "Scripts" / "SimTutor" / "SimTutor Function.lua", "-- functions\n")
+    _write(saved_games_dir / "Scripts" / "Hooks" / "SimTutorHighlight.lua", "-- highlight\n")
+    _write(
+        saved_games_dir / "Scripts" / "SimTutor" / "SimTutorConfig.lua",
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_ids = {9101, 9102, 9103, 9104},\n"
+        "    },\n"
+        "}\n",
+    )
+    _write(saved_games_dir / "Config" / "MonitorSetup" / f"{MONITOR_SETUP_BASENAME}.lua", "-- monitor\n")
+
+
+def _entry_by_code(report, code: str):
+    return next(entry for entry in report.entries if entry.code == code)
+
+
+def test_preflight_reports_installed_tree_as_pass(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    saved_games_dir = Path(settings.saved_games_path)
+    _write_installed_tree(saved_games_dir)
+
+    report = run_preflight(settings, port_checker=lambda _port: True)
+
+    assert report.ok is True
+    assert {entry.status for entry in report.entries} == {"pass"}
+    assert "PASS saved_games_exists" in report.to_text()
+
+
+def test_preflight_reports_missing_required_file(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    saved_games_dir = Path(settings.saved_games_path)
+    _write_installed_tree(saved_games_dir)
+    (saved_games_dir / "Scripts" / "SimTutor" / "SimTutor Function.lua").unlink()
+
+    report = run_preflight(settings, port_checker=lambda _port: True)
+
+    entry = _entry_by_code(report, "simtutor_function_lua_exists")
+    assert report.ok is False
+    assert entry.status == "error"
+    assert "SimTutor Function.lua" in entry.message
+
+
+def test_preflight_requires_exact_export_snippet(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    saved_games_dir = Path(settings.saved_games_path)
+    _write_installed_tree(saved_games_dir)
+    _write(
+        saved_games_dir / "Scripts" / "Export.lua",
+        "-- mentions Scripts/SimTutor/SimTutor.lua but does not install the hook\n",
+    )
+
+    report = run_preflight(settings, port_checker=lambda _port: True)
+
+    entry = _entry_by_code(report, "export_lua_contains_simtutor_snippet")
+    assert report.ok is False
+    assert entry.status == "error"
+
+
+def test_preflight_reports_missing_highlight_slots(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    saved_games_dir = Path(settings.saved_games_path)
+    _write_installed_tree(saved_games_dir)
+    _write(
+        saved_games_dir / "Scripts" / "SimTutor" / "SimTutorConfig.lua",
+        "return {\n"
+        "    overlay = {\n"
+        "        hilite_ids = {9101, 9102},\n"
+        "    },\n"
+        "}\n",
+    )
+
+    report = run_preflight(settings, port_checker=lambda _port: True)
+
+    entry = _entry_by_code(report, "overlay_hilite_slots")
+    assert report.ok is False
+    assert entry.status == "error"
+    assert "2" in entry.message
+    assert "4" in entry.message
+
+
+def test_preflight_reports_port_conflict(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    saved_games_dir = Path(settings.saved_games_path)
+    _write_installed_tree(saved_games_dir)
+    conflicted = next(port for port in REQUIRED_PORTS if port.name == "overlay_command")
+
+    def fake_port_checker(port) -> bool:
+        return port != conflicted
+
+    report = run_preflight(settings, port_checker=fake_port_checker)
+
+    entry = _entry_by_code(report, "port_overlay_command_available")
+    assert report.ok is False
+    assert entry.status == "error"
+    assert str(conflicted.port) in entry.message
+
+
+def test_preflight_reports_real_udp_port_conflict(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    saved_games_dir = Path(settings.saved_games_path)
+    _write_installed_tree(saved_games_dir)
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    except PermissionError as exc:
+        pytest.skip(f"socket creation is not permitted in this environment: {exc}")
+    with sock:
+        try:
+            sock.bind(("127.0.0.1", 0))
+        except PermissionError as exc:
+            pytest.skip(f"socket bind is not permitted in this environment: {exc}")
+        occupied_port = int(sock.getsockname()[1])
+
+        report = run_preflight(
+            settings,
+            required_ports=(RequiredPort("demo", "127.0.0.1", occupied_port),),
+        )
+
+    entry = _entry_by_code(report, "port_demo_available")
+    assert report.ok is False
+    assert entry.status == "error"
+    assert str(occupied_port) in entry.message
+
+
+def test_launcher_install_reuses_existing_installers(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    repo_root = tmp_path / "repo"
+    _write_repo_scripting_files(repo_root)
+
+    result = run_launcher_install(
+        settings,
+        source_root=repo_root,
+        main_width=1920,
+        main_height=1080,
+    )
+
+    saved_games_dir = Path(settings.saved_games_path)
+    assert result.files_copied is True
+    assert result.export_patched is True
+    assert result.config_path == saved_games_dir / "Scripts" / "SimTutor" / "SimTutorConfig.lua"
+    assert result.monitor_setup_path == saved_games_dir / "Config" / "MonitorSetup" / f"{MONITOR_SETUP_BASENAME}.lua"
+    assert SIMTUTOR_EXPORT_SNIPPET in (saved_games_dir / "Scripts" / "Export.lua").read_text(encoding="utf-8")
+
+
+def test_launcher_install_action_formats_summary_without_process_start(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    calls: list[LauncherSettings] = []
+
+    def fake_installer(received: LauncherSettings):
+        calls.append(received)
+        return SimpleNamespace(
+            files_copied=True,
+            export_patched=False,
+            config_written=True,
+            monitor_setup_written=True,
+            vlm_frame_enabled=True,
+        )
+
+    summary = _run_install_action(settings, installer=fake_installer)
+
+    assert calls == [settings]
+    assert "install complete" in summary
+    assert "files_copied=True" in summary
+    assert "vlm_frame_enabled=True" in summary
+
+
+def test_launcher_preflight_action_formats_report_without_process_start(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    report = PreflightReport((PreflightEntry("pass", "demo", "ready"),))
+    calls: list[LauncherSettings] = []
+
+    def fake_runner(received: LauncherSettings) -> PreflightReport:
+        calls.append(received)
+        return report
+
+    returned, text = _run_preflight_action(settings, runner=fake_runner)
+
+    assert calls == [settings]
+    assert returned is report
+    assert text == "preflight report:\nPASS demo: ready"


### PR DESCRIPTION
## Summary
- Add launcher preflight validation with structured pass/warn/error entries for DCS install files, overlay slots, writable output dir, ports, and formal-run metadata.
- Add launcher install/preflight actions that reuse the existing DCS installer path without starting live-dcs.
- Add an adapter-facing installer facade and focused tests for installed, missing-file, missing-highlight-slot, port-conflict, and launcher action behavior.

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_launcher_preflight.py tests/test_launcher_entry.py tests/test_launcher_settings.py tests/test_launcher_processes.py tests/test_install_dcs_hook.py tests/test_install_dcs_monitor_setup.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #365