### PR TITLE
Add launcher remote model profiles

### DIFF
--- a/simtutor/launcher.py
+++ b/simtutor/launcher.py
@@ -19,6 +19,7 @@ else:
     _TK_IMPORT_ERROR = None
 
 from simtutor.launcher_processes import LauncherProcess, ProcessState
+from simtutor.launcher_model_check import validate_launcher_model_profile
 from simtutor.launcher_preflight import run_launcher_install, run_preflight
 from simtutor.launcher_settings import (
     LauncherSettings,
@@ -29,6 +30,7 @@ from simtutor.launcher_settings import (
     save_settings,
     validate_settings,
 )
+from simtutor.launcher_tunnel import LauncherTunnel
 
 
 NORMAL_FIELDS = (
@@ -45,12 +47,21 @@ NORMAL_FIELDS = (
 
 ADVANCED_FIELDS = (
     ("model_provider", "Model provider"),
+    ("model_profile_mode", "Model profile mode"),
     ("model_base_url", "Model base URL"),
     ("text_model_name", "Text model name"),
     ("vision_model_name", "Vision model name"),
     ("model_timeout_s", "Model timeout"),
+    ("model_enable_multimodal", "VLM facts enabled"),
     ("max_overlay_targets", "Max overlay targets"),
     ("ssh_tunnel_profile", "SSH tunnel profile"),
+    ("ssh_executable_path", "SSH executable path"),
+    ("ssh_user", "SSH user"),
+    ("ssh_host", "SSH host"),
+    ("ssh_local_port", "SSH local port"),
+    ("ssh_remote_host", "SSH remote host"),
+    ("ssh_remote_port", "SSH remote port"),
+    ("ssh_identity_file_path", "SSH identity file path"),
     ("preflight_profile", "Preflight profile"),
     ("export_profile", "Export profile"),
 )
@@ -81,6 +92,7 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
             for name in ("DCS", "model", "tunnel", "tutor", "vision")
         }
         self.process: LauncherProcess | None = None
+        self.tunnel: LauncherTunnel | None = None
 
         master.title("SimTutor Experiment Launcher")
         master.minsize(860, 620)
@@ -128,7 +140,7 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
     def _build_buttons(self) -> None:
         frame = ttk.Frame(self)
         frame.grid(row=2, column=0, sticky="ew", pady=(10, 0))
-        frame.columnconfigure(9, weight=1)
+        frame.columnconfigure(10, weight=1)
         ttk.Button(frame, text="Load", command=self._load).grid(row=0, column=0, padx=(0, 6))
         ttk.Button(frame, text="Save", command=self._save).grid(row=0, column=1, padx=(0, 6))
         ttk.Button(frame, text="Save Profile", command=self._save_profile).grid(row=0, column=2, padx=(0, 6))
@@ -137,7 +149,8 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
         ttk.Button(frame, text="Stop", command=self._stop).grid(row=0, column=5, padx=(0, 18))
         ttk.Button(frame, text="Install", command=self._install).grid(row=0, column=6, padx=(0, 6))
         ttk.Button(frame, text="Preflight", command=self._preflight).grid(row=0, column=7, padx=(0, 6))
-        ttk.Button(frame, text="Export", command=self._placeholder_export).grid(row=0, column=8, padx=(0, 6))
+        ttk.Button(frame, text="Validate Model", command=self._validate_model).grid(row=0, column=8, padx=(0, 6))
+        ttk.Button(frame, text="Export", command=self._placeholder_export).grid(row=0, column=9, padx=(0, 6))
 
     def _build_log_area(self) -> None:
         frame = ttk.LabelFrame(self, text="Process log", padding=10)
@@ -228,6 +241,9 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
     def _stop(self) -> None:
         if self.process is not None:
             self.process.stop()
+        if self.tunnel is not None:
+            self.tunnel.stop()
+            self.status_variables["tunnel"].set("stopped")
         self.status_variables["tutor"].set("stopped")
 
     def _poll_process(self) -> None:
@@ -271,6 +287,28 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
             assert messagebox is not None
             messagebox.showwarning("Preflight found issues", "See the process log for details.")
 
+    def _validate_model(self) -> None:
+        try:
+            settings = self._collect_settings()
+            validate_settings(settings)
+            if settings.model_profile_mode == "remote_tunnel":
+                if self.tunnel is None or not self.tunnel.snapshot().running:
+                    self.tunnel = LauncherTunnel(settings)
+                    self.tunnel.start()
+                self.status_variables["tunnel"].set("running")
+            report, text = _run_model_check_action(settings)
+        except Exception as exc:
+            assert messagebox is not None
+            messagebox.showerror("Model validation failed", str(exc))
+            self._append_log(f"model validation failed: {exc}")
+            return
+        self.settings = settings
+        self.status_variables["model"].set(settings.model_profile_mode)
+        self._append_log(text)
+        if not report.ok:
+            assert messagebox is not None
+            messagebox.showwarning("Model validation found issues", "See the process log for details.")
+
     def _placeholder_export(self) -> None:
         self._append_log("export placeholder: experiment export implementation is out of scope for this MVP")
 
@@ -312,6 +350,14 @@ def _run_preflight_action(
 ) -> tuple[Any, str]:
     report = runner(settings)
     return report, "preflight report:\n" + report.to_text()
+
+
+def _run_model_check_action(
+    settings: LauncherSettings,
+    runner: Callable[[LauncherSettings], Any] = validate_launcher_model_profile,
+) -> tuple[Any, str]:
+    report = runner(settings)
+    return report, "model validation report:\n" + report.to_text()
 
 
 def main() -> int:

--- a/simtutor/launcher_model_check.py
+++ b/simtutor/launcher_model_check.py
@@ -1,0 +1,156 @@
+"""Remote model endpoint validation for the SimTutor launcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from simtutor.launcher_settings import LauncherSettings
+
+
+@dataclass(frozen=True)
+class ModelCheckEntry:
+    status: str
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ModelCheckReport:
+    entries: tuple[ModelCheckEntry, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(entry.status != "error" for entry in self.entries)
+
+    def to_text(self) -> str:
+        return "\n".join(f"{entry.status.upper()} {entry.code}: {entry.message}" for entry in self.entries)
+
+
+@dataclass(frozen=True)
+class ModelEndpointConfig:
+    base_url: str
+    text_model_name: str
+    vision_model_name: str
+    require_vision_model: bool
+    timeout_s: float
+
+
+def validate_launcher_model_profile(settings: LauncherSettings, *, client: Any | None = None) -> ModelCheckReport:
+    if settings.model_profile_mode == "local_stub":
+        return ModelCheckReport((ModelCheckEntry("pass", "model_profile_local_stub", "local stub profile selected"),))
+    report = check_model_endpoint(endpoint_config_from_settings(settings), client=client)
+    if settings.model_profile_mode == "remote_tunnel" and _has_endpoint_error(report):
+        return ModelCheckReport(
+            (
+                *report.entries,
+                ModelCheckEntry(
+                    "warn",
+                    "ssh_key_auth_hint",
+                    "SSH key authentication must be configured; launcher password prompts are disabled.",
+                ),
+            )
+        )
+    return report
+
+
+def endpoint_config_from_settings(settings: LauncherSettings) -> ModelEndpointConfig:
+    base_url = settings.model_base_url
+    if settings.model_profile_mode == "remote_tunnel" and not str(base_url).strip():
+        base_url = f"http://127.0.0.1:{int(settings.ssh_local_port)}"
+    return ModelEndpointConfig(
+        base_url=_normalize_base_url(str(base_url)),
+        text_model_name=settings.text_model_name,
+        vision_model_name=settings.vision_model_name,
+        require_vision_model=bool(settings.model_enable_multimodal),
+        timeout_s=float(settings.model_timeout_s),
+    )
+
+
+def check_model_endpoint(config: ModelEndpointConfig, *, client: Any | None = None) -> ModelCheckReport:
+    owns_client = client is None
+    http_client = client or _make_http_client()
+    entries: list[ModelCheckEntry] = []
+    base_url = _normalize_base_url(config.base_url)
+
+    try:
+        try:
+            response = http_client.get(f"{base_url}/health", timeout=config.timeout_s)
+            response.raise_for_status()
+        except Exception as exc:
+            entries.append(ModelCheckEntry("error", "endpoint_health", f"GET /health failed: {exc}"))
+            return ModelCheckReport(tuple(entries))
+        entries.append(ModelCheckEntry("pass", "endpoint_health", "GET /health succeeded"))
+
+        try:
+            response = http_client.get(f"{base_url}/v1/models", timeout=config.timeout_s)
+            response.raise_for_status()
+            model_ids = _extract_model_ids(response.json())
+        except Exception as exc:
+            entries.append(ModelCheckEntry("error", "endpoint_models", f"GET /v1/models failed: {exc}"))
+            return ModelCheckReport(tuple(entries))
+        entries.append(ModelCheckEntry("pass", "endpoint_models", f"GET /v1/models returned {len(model_ids)} models"))
+
+        text_name = config.text_model_name.strip()
+        if text_name in model_ids:
+            entries.append(ModelCheckEntry("pass", "text_model_available", f"text model available: {text_name}"))
+        else:
+            entries.append(ModelCheckEntry("error", "text_model_available", f"missing text model: {text_name}"))
+
+        vision_name = config.vision_model_name.strip()
+        if config.require_vision_model:
+            if vision_name in model_ids:
+                entries.append(ModelCheckEntry("pass", "vision_model_available", f"vision model available: {vision_name}"))
+            else:
+                entries.append(ModelCheckEntry("error", "vision_model_available", f"missing vision model: {vision_name}"))
+        return ModelCheckReport(tuple(entries))
+    finally:
+        if owns_client and hasattr(http_client, "close"):
+            http_client.close()
+
+
+def _normalize_base_url(raw: str) -> str:
+    value = raw.strip().rstrip("/")
+    if value.lower().endswith("/v1"):
+        value = value[:-3].rstrip("/")
+    if not value:
+        raise ValueError("model base URL is required")
+    return value
+
+
+def _extract_model_ids(body: Any) -> set[str]:
+    if not isinstance(body, Mapping):
+        raise ValueError("models response must be a JSON object")
+    data = body.get("data")
+    if not isinstance(data, list):
+        raise ValueError("models response must include a data list")
+    ids: set[str] = set()
+    for item in data:
+        if isinstance(item, Mapping) and isinstance(item.get("id"), str):
+            ids.add(item["id"])
+    return ids
+
+
+def _has_endpoint_error(report: ModelCheckReport) -> bool:
+    return any(
+        entry.status == "error" and entry.code in {"endpoint_health", "endpoint_models"}
+        for entry in report.entries
+    )
+
+
+def _make_http_client() -> Any:
+    try:
+        import httpx
+    except ModuleNotFoundError as exc:
+        raise RuntimeError("httpx is required when no client is injected") from exc
+    return httpx.Client()
+
+
+__all__ = [
+    "ModelCheckEntry",
+    "ModelCheckReport",
+    "ModelEndpointConfig",
+    "check_model_endpoint",
+    "endpoint_config_from_settings",
+    "validate_launcher_model_profile",
+]

--- a/simtutor/launcher_settings.py
+++ b/simtutor/launcher_settings.py
@@ -18,6 +18,7 @@ PROFILES_DIR_NAME = "profiles"
 
 SUPPORTED_LANGUAGES = ("zh", "en")
 SUPPORTED_MODEL_PROVIDERS = ("stub", "openai_compat", "ollama")
+SUPPORTED_MODEL_PROFILE_MODES = ("local_stub", "remote_direct", "remote_tunnel")
 
 _SECRET_KEY_FRAGMENTS = ("api_key", "token", "password", "secret")
 
@@ -38,12 +39,21 @@ class LauncherSettings:
     condition: str = ""
     trial_id: str = ""
     model_provider: str = "stub"
+    model_profile_mode: str = "local_stub"
     model_base_url: str = ""
     text_model_name: str = "Qwen3-8B-Instruct"
     vision_model_name: str = "simtutor-vision"
     model_timeout_s: float = 20.0
+    model_enable_multimodal: bool = False
     max_overlay_targets: int = 1
     ssh_tunnel_profile: str = ""
+    ssh_executable_path: str = ""
+    ssh_user: str = ""
+    ssh_host: str = ""
+    ssh_local_port: int = 16324
+    ssh_remote_host: str = "127.0.0.1"
+    ssh_remote_port: int = 6324
+    ssh_identity_file_path: str = ""
     preflight_profile: str = ""
     export_profile: str = ""
 
@@ -58,6 +68,19 @@ class LauncherSettings:
             settings.max_overlay_targets = int(settings.max_overlay_targets)
         except (TypeError, ValueError) as exc:
             raise LauncherSettingsError("model_timeout_s and max_overlay_targets must be numeric") from exc
+        settings.model_enable_multimodal = _parse_bool(settings.model_enable_multimodal, "model_enable_multimodal")
+        settings.ssh_local_port = _parse_profile_port(
+            settings.ssh_local_port,
+            "ssh_local_port",
+            default=16324,
+            required=settings.model_profile_mode == "remote_tunnel",
+        )
+        settings.ssh_remote_port = _parse_profile_port(
+            settings.ssh_remote_port,
+            "ssh_remote_port",
+            default=6324,
+            required=settings.model_profile_mode == "remote_tunnel",
+        )
         if not math.isfinite(settings.model_timeout_s):
             raise LauncherSettingsError("model_timeout_s must be finite")
         return settings
@@ -141,6 +164,7 @@ def validate_settings(settings: LauncherSettings) -> None:
         "condition",
         "trial_id",
         "model_provider",
+        "model_profile_mode",
         "text_model_name",
         "vision_model_name",
     )
@@ -153,10 +177,17 @@ def validate_settings(settings: LauncherSettings) -> None:
         errors.append("language")
     if settings.model_provider not in SUPPORTED_MODEL_PROVIDERS:
         errors.append("model_provider")
-    if settings.model_provider in {"openai_compat", "ollama"} and (
+    if settings.model_profile_mode not in SUPPORTED_MODEL_PROFILE_MODES:
+        errors.append("model_profile_mode")
+    if settings.model_profile_mode == "remote_direct" and (
         not isinstance(settings.model_base_url, str) or not settings.model_base_url.strip()
     ):
         errors.append("model_base_url")
+    if settings.model_profile_mode == "remote_tunnel":
+        for name in ("ssh_user", "ssh_host", "ssh_remote_host"):
+            value = getattr(settings, name)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(name)
     try:
         timeout_s = float(settings.model_timeout_s)
     except (TypeError, ValueError):
@@ -172,6 +203,15 @@ def validate_settings(settings: LauncherSettings) -> None:
         errors.append("model_timeout_s")
     if max_overlay_targets < 0:
         errors.append("max_overlay_targets")
+    if settings.model_profile_mode == "remote_tunnel":
+        for name in ("ssh_local_port", "ssh_remote_port"):
+            try:
+                port = int(getattr(settings, name))
+            except (TypeError, ValueError):
+                errors.append(name)
+                continue
+            if port <= 0 or port > 65535:
+                errors.append(name)
 
     if errors:
         raise LauncherSettingsError("invalid launcher settings: " + ", ".join(sorted(set(errors))))
@@ -206,6 +246,31 @@ def _reject_secret_keys(payload: Mapping[str, Any]) -> None:
 
 def _reject_json_constant(value: str) -> None:
     raise LauncherSettingsError(f"invalid non-finite JSON number: {value}")
+
+
+def _parse_bool(value: Any, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise LauncherSettingsError(f"{name} must be a boolean")
+
+
+def _parse_profile_port(value: Any, name: str, *, default: int, required: bool) -> int:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        if required:
+            raise LauncherSettingsError(f"{name} must be numeric")
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        if required:
+            raise LauncherSettingsError(f"{name} must be numeric") from exc
+        return default
 
 
 __all__ = [

--- a/simtutor/launcher_tunnel.py
+++ b/simtutor/launcher_tunnel.py
@@ -1,0 +1,181 @@
+"""SSH tunnel management for the SimTutor experiment launcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shutil
+import socket
+import subprocess
+import sys
+from typing import Any, Callable
+
+from simtutor.launcher_settings import LauncherSettings
+
+
+class LauncherTunnelError(RuntimeError):
+    """Raised when the launcher cannot start or stop its SSH tunnel."""
+
+
+PopenFactory = Callable[..., Any]
+PortChecker = Callable[[str, int], bool]
+SshResolver = Callable[[LauncherSettings], str]
+
+
+@dataclass(frozen=True)
+class LauncherTunnelSnapshot:
+    command: tuple[str, ...]
+    running: bool
+    returncode: int | None
+
+
+def tcp_port_is_available(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, int(port)))
+        except OSError:
+            return False
+    return True
+
+
+def resolve_ssh_executable(settings: LauncherSettings) -> str:
+    configured = settings.ssh_executable_path.strip() if isinstance(settings.ssh_executable_path, str) else ""
+    if configured:
+        return configured
+    detected = shutil.which("ssh.exe") or shutil.which("ssh")
+    if detected:
+        return detected
+    return "ssh.exe" if sys.platform == "win32" else "ssh"
+
+
+def build_ssh_tunnel_command(settings: LauncherSettings, *, ssh_executable: str | None = None) -> list[str]:
+    executable = ssh_executable or resolve_ssh_executable(settings)
+    user = _required_text(settings.ssh_user, "ssh_user")
+    host = _required_text(settings.ssh_host, "ssh_host")
+    remote_host = _required_text(settings.ssh_remote_host, "ssh_remote_host")
+    local_port = _required_port(settings.ssh_local_port, "ssh_local_port")
+    remote_port = _required_port(settings.ssh_remote_port, "ssh_remote_port")
+
+    command = [
+        executable,
+        "-N",
+        "-L",
+        f"{local_port}:{remote_host}:{remote_port}",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "BatchMode=yes",
+    ]
+    identity = settings.ssh_identity_file_path.strip() if isinstance(settings.ssh_identity_file_path, str) else ""
+    if identity:
+        command.extend(["-i", identity])
+    command.append(f"{user}@{host}")
+    return command
+
+
+class LauncherTunnel:
+    def __init__(
+        self,
+        settings: LauncherSettings,
+        *,
+        popen_factory: PopenFactory = subprocess.Popen,
+        port_checker: PortChecker = tcp_port_is_available,
+        ssh_resolver: SshResolver = resolve_ssh_executable,
+    ) -> None:
+        self.settings = settings
+        self.popen_factory = popen_factory
+        self.port_checker = port_checker
+        self.ssh_resolver = ssh_resolver
+        self.process: Any | None = None
+        self.command: tuple[str, ...] = ()
+
+    def start(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            raise LauncherTunnelError("launcher-owned SSH tunnel is already running")
+        local_port = _required_port(self.settings.ssh_local_port, "ssh_local_port")
+        if not self.port_checker("127.0.0.1", local_port):
+            raise LauncherTunnelError(f"local TCP port {local_port} is already occupied")
+        command = build_ssh_tunnel_command(self.settings, ssh_executable=self.ssh_resolver(self.settings))
+        self.command = tuple(command)
+        kwargs: dict[str, Any] = {
+            "stdin": subprocess.DEVNULL,
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+            "text": True,
+        }
+        if sys.platform == "win32" and hasattr(subprocess, "CREATE_NO_WINDOW"):
+            kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+        try:
+            self.process = self.popen_factory(command, **kwargs)
+        except OSError as exc:
+            raise LauncherTunnelError(f"could not start SSH tunnel: {exc}") from exc
+        self._raise_if_exited_immediately()
+
+    def stop(self, *, timeout_s: float = 5.0) -> None:
+        if self.process is None:
+            return
+        if self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=timeout_s)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=timeout_s)
+
+    def snapshot(self) -> LauncherTunnelSnapshot:
+        returncode = self.process.poll() if self.process is not None else None
+        return LauncherTunnelSnapshot(
+            command=self.command,
+            running=self.process is not None and returncode is None,
+            returncode=returncode,
+        )
+
+    def _raise_if_exited_immediately(self) -> None:
+        if self.process is None:
+            return
+        returncode = self.process.poll()
+        if returncode is None:
+            return
+        output = _read_process_output(self.process)
+        detail = f": {output}" if output else ""
+        hint = ""
+        lowered = output.lower()
+        if "permission denied" in lowered or "publickey" in lowered or "password" in lowered:
+            hint = " Configure SSH key authentication; launcher password prompts are disabled."
+        raise LauncherTunnelError(f"SSH tunnel exited during startup with code {returncode}{detail}.{hint}")
+
+
+def _required_text(value: str, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise LauncherTunnelError(f"{name} is required")
+    return value.strip()
+
+
+def _required_port(value: int, name: str) -> int:
+    try:
+        port = int(value)
+    except (TypeError, ValueError) as exc:
+        raise LauncherTunnelError(f"{name} must be a TCP port") from exc
+    if port <= 0 or port > 65535:
+        raise LauncherTunnelError(f"{name} must be between 1 and 65535")
+    return port
+
+
+def _read_process_output(process: Any) -> str:
+    stdout = getattr(process, "stdout", None)
+    if stdout is None or not hasattr(stdout, "read"):
+        return ""
+    try:
+        text = stdout.read()
+    except Exception:
+        return ""
+    return str(text).strip()
+
+
+__all__ = [
+    "LauncherTunnel",
+    "LauncherTunnelError",
+    "LauncherTunnelSnapshot",
+    "build_ssh_tunnel_command",
+    "resolve_ssh_executable",
+    "tcp_port_is_available",
+]

--- a/tests/test_launcher_model_check.py
+++ b/tests/test_launcher_model_check.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import Any
+
+from simtutor.launcher_model_check import (
+    ModelEndpointConfig,
+    check_model_endpoint,
+    endpoint_config_from_settings,
+    validate_launcher_model_profile,
+)
+from simtutor.launcher_settings import LauncherSettings
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"http {self.status_code}")
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class FakeClient:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, timeout: float) -> FakeResponse:
+        self.calls.append({"url": url, "timeout": timeout})
+        if not self.responses:
+            raise RuntimeError("no fake response left")
+        return self.responses.pop(0)
+
+
+def test_check_model_endpoint_checks_health_and_models() -> None:
+    client = FakeClient(
+        [
+            FakeResponse({"status": "ok"}),
+            FakeResponse({"data": [{"id": "qwen36_27b"}, {"id": "simtutor-vision"}]}),
+        ]
+    )
+    config = ModelEndpointConfig(
+        base_url="http://localhost:16324",
+        text_model_name="qwen36_27b",
+        vision_model_name="simtutor-vision",
+        require_vision_model=True,
+        timeout_s=3.0,
+    )
+
+    report = check_model_endpoint(config, client=client)
+
+    assert report.ok is True
+    assert [call["url"] for call in client.calls] == [
+        "http://localhost:16324/health",
+        "http://localhost:16324/v1/models",
+    ]
+
+
+def test_check_model_endpoint_reports_missing_model_names() -> None:
+    client = FakeClient(
+        [
+            FakeResponse({"status": "ok"}),
+            FakeResponse({"data": [{"id": "qwen36_27b"}]}),
+        ]
+    )
+    config = ModelEndpointConfig(
+        base_url="http://localhost:16324",
+        text_model_name="missing-text",
+        vision_model_name="missing-vision",
+        require_vision_model=True,
+        timeout_s=3.0,
+    )
+
+    report = check_model_endpoint(config, client=client)
+
+    assert report.ok is False
+    assert "missing text model: missing-text" in report.to_text()
+    assert "missing vision model: missing-vision" in report.to_text()
+
+
+def test_validate_launcher_model_profile_local_stub_skips_remote_endpoint() -> None:
+    settings = LauncherSettings(
+        saved_games_path="C:/Users/test/Saved Games/DCS",
+        output_log_directory="C:/SimTutor/logs",
+        participant_id="P01",
+        condition="with_tutor",
+        trial_id="T01",
+        model_provider="stub",
+        model_profile_mode="local_stub",
+        model_base_url="",
+    )
+    client = FakeClient([])
+
+    report = validate_launcher_model_profile(settings, client=client)
+
+    assert report.ok is True
+    assert "local stub profile selected" in report.to_text()
+    assert client.calls == []
+
+
+def test_remote_tunnel_endpoint_defaults_to_local_forward_port() -> None:
+    settings = LauncherSettings(
+        model_provider="openai_compat",
+        model_profile_mode="remote_tunnel",
+        model_base_url="",
+        ssh_user="pilot",
+        ssh_host="cloud.example.test",
+        ssh_local_port=16324,
+    )
+
+    config = endpoint_config_from_settings(settings)
+
+    assert config.base_url == "http://127.0.0.1:16324"
+
+
+def test_remote_tunnel_endpoint_failure_includes_key_auth_hint() -> None:
+    settings = LauncherSettings(
+        model_provider="openai_compat",
+        model_profile_mode="remote_tunnel",
+        model_base_url="http://localhost:16324",
+        ssh_user="pilot",
+        ssh_host="cloud.example.test",
+    )
+    client = FakeClient([FakeResponse({}, status_code=503)])
+
+    report = validate_launcher_model_profile(settings, client=client)
+
+    assert report.ok is False
+    assert "password prompts are disabled" in report.to_text()
+
+
+def test_remote_tunnel_missing_model_does_not_include_key_auth_hint() -> None:
+    settings = LauncherSettings(
+        model_provider="openai_compat",
+        model_profile_mode="remote_tunnel",
+        model_base_url="http://localhost:16324",
+        text_model_name="missing-text",
+        ssh_user="pilot",
+        ssh_host="cloud.example.test",
+    )
+    client = FakeClient(
+        [
+            FakeResponse({"status": "ok"}),
+            FakeResponse({"data": [{"id": "other-model"}]}),
+        ]
+    )
+
+    report = validate_launcher_model_profile(settings, client=client)
+
+    assert report.ok is False
+    assert "missing text model: missing-text" in report.to_text()
+    assert "password prompts are disabled" not in report.to_text()

--- a/tests/test_launcher_settings.py
+++ b/tests/test_launcher_settings.py
@@ -35,6 +35,7 @@ def _valid_settings() -> LauncherSettings:
         vision_model_name="simtutor-vision",
         model_timeout_s=30.0,
         max_overlay_targets=2,
+        model_profile_mode="remote_direct",
     )
 
 
@@ -126,6 +127,58 @@ def test_openai_compat_requires_model_base_url() -> None:
 
     with pytest.raises(LauncherSettingsError, match="model_base_url"):
         validate_settings(settings)
+
+
+def test_remote_tunnel_requires_ssh_profile_fields() -> None:
+    settings = _valid_settings()
+    settings.model_profile_mode = "remote_tunnel"
+    settings.model_base_url = ""
+    settings.ssh_user = ""
+    settings.ssh_host = ""
+
+    with pytest.raises(LauncherSettingsError) as exc:
+        validate_settings(settings)
+
+    message = str(exc.value)
+    assert "ssh_user" in message
+    assert "ssh_host" in message
+
+
+def test_local_stub_does_not_require_remote_base_url() -> None:
+    settings = _valid_settings()
+    settings.model_profile_mode = "local_stub"
+    settings.model_provider = "stub"
+    settings.model_base_url = ""
+
+    validate_settings(settings)
+
+
+def test_non_tunnel_profiles_ignore_blank_or_bad_ssh_ports() -> None:
+    local_stub = _valid_settings()
+    local_stub.model_profile_mode = "local_stub"
+    local_stub.model_provider = "stub"
+    local_stub.model_base_url = ""
+    local_stub.ssh_local_port = ""  # type: ignore[assignment]
+    local_stub.ssh_remote_port = "not-a-port"  # type: ignore[assignment]
+
+    loaded = LauncherSettings.from_dict(local_stub.to_dict())
+    validate_settings(loaded)
+
+    remote_direct = _valid_settings()
+    remote_direct.ssh_local_port = "not-a-port"  # type: ignore[assignment]
+    remote_direct.ssh_remote_port = ""  # type: ignore[assignment]
+
+    loaded = LauncherSettings.from_dict(remote_direct.to_dict())
+    validate_settings(loaded)
+
+
+def test_ollama_provider_remains_valid_for_existing_launcher_settings() -> None:
+    settings = _valid_settings()
+    settings.model_provider = "ollama"
+    settings.model_profile_mode = "remote_direct"
+    settings.model_base_url = "http://127.0.0.1:11434"
+
+    validate_settings(settings)
 
 
 def test_openai_compat_rejects_non_string_base_url() -> None:

--- a/tests/test_launcher_tunnel.py
+++ b/tests/test_launcher_tunnel.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from simtutor.launcher_settings import LauncherSettings
+from simtutor.launcher_tunnel import (
+    LauncherTunnel,
+    LauncherTunnelError,
+    build_ssh_tunnel_command,
+)
+
+import pytest
+
+
+class FakeProcess:
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+class FakeExitedProcess(FakeProcess):
+    def __init__(self) -> None:
+        super().__init__()
+        self.returncode = 255
+        self.stdout = FakeStdout("Permission denied (publickey).\n")
+
+
+class FakeStdout:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def read(self) -> str:
+        return self.text
+
+
+def _remote_tunnel_settings() -> LauncherSettings:
+    return LauncherSettings(
+        saved_games_path="C:/Users/test/Saved Games/DCS",
+        output_log_directory="C:/SimTutor/logs",
+        participant_id="P01",
+        condition="with_tutor",
+        trial_id="T01",
+        model_provider="openai_compat",
+        model_profile_mode="remote_tunnel",
+        text_model_name="qwen36_27b",
+        vision_model_name="simtutor-vision",
+        ssh_user="pilot",
+        ssh_host="cloud.example.test",
+        ssh_local_port=16324,
+        ssh_remote_host="127.0.0.1",
+        ssh_remote_port=6324,
+        ssh_identity_file_path="C:/Users/test/.ssh/id_ed25519",
+    )
+
+
+def test_build_ssh_tunnel_command_uses_exit_on_forward_failure_and_identity() -> None:
+    settings = _remote_tunnel_settings()
+
+    command = build_ssh_tunnel_command(settings, ssh_executable="C:/Windows/System32/OpenSSH/ssh.exe")
+
+    assert command == [
+        "C:/Windows/System32/OpenSSH/ssh.exe",
+        "-N",
+        "-L",
+        "16324:127.0.0.1:6324",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-o",
+        "BatchMode=yes",
+        "-i",
+        "C:/Users/test/.ssh/id_ed25519",
+        "pilot@cloud.example.test",
+    ]
+
+
+def test_launcher_tunnel_rejects_occupied_local_port_before_start() -> None:
+    calls: list[list[str]] = []
+
+    def fake_popen(command: list[str], **kwargs: object) -> FakeProcess:
+        calls.append(command)
+        return FakeProcess()
+
+    tunnel = LauncherTunnel(
+        _remote_tunnel_settings(),
+        popen_factory=fake_popen,
+        port_checker=lambda _host, _port: False,
+        ssh_resolver=lambda _settings: "ssh.exe",
+    )
+
+    with pytest.raises(LauncherTunnelError, match="local TCP port 16324 is already occupied"):
+        tunnel.start()
+
+    assert calls == []
+
+
+def test_launcher_tunnel_stops_only_owned_process() -> None:
+    created: list[FakeProcess] = []
+
+    def fake_popen(command: list[str], **kwargs: object) -> FakeProcess:
+        process = FakeProcess()
+        created.append(process)
+        return process
+
+    tunnel = LauncherTunnel(
+        _remote_tunnel_settings(),
+        popen_factory=fake_popen,
+        port_checker=lambda _host, _port: True,
+        ssh_resolver=lambda _settings: "ssh.exe",
+    )
+
+    tunnel.start()
+    tunnel.stop()
+
+    assert len(created) == 1
+    assert created[0].terminated is True
+
+
+def test_launcher_tunnel_reports_immediate_key_auth_failure() -> None:
+    tunnel = LauncherTunnel(
+        _remote_tunnel_settings(),
+        popen_factory=lambda _command, **_kwargs: FakeExitedProcess(),
+        port_checker=lambda _host, _port: True,
+        ssh_resolver=lambda _settings: "ssh.exe",
+    )
+
+    with pytest.raises(LauncherTunnelError, match="password prompts are disabled"):
+        tunnel.start()


### PR DESCRIPTION
## Summary
- add launcher settings for local_stub, remote_direct, and remote_tunnel model profiles
- add launcher-owned SSH tunnel process management with port checks, BatchMode, ExitOnForwardFailure, and immediate startup failure diagnostics
- add endpoint validation for /health and /v1/models with clear missing text/vision model errors
- wire a Validate Model action into the launcher GUI

Closes #366.

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_launcher_settings.py tests/test_launcher_tunnel.py tests/test_launcher_model_check.py tests/test_launcher_preflight.py tests/test_launcher_processes.py tests/test_launcher_entry.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

## Review-fix loop
- subagent review found SSH startup diagnostics, provider/profile narrowing, httpx close, irrelevant tunnel field validation, and key-auth hint noise
- fixed all listed findings and reran local targeted + full tests