### PR TITLE
Add launcher experiment session workflow

### DIFF
--- a/simtutor/launcher.py
+++ b/simtutor/launcher.py
@@ -19,6 +19,7 @@ else:
     _TK_IMPORT_ERROR = None
 
 from simtutor.launcher_processes import LauncherProcess, ProcessState
+from simtutor.launcher_session import LauncherExperimentSession, format_dry_run_plan
 from simtutor.launcher_model_check import validate_launcher_model_profile
 from simtutor.launcher_preflight import run_launcher_install, run_preflight
 from simtutor.launcher_settings import (
@@ -40,9 +41,16 @@ NORMAL_FIELDS = (
     ("language", "Language"),
     ("scenario_profile", "Scenario profile"),
     ("output_log_directory", "Output log directory"),
+    ("export_output_directory", "Export output directory"),
+    ("analysis_output_directory", "Analysis output directory"),
     ("participant_id", "Participant id"),
     ("condition", "Condition"),
     ("trial_id", "Trial id"),
+    ("study_id", "Study id"),
+    ("participant_group", "Participant group"),
+    ("experimenter_id", "Experimenter id"),
+    ("questionnaire_ref", "Questionnaire ref"),
+    ("recording_ref", "Recording ref"),
 )
 
 ADVANCED_FIELDS = (
@@ -54,6 +62,29 @@ ADVANCED_FIELDS = (
     ("model_timeout_s", "Model timeout"),
     ("model_enable_multimodal", "VLM facts enabled"),
     ("max_overlay_targets", "Max overlay targets"),
+    ("pack_path", "Pack path"),
+    ("taxonomy_path", "Taxonomy path"),
+    ("ui_map_path", "UI map path"),
+    ("telemetry_map_path", "Telemetry map path"),
+    ("bios_to_ui_path", "BIOS-to-UI path"),
+    ("knowledge_index_path", "Knowledge index path"),
+    ("rag_top_k", "RAG top-k"),
+    ("dcs_bios_source", "DCS-BIOS source"),
+    ("raw_bios_host", "Raw BIOS host"),
+    ("raw_bios_port", "Raw BIOS port"),
+    ("raw_bios_control_dir", "Raw BIOS control dir"),
+    ("dcs_aircraft", "DCS aircraft"),
+    ("dcs_mission", "DCS mission"),
+    ("vr_setup", "VR setup"),
+    ("monitor_setup", "Monitor setup"),
+    ("prompt_version", "Prompt version"),
+    ("prompt_hash", "Prompt hash"),
+    ("global_help_hotkey", "Global help hotkey"),
+    ("global_help_modifiers", "Global help modifiers"),
+    ("global_help_cooldown_ms", "Global help cooldown ms"),
+    ("vision_trigger_wait_ms", "Vision trigger wait ms"),
+    ("vision_capture_trigger_host", "Vision trigger host"),
+    ("vision_capture_trigger_port", "Vision trigger port"),
     ("ssh_tunnel_profile", "SSH tunnel profile"),
     ("ssh_executable_path", "SSH executable path"),
     ("ssh_user", "SSH user"),
@@ -89,10 +120,12 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
         self.variables: dict[str, tk.StringVar] = {}
         self.status_variables = {
             name: tk.StringVar(value="stopped")
-            for name in ("DCS", "model", "tunnel", "tutor", "vision")
+            for name in ("DCS", "model", "tunnel", "tutor", "vision", "export", "analysis")
         }
         self.process: LauncherProcess | None = None
         self.tunnel: LauncherTunnel | None = None
+        self.session: LauncherExperimentSession | None = None
+        self.session_log_header: list[str] = []
 
         master.title("SimTutor Experiment Launcher")
         master.minsize(860, 620)
@@ -126,7 +159,7 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
             self.variables[name] = var
             entry = ttk.Entry(frame, textvariable=var)
             entry.grid(row=row, column=1, sticky="ew", pady=3)
-            if name in {"saved_games_path", "output_log_directory"}:
+            if name in {"saved_games_path", "output_log_directory", "export_output_directory", "analysis_output_directory"}:
                 button = ttk.Button(frame, text="Browse", command=lambda key=name: self._browse_directory(key))
                 button.grid(row=row, column=2, sticky="e", padx=(8, 0), pady=3)
 
@@ -145,12 +178,13 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
         ttk.Button(frame, text="Save", command=self._save).grid(row=0, column=1, padx=(0, 6))
         ttk.Button(frame, text="Save Profile", command=self._save_profile).grid(row=0, column=2, padx=(0, 6))
         ttk.Button(frame, text="Load Profile", command=self._load_profile).grid(row=0, column=3, padx=(0, 18))
-        ttk.Button(frame, text="Start", command=self._start).grid(row=0, column=4, padx=(0, 6))
-        ttk.Button(frame, text="Stop", command=self._stop).grid(row=0, column=5, padx=(0, 18))
-        ttk.Button(frame, text="Install", command=self._install).grid(row=0, column=6, padx=(0, 6))
-        ttk.Button(frame, text="Preflight", command=self._preflight).grid(row=0, column=7, padx=(0, 6))
-        ttk.Button(frame, text="Validate Model", command=self._validate_model).grid(row=0, column=8, padx=(0, 6))
-        ttk.Button(frame, text="Export", command=self._placeholder_export).grid(row=0, column=9, padx=(0, 6))
+        ttk.Button(frame, text="Dry Run", command=self._dry_run).grid(row=0, column=4, padx=(0, 6))
+        ttk.Button(frame, text="Start", command=self._start).grid(row=0, column=5, padx=(0, 6))
+        ttk.Button(frame, text="Stop", command=self._stop).grid(row=0, column=6, padx=(0, 18))
+        ttk.Button(frame, text="Install", command=self._install).grid(row=0, column=7, padx=(0, 6))
+        ttk.Button(frame, text="Preflight", command=self._preflight).grid(row=0, column=8, padx=(0, 6))
+        ttk.Button(frame, text="Validate Model", command=self._validate_model).grid(row=0, column=9, padx=(0, 6))
+        ttk.Button(frame, text="Export", command=self._export).grid(row=0, column=10, padx=(0, 6))
 
     def _build_log_area(self) -> None:
         frame = ttk.LabelFrame(self, text="Process log", padding=10)
@@ -216,6 +250,14 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
             messagebox.showerror("Profile load failed", str(exc))
 
     def _start(self) -> None:
+        if self.session is not None and any(
+            snapshot.state == ProcessState.RUNNING
+            for snapshot in self.session.snapshots()
+        ):
+            assert messagebox is not None
+            messagebox.showerror("Start failed", "An experiment session is already running.")
+            self._append_log("start failed: an experiment session is already running")
+            return
         try:
             settings = self._collect_settings()
             save_settings(settings)
@@ -224,30 +266,74 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
             messagebox.showerror("Start failed", str(exc))
             return
         self.settings = settings
-        if self.process is None or self.process.snapshot().state != ProcessState.RUNNING:
-            self.process = self.process_factory(name="simtutor-fake-session", command=self.command_builder(settings))
         try:
-            self.process.start()
+            session = LauncherExperimentSession(
+                settings,
+                process_factory=self.process_factory,
+                tunnel_factory=LauncherTunnel,
+                python_executable=sys.executable,
+            )
+            result = session.start()
         except Exception as exc:
             assert messagebox is not None
             messagebox.showerror("Start failed", str(exc))
+            self._append_log(f"start failed: {exc}")
+            self.session = None
             return
+        self.session = session
         self.status_variables["DCS"].set("external")
-        self.status_variables["model"].set(settings.model_provider)
-        self.status_variables["tunnel"].set("placeholder")
+        self.status_variables["model"].set(settings.model_profile_mode)
+        self.status_variables["tunnel"].set("running" if settings.model_profile_mode == "remote_tunnel" else "not required")
         self.status_variables["tutor"].set("running")
-        self.status_variables["vision"].set("placeholder")
+        self.status_variables["vision"].set("running")
+        self.status_variables["export"].set("pending")
+        self.status_variables["analysis"].set("pending")
+        self.session_log_header = [
+            f"session started: {result.session_id}",
+            f"live log: {result.live_log_path}",
+        ]
+        self._append_log("\n".join(self.session_log_header))
 
     def _stop(self) -> None:
-        if self.process is not None:
+        if self.session is not None:
+            try:
+                self.session.stop(run_post_run=True)
+                self.status_variables["export"].set("complete")
+                self.status_variables["analysis"].set("complete")
+                if self.session.plan is not None:
+                    self.session_log_header.extend(
+                        [
+                            f"export output: {self.session.plan.export_output_dir}",
+                            f"analysis output: {self.session.plan.analysis_output_dir}",
+                        ]
+                    )
+                    self._append_log("\n".join(self.session_log_header[-2:]))
+            except Exception as exc:
+                assert messagebox is not None
+                messagebox.showerror("Stop/export failed", str(exc))
+                self._append_log(f"stop/export failed: {exc}")
+        elif self.process is not None:
             self.process.stop()
         if self.tunnel is not None:
             self.tunnel.stop()
-            self.status_variables["tunnel"].set("stopped")
+        self.status_variables["tunnel"].set("stopped")
         self.status_variables["tutor"].set("stopped")
+        self.status_variables["vision"].set("stopped")
 
     def _poll_process(self) -> None:
-        if self.process is not None:
+        if self.session is not None:
+            lines: list[str] = list(self.session_log_header)
+            for snapshot in self.session.snapshots():
+                lines.extend(f"[{snapshot.name}] {line}" for line in snapshot.log_lines)
+                if snapshot.name == "live-dcs" and snapshot.state == ProcessState.EXITED:
+                    self.status_variables["tutor"].set(f"exited ({snapshot.returncode})")
+                if snapshot.name == "vision-sidecar" and snapshot.state == ProcessState.EXITED:
+                    self.status_variables["vision"].set(f"exited ({snapshot.returncode})")
+            if lines:
+                self.log_text.delete("1.0", "end")
+                self.log_text.insert("end", "\n".join(lines))
+                self.log_text.see("end")
+        elif self.process is not None:
             snapshot = self.process.snapshot()
             self.log_text.delete("1.0", "end")
             self.log_text.insert("end", "\n".join(snapshot.log_lines))
@@ -309,8 +395,43 @@ class LauncherApp(ttk.Frame if ttk is not None else object):
             assert messagebox is not None
             messagebox.showwarning("Model validation found issues", "See the process log for details.")
 
-    def _placeholder_export(self) -> None:
-        self._append_log("export placeholder: experiment export implementation is out of scope for this MVP")
+    def _dry_run(self) -> None:
+        try:
+            settings = self._collect_settings()
+            session = LauncherExperimentSession(
+                settings,
+                process_factory=self.process_factory,
+                python_executable=sys.executable,
+            )
+            plan = session.start(dry_run=True).plan
+            text = (
+                "workflow:\n"
+                "- validate settings and preflight\n"
+                "- start SSH tunnel when model_profile_mode=remote_tunnel\n"
+                "- validate model endpoint\n"
+                "- launch the commands below\n"
+                + format_dry_run_plan(plan)
+            )
+        except Exception as exc:
+            assert messagebox is not None
+            messagebox.showerror("Dry run failed", str(exc))
+            self._append_log(f"dry run failed: {exc}")
+            return
+        self._append_log("dry run:\n" + text)
+
+    def _export(self) -> None:
+        if self.session is None:
+            self._append_log("export skipped: no completed session is available")
+            return
+        try:
+            self.session.run_post_run()
+        except Exception as exc:
+            assert messagebox is not None
+            messagebox.showerror("Export failed", str(exc))
+            self._append_log(f"export failed: {exc}")
+            return
+        self.status_variables["export"].set("complete")
+        self.status_variables["analysis"].set("complete")
 
 
 def _fake_process_command(settings: LauncherSettings) -> list[str]:

--- a/simtutor/launcher_session.py
+++ b/simtutor/launcher_session.py
@@ -1,0 +1,466 @@
+"""Experiment session orchestration for the SimTutor launcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import shlex
+import re
+import sys
+from typing import Any, Callable
+
+from simtutor.launcher_model_check import validate_launcher_model_profile
+from simtutor.launcher_preflight import run_preflight
+from simtutor.launcher_processes import LauncherProcess, ProcessSnapshot, ProcessState
+from simtutor.launcher_settings import LauncherSettings, validate_settings
+from simtutor.launcher_tunnel import LauncherTunnel
+
+
+class LauncherSessionError(RuntimeError):
+    """Raised when an experiment session cannot advance safely."""
+
+
+@dataclass(frozen=True)
+class LauncherSessionPlan:
+    session_id: str
+    live_log_path: Path
+    export_output_dir: Path
+    analysis_output_dir: Path
+    sidecar_command: tuple[str, ...]
+    live_dcs_command: tuple[str, ...]
+    export_command: tuple[str, ...]
+    analyze_command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class LauncherSessionStartResult:
+    session_id: str
+    live_log_path: Path
+    plan: LauncherSessionPlan
+
+
+ProcessFactory = Callable[..., Any]
+TunnelFactory = Callable[[LauncherSettings], Any]
+ReportRunner = Callable[[LauncherSettings], Any]
+TimestampFactory = Callable[[], str]
+
+
+def resolve_unique_live_log_path(settings: LauncherSettings, *, timestamp: str | None = None) -> Path:
+    out_dir = Path(settings.output_log_directory).expanduser()
+    stamp = timestamp or datetime.now().strftime("%Y%m%d_%H%M%S")
+    participant = _slug(settings.participant_id or "participant")
+    trial = _slug(settings.trial_id or "trial")
+    stem = f"live_dcs_{participant}_{trial}_{stamp}"
+    for suffix in ("", *[f"_{index}" for index in range(2, 1000)]):
+        candidate = out_dir / f"{stem}{suffix}.jsonl"
+        if not candidate.exists():
+            return candidate
+    raise LauncherSessionError(f"could not resolve unique live log path in {out_dir}")
+
+
+def build_launcher_session_plan(
+    settings: LauncherSettings,
+    *,
+    log_path: str | Path,
+    session_id: str,
+    python_executable: str | None = None,
+) -> LauncherSessionPlan:
+    executable = python_executable or sys.executable
+    saved_games_dir = Path(settings.saved_games_path).expanduser()
+    live_log_path = Path(log_path).expanduser()
+    export_output_dir = Path(settings.export_output_directory).expanduser()
+    analysis_output_dir = Path(settings.analysis_output_directory).expanduser()
+
+    sidecar_command = [
+        executable,
+        "-u",
+        "tools/capture_vision_sidecar.py",
+        "--saved-games-dir",
+        str(saved_games_dir),
+        "--session-id",
+        session_id,
+        "--trigger-host",
+        settings.vision_capture_trigger_host,
+        "--trigger-port",
+        str(settings.vision_capture_trigger_port),
+        "--capture-fps",
+        "0",
+    ]
+
+    live_dcs_command = [
+        executable,
+        "-m",
+        "simtutor",
+        "live-dcs",
+        "--bios-source",
+        settings.dcs_bios_source,
+        "--raw-bios-host",
+        settings.raw_bios_host,
+        "--raw-bios-port",
+        str(settings.raw_bios_port),
+        "--raw-bios-aircraft",
+        settings.dcs_aircraft,
+        "--raw-bios-control-dir",
+        settings.raw_bios_control_dir,
+        "--timeout",
+        "0.5",
+        "--pack",
+        settings.pack_path,
+        "--ui-map",
+        settings.ui_map_path,
+        "--telemetry-map",
+        settings.telemetry_map_path,
+        "--bios-to-ui",
+        settings.bios_to_ui_path,
+        "--knowledge-index",
+        settings.knowledge_index_path,
+        "--rag-top-k",
+        str(settings.rag_top_k),
+        "--max-overlay-targets",
+        str(settings.max_overlay_targets),
+        "--output",
+        str(live_log_path),
+        "--session-id",
+        session_id,
+        "--vision-saved-games-dir",
+        str(saved_games_dir),
+        "--vision-session-id",
+        session_id,
+        "--vision-trigger-wait-ms",
+        str(settings.vision_trigger_wait_ms),
+        "--vision-capture-trigger-host",
+        settings.vision_capture_trigger_host,
+        "--vision-capture-trigger-port",
+        str(settings.vision_capture_trigger_port),
+        "--global-help-hotkey",
+        settings.global_help_hotkey,
+        "--global-help-cooldown-ms",
+        str(settings.global_help_cooldown_ms),
+        "--model-provider",
+        settings.model_provider,
+        "--model-base-url",
+        settings.model_base_url,
+        "--model-name",
+        settings.text_model_name,
+        "--vision-model-name",
+        settings.vision_model_name,
+        "--model-timeout-s",
+        str(settings.model_timeout_s),
+        "--lang",
+        settings.language,
+        "--scenario-profile",
+        settings.scenario_profile,
+        "--no-cold-start-production",
+    ]
+    if settings.global_help_modifiers.strip():
+        live_dcs_command.extend(["--global-help-modifiers", settings.global_help_modifiers.strip()])
+    if settings.model_enable_multimodal:
+        live_dcs_command.append("--model-enable-multimodal")
+    else:
+        live_dcs_command.append("--no-model-enable-multimodal")
+
+    export_command = [
+        executable,
+        "-m",
+        "simtutor",
+        "experiment-export",
+        str(live_log_path),
+        "--output-dir",
+        str(export_output_dir),
+        "--trial-id",
+        settings.trial_id,
+        "--study-id",
+        settings.study_id,
+        "--participant-id",
+        settings.participant_id,
+        "--condition",
+        settings.condition,
+        "--recording-ref",
+        settings.recording_ref or str(live_log_path),
+        "--pack",
+        settings.pack_path,
+        "--taxonomy",
+        settings.taxonomy_path,
+        "--ui-map",
+        settings.ui_map_path,
+        "--bios-to-ui",
+        settings.bios_to_ui_path,
+        "--model-provider",
+        settings.model_provider,
+        "--model-name",
+        settings.text_model_name,
+        "--vision-model-name",
+        settings.vision_model_name,
+        "--scenario-profile",
+        settings.scenario_profile,
+        "--dcs-aircraft",
+        settings.dcs_aircraft,
+        "--monitor-setup",
+        settings.monitor_setup or settings.monitor_mode,
+        "--strict",
+    ]
+    _append_optional(export_command, "--group", settings.participant_group)
+    _append_optional(export_command, "--experimenter-id", settings.experimenter_id)
+    _append_optional(export_command, "--questionnaire", settings.questionnaire_ref)
+    _append_optional(export_command, "--prompt-version", settings.prompt_version)
+    _append_optional(export_command, "--prompt-hash", settings.prompt_hash)
+    _append_optional(export_command, "--dcs-mission", settings.dcs_mission)
+    _append_optional(export_command, "--vr-setup", settings.vr_setup)
+
+    analyze_command = [
+        executable,
+        "-m",
+        "simtutor",
+        "experiment-analyze",
+        str(export_output_dir),
+        "--output-dir",
+        str(analysis_output_dir),
+    ]
+
+    return LauncherSessionPlan(
+        session_id=session_id,
+        live_log_path=live_log_path,
+        export_output_dir=export_output_dir,
+        analysis_output_dir=analysis_output_dir,
+        sidecar_command=tuple(sidecar_command),
+        live_dcs_command=tuple(live_dcs_command),
+        export_command=tuple(export_command),
+        analyze_command=tuple(analyze_command),
+    )
+
+
+def format_dry_run_plan(plan: LauncherSessionPlan) -> str:
+    lines = [
+        f"session_id: {plan.session_id}",
+        f"live_log_path: {plan.live_log_path}",
+        "vision sidecar:",
+        shlex.join(plan.sidecar_command),
+        "live-dcs:",
+        shlex.join(plan.live_dcs_command),
+        "experiment-export:",
+        shlex.join(plan.export_command),
+        "experiment-analyze:",
+        shlex.join(plan.analyze_command),
+    ]
+    return "\n".join(lines)
+
+
+class LauncherExperimentSession:
+    def __init__(
+        self,
+        settings: LauncherSettings,
+        *,
+        process_factory: ProcessFactory = LauncherProcess,
+        tunnel_factory: TunnelFactory = LauncherTunnel,
+        preflight_runner: ReportRunner = run_preflight,
+        model_validator: ReportRunner = validate_launcher_model_profile,
+        timestamp: TimestampFactory | None = None,
+        python_executable: str | None = None,
+    ) -> None:
+        self.settings = settings
+        self.process_factory = process_factory
+        self.tunnel_factory = tunnel_factory
+        self.preflight_runner = preflight_runner
+        self.model_validator = model_validator
+        self.timestamp = timestamp or (lambda: datetime.now().strftime("%Y%m%d_%H%M%S"))
+        self.python_executable = python_executable
+        self.plan: LauncherSessionPlan | None = None
+        self.tunnel: Any | None = None
+        self.sidecar_process: Any | None = None
+        self.live_process: Any | None = None
+        self.export_process: Any | None = None
+        self.analyze_process: Any | None = None
+        self.post_run_complete = False
+        self._stop_requested = False
+
+    def dry_run_text(self) -> str:
+        validate_session_settings(self.settings)
+        return format_dry_run_plan(self._build_plan())
+
+    def start(self, *, dry_run: bool = False) -> LauncherSessionStartResult:
+        if self._has_running_live_process():
+            raise LauncherSessionError("experiment session is already running")
+        validate_session_settings(self.settings)
+        plan = self._build_plan()
+        self.plan = plan
+        if dry_run:
+            return LauncherSessionStartResult(session_id=plan.session_id, live_log_path=plan.live_log_path, plan=plan)
+
+        preflight_report = self.preflight_runner(self.settings)
+        if not getattr(preflight_report, "ok", False):
+            raise LauncherSessionError(f"preflight failed:\n{preflight_report.to_text()}")
+
+        try:
+            if self.settings.model_profile_mode == "remote_tunnel":
+                self.tunnel = self.tunnel_factory(self.settings)
+                self.tunnel.start()
+
+            model_report = self.model_validator(self.settings)
+            if not getattr(model_report, "ok", False):
+                raise LauncherSessionError(f"model validation failed:\n{model_report.to_text()}")
+
+            self.sidecar_process = self.process_factory(
+                name="vision-sidecar",
+                command=list(plan.sidecar_command),
+            )
+            self.sidecar_process.start()
+            self.live_process = self.process_factory(
+                name="live-dcs",
+                command=list(plan.live_dcs_command),
+            )
+            self.live_process.start()
+        except Exception:
+            self._stop_live_processes()
+            self._stop_tunnel()
+            raise
+
+        return LauncherSessionStartResult(session_id=plan.session_id, live_log_path=plan.live_log_path, plan=plan)
+
+    def stop(self, *, run_post_run: bool = True) -> None:
+        self._stop_live_processes()
+        self._stop_tunnel()
+        if run_post_run:
+            self.run_post_run()
+
+    def run_post_run(self) -> None:
+        if self.plan is None:
+            raise LauncherSessionError("session has not been started")
+        if self.post_run_complete:
+            return
+        self._ensure_live_log_ready_for_export()
+        self.export_process = self.process_factory(
+            name="experiment-export",
+            command=list(self.plan.export_command),
+        )
+        self.export_process.start()
+        self._wait_for_process_exit(self.export_process, timeout_s=600.0)
+        export_snapshot = self.export_process.snapshot()
+        if export_snapshot.returncode not in (0, None):
+            raise LauncherSessionError(f"experiment-export failed with code {export_snapshot.returncode}")
+        self.analyze_process = self.process_factory(
+            name="experiment-analyze",
+            command=list(self.plan.analyze_command),
+        )
+        self.analyze_process.start()
+        self._wait_for_process_exit(self.analyze_process, timeout_s=600.0)
+        analyze_snapshot = self.analyze_process.snapshot()
+        if analyze_snapshot.returncode not in (0, None):
+            raise LauncherSessionError(f"experiment-analyze failed with code {analyze_snapshot.returncode}")
+        self.post_run_complete = True
+
+    def snapshots(self) -> tuple[ProcessSnapshot, ...]:
+        snapshots: list[ProcessSnapshot] = []
+        for process in (
+            self.sidecar_process,
+            self.live_process,
+            self.export_process,
+            self.analyze_process,
+        ):
+            if process is not None:
+                snapshots.append(process.snapshot())
+        return tuple(snapshots)
+
+    def _build_plan(self) -> LauncherSessionPlan:
+        timestamp = self.timestamp()
+        log_path = resolve_unique_live_log_path(self.settings, timestamp=timestamp)
+        session_id = f"sess-{_slug(self.settings.participant_id)}-{_slug(self.settings.trial_id)}-{timestamp}"
+        return build_launcher_session_plan(
+            self.settings,
+            log_path=log_path,
+            session_id=session_id,
+            python_executable=self.python_executable,
+        )
+
+    def _stop_live_processes(self) -> None:
+        if self.live_process is not None:
+            was_running = self.live_process.snapshot().state == ProcessState.RUNNING
+            self.live_process.stop()
+            if was_running:
+                self._stop_requested = True
+        if self.sidecar_process is not None:
+            self.sidecar_process.stop()
+
+    def _stop_tunnel(self) -> None:
+        if self.tunnel is not None:
+            self.tunnel.stop()
+
+    def _ensure_live_log_ready_for_export(self) -> None:
+        if self.plan is None:
+            raise LauncherSessionError("session has not been started")
+        if self.live_process is not None:
+            snapshot = self.live_process.snapshot()
+            if snapshot.state == ProcessState.RUNNING:
+                raise LauncherSessionError("live-dcs is still running; stop the session before export")
+            if snapshot.returncode not in (0, None) and not self._stop_requested:
+                raise LauncherSessionError(f"live-dcs exited with code {snapshot.returncode}; export skipped")
+        if not self.plan.live_log_path.is_file():
+            raise LauncherSessionError(f"live-dcs log was not written: {self.plan.live_log_path}")
+        if self.plan.live_log_path.stat().st_size <= 0:
+            raise LauncherSessionError(f"live-dcs log is empty: {self.plan.live_log_path}")
+
+    @staticmethod
+    def _wait_for_process_exit(process: Any, *, timeout_s: float) -> None:
+        child = getattr(process, "process", None)
+        if child is not None and hasattr(child, "wait"):
+            child.wait(timeout=timeout_s)
+        process.wait_for_output(timeout_s=1.0)
+
+    def _has_running_live_process(self) -> bool:
+        return self.live_process is not None and self.live_process.snapshot().state == ProcessState.RUNNING
+
+
+def _append_optional(command: list[str], flag: str, value: str | None) -> None:
+    if isinstance(value, str) and value.strip():
+        command.extend([flag, value.strip()])
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value).strip()).strip("._-")
+    return slug or "unknown"
+
+
+def validate_session_settings(settings: LauncherSettings) -> None:
+    validate_settings(settings)
+    missing = [
+        name
+        for name in (
+            "study_id",
+            "participant_id",
+            "condition",
+            "trial_id",
+            "participant_group",
+            "experimenter_id",
+            "questionnaire_ref",
+            "recording_ref",
+            "model_provider",
+            "text_model_name",
+            "vision_model_name",
+            "scenario_profile",
+            "dcs_mission",
+            "dcs_aircraft",
+        )
+        if not _setting_text_present(getattr(settings, name))
+    ]
+    if not (_setting_text_present(settings.prompt_version) or _setting_text_present(settings.prompt_hash)):
+        missing.append("prompt_version or prompt_hash")
+    if not (_setting_text_present(settings.vr_setup) or _setting_text_present(settings.monitor_setup)):
+        missing.append("vr_setup or monitor_setup")
+    if missing:
+        raise LauncherSessionError("missing experiment session metadata: " + ", ".join(missing))
+
+
+def _setting_text_present(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+__all__ = [
+    "LauncherExperimentSession",
+    "LauncherSessionError",
+    "LauncherSessionPlan",
+    "LauncherSessionStartResult",
+    "build_launcher_session_plan",
+    "format_dry_run_plan",
+    "resolve_unique_live_log_path",
+    "validate_session_settings",
+]

--- a/simtutor/launcher_settings.py
+++ b/simtutor/launcher_settings.py
@@ -35,17 +35,47 @@ class LauncherSettings:
     language: str = "zh"
     scenario_profile: str = "airfield"
     output_log_directory: str = "logs"
+    export_output_directory: str = "artifacts/experiments"
+    analysis_output_directory: str = "artifacts/experiment_analysis"
     participant_id: str = ""
     condition: str = ""
     trial_id: str = ""
+    study_id: str = ""
+    participant_group: str = ""
+    experimenter_id: str = ""
+    questionnaire_ref: str = ""
+    recording_ref: str = ""
     model_provider: str = "stub"
     model_profile_mode: str = "local_stub"
     model_base_url: str = ""
     text_model_name: str = "Qwen3-8B-Instruct"
     vision_model_name: str = "simtutor-vision"
     model_timeout_s: float = 20.0
-    model_enable_multimodal: bool = False
-    max_overlay_targets: int = 1
+    model_enable_multimodal: bool = True
+    max_overlay_targets: int = 4
+    pack_path: str = "packs/fa18c_startup/pack.yaml"
+    taxonomy_path: str = "packs/fa18c_startup/taxonomy.yaml"
+    ui_map_path: str = "packs/fa18c_startup/ui_map.yaml"
+    telemetry_map_path: str = "packs/fa18c_startup/telemetry_map.yaml"
+    bios_to_ui_path: str = "packs/fa18c_startup/bios_to_ui.yaml"
+    knowledge_index_path: str = "Doc/Evaluation/index.json"
+    rag_top_k: int = 5
+    dcs_bios_source: str = "raw"
+    raw_bios_host: str = "239.255.50.10"
+    raw_bios_port: int = 5010
+    raw_bios_control_dir: str = "DCS/Scripts/DCS-BIOS/doc/json"
+    dcs_aircraft: str = "FA-18C_hornet"
+    dcs_mission: str = ""
+    vr_setup: str = ""
+    monitor_setup: str = ""
+    prompt_version: str = "launcher-v0.4"
+    prompt_hash: str = ""
+    global_help_hotkey: str = "X1"
+    global_help_modifiers: str = ""
+    global_help_cooldown_ms: int = 800
+    vision_trigger_wait_ms: int = 4000
+    vision_capture_trigger_host: str = "127.0.0.1"
+    vision_capture_trigger_port: int = 7795
     ssh_tunnel_profile: str = ""
     ssh_executable_path: str = ""
     ssh_user: str = ""
@@ -66,8 +96,17 @@ class LauncherSettings:
         try:
             settings.model_timeout_s = float(settings.model_timeout_s)
             settings.max_overlay_targets = int(settings.max_overlay_targets)
+            settings.rag_top_k = int(settings.rag_top_k)
+            settings.raw_bios_port = int(settings.raw_bios_port)
+            settings.global_help_cooldown_ms = int(settings.global_help_cooldown_ms)
+            settings.vision_trigger_wait_ms = int(settings.vision_trigger_wait_ms)
+            settings.vision_capture_trigger_port = int(settings.vision_capture_trigger_port)
         except (TypeError, ValueError) as exc:
-            raise LauncherSettingsError("model_timeout_s and max_overlay_targets must be numeric") from exc
+            raise LauncherSettingsError(
+                "model_timeout_s, max_overlay_targets, rag_top_k, raw_bios_port, "
+                "global_help_cooldown_ms, vision_trigger_wait_ms, and "
+                "vision_capture_trigger_port must be numeric"
+            ) from exc
         settings.model_enable_multimodal = _parse_bool(settings.model_enable_multimodal, "model_enable_multimodal")
         settings.ssh_local_port = _parse_profile_port(
             settings.ssh_local_port,
@@ -203,6 +242,34 @@ def validate_settings(settings: LauncherSettings) -> None:
         errors.append("model_timeout_s")
     if max_overlay_targets < 0:
         errors.append("max_overlay_targets")
+    for name in ("rag_top_k", "global_help_cooldown_ms", "vision_trigger_wait_ms"):
+        try:
+            value = int(getattr(settings, name))
+        except (TypeError, ValueError):
+            errors.append(name)
+            continue
+        if value < 0:
+            errors.append(name)
+    try:
+        raw_bios_port = int(settings.raw_bios_port)
+    except (TypeError, ValueError):
+        errors.append("raw_bios_port")
+    else:
+        if raw_bios_port <= 0 or raw_bios_port > 65535:
+            errors.append("raw_bios_port")
+    try:
+        vision_capture_trigger_port = int(settings.vision_capture_trigger_port)
+    except (TypeError, ValueError):
+        errors.append("vision_capture_trigger_port")
+    else:
+        if vision_capture_trigger_port < 0 or vision_capture_trigger_port > 65535:
+            errors.append("vision_capture_trigger_port")
+    if settings.dcs_bios_source not in {"decoded", "raw"}:
+        errors.append("dcs_bios_source")
+    if settings.dcs_bios_source == "raw" and (
+        not isinstance(settings.dcs_aircraft, str) or not settings.dcs_aircraft.strip()
+    ):
+        errors.append("dcs_aircraft")
     if settings.model_profile_mode == "remote_tunnel":
         for name in ("ssh_local_port", "ssh_remote_port"):
             try:

--- a/tests/test_launcher_session.py
+++ b/tests/test_launcher_session.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from simtutor.launcher_processes import ProcessSnapshot, ProcessState
+from simtutor.launcher_session import (
+    LauncherExperimentSession,
+    LauncherSessionError,
+    build_launcher_session_plan,
+    format_dry_run_plan,
+    resolve_unique_live_log_path,
+)
+from simtutor.launcher_settings import LauncherSettings
+
+
+@dataclass(frozen=True)
+class FakeEntry:
+    status: str
+    code: str
+    message: str
+
+
+class FakeReport:
+    def __init__(self, ok: bool = True, text: str = "ready") -> None:
+        self.ok = ok
+        self.text = text
+        self.entries = (FakeEntry("pass" if ok else "error", "fake", text),)
+
+    def to_text(self) -> str:
+        return self.text
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        *,
+        name: str,
+        command: list[str],
+        events: list[str],
+        stop_returncode: int = 0,
+        initial_returncode: int | None = None,
+        **_kwargs: object,
+    ) -> None:
+        self.name = name
+        self.command = tuple(command)
+        self.events = events
+        self.stop_returncode = stop_returncode
+        self.initial_returncode = initial_returncode
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.events.append(f"start:{self.name}")
+        self.started = True
+        if self.name == "live-dcs":
+            _write_fake_live_log(self.command)
+
+    def stop(self, *, timeout_s: float = 5.0) -> None:
+        self.events.append(f"stop:{self.name}")
+        self.stopped = True
+        if self.initial_returncode is not None:
+            self.stop_returncode = self.initial_returncode
+
+    def wait_for_output(self, *, timeout_s: float = 1.0) -> None:
+        self.events.append(f"wait:{self.name}")
+
+    def snapshot(self) -> ProcessSnapshot:
+        state = ProcessState.STOPPED if self.stopped or self.initial_returncode is not None else ProcessState.RUNNING
+        returncode = self.stop_returncode if self.stopped else self.initial_returncode
+        return ProcessSnapshot(
+            name=self.name,
+            command=self.command,
+            state=state,
+            returncode=returncode,
+            log_lines=(f"{self.name} log",),
+        )
+
+
+class FakeTunnel:
+    def __init__(self, settings: LauncherSettings, events: list[str], *, fail_start: bool = False) -> None:
+        self.settings = settings
+        self.events = events
+        self.fail_start = fail_start
+
+    def start(self) -> None:
+        self.events.append("start:tunnel")
+        if self.fail_start:
+            raise RuntimeError("tunnel failed")
+
+    def stop(self) -> None:
+        self.events.append("stop:tunnel")
+
+    def snapshot(self):
+        return type("TunnelSnapshot", (), {"running": True, "returncode": None, "command": ("ssh",)})()
+
+
+def _settings(tmp_path: Path, *, model_profile_mode: str = "remote_direct") -> LauncherSettings:
+    saved_games = tmp_path / "Saved Games" / "DCS"
+    logs = tmp_path / "logs"
+    saved_games.mkdir(parents=True)
+    logs.mkdir()
+    return LauncherSettings(
+        saved_games_path=str(saved_games),
+        dcs_variant="DCS",
+        monitor_mode="fa18c_composite_panel_v2",
+        language="zh",
+        scenario_profile="airfield",
+        output_log_directory=str(logs),
+        participant_id="P01",
+        condition="with_tutor",
+        trial_id="T01",
+        study_id="study-alpha",
+        participant_group="novice",
+        experimenter_id="E01",
+        questionnaire_ref="questionnaires/P01.yaml",
+        recording_ref="recordings/P01_T01.mp4",
+        model_provider="openai_compat",
+        model_profile_mode=model_profile_mode,
+        model_base_url="http://127.0.0.1:16324",
+        text_model_name="simtutor-base",
+        vision_model_name="simtutor-vision",
+        model_timeout_s=60,
+        model_enable_multimodal=True,
+        max_overlay_targets=4,
+        dcs_aircraft="FA-18C_hornet",
+        dcs_mission="cold_start.miz",
+        vr_setup="none",
+        monitor_setup="fa18c_composite_panel_v2",
+        prompt_version="launcher-v0.4",
+    )
+
+
+def _write_fake_live_log(command: tuple[str, ...]) -> None:
+    if "--output" not in command:
+        return
+    output = Path(command[command.index("--output") + 1])
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("{}\n", encoding="utf-8")
+
+
+def test_build_launcher_session_plan_uses_production_live_dcs_flags(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    log_path = tmp_path / "logs" / "live.jsonl"
+
+    plan = build_launcher_session_plan(settings, log_path=log_path, session_id="sess-P01-T01", python_executable="python")
+
+    assert plan.live_log_path == log_path
+    assert plan.sidecar_command[:3] == ("python", "-u", "tools/capture_vision_sidecar.py")
+    assert plan.live_dcs_command[:4] == ("python", "-m", "simtutor", "live-dcs")
+    assert "--bios-source" in plan.live_dcs_command
+    assert "raw" in plan.live_dcs_command
+    assert "--global-help-hotkey" in plan.live_dcs_command
+    assert "X1" in plan.live_dcs_command
+    assert "--max-overlay-targets" in plan.live_dcs_command
+    assert "4" in plan.live_dcs_command
+    assert "--model-enable-multimodal" in plan.live_dcs_command
+    assert "--no-cold-start-production" in plan.live_dcs_command
+    assert plan.export_command[:4] == ("python", "-m", "simtutor", "experiment-export")
+    assert "--strict" in plan.export_command
+    assert "--study-id" in plan.export_command
+    assert "--recording-ref" in plan.export_command
+    assert plan.analyze_command[:4] == ("python", "-m", "simtutor", "experiment-analyze")
+
+
+def test_dry_run_formats_exact_commands_and_unique_log_path(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    first = tmp_path / "logs" / "live_dcs_P01_T01_20260521_153000.jsonl"
+    first.write_text("", encoding="utf-8")
+
+    log_path = resolve_unique_live_log_path(settings, timestamp="20260521_153000")
+    plan = build_launcher_session_plan(settings, log_path=log_path, session_id="sess-P01-T01", python_executable="python")
+    text = format_dry_run_plan(plan)
+
+    assert log_path.name == "live_dcs_P01_T01_20260521_153000_2.jsonl"
+    assert "python -m simtutor live-dcs" in text
+    assert str(log_path) in text
+    assert "python -m simtutor experiment-export" in text
+    assert "python -m simtutor experiment-analyze" in text
+
+
+def test_session_starts_preflight_tunnel_model_sidecar_then_live_and_stops_in_reverse(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, model_profile_mode="remote_tunnel")
+    settings.ssh_user = "yz"
+    settings.ssh_host = "example.invalid"
+    events: list[str] = []
+
+    def process_factory(*, name: str, command: list[str], **kwargs: object) -> FakeProcess:
+        return FakeProcess(name=name, command=command, events=events, **kwargs)
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=process_factory,
+        tunnel_factory=lambda received: FakeTunnel(received, events),
+        preflight_runner=lambda received: events.append("preflight") or FakeReport(ok=True),
+        model_validator=lambda received: events.append("model") or FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    result = session.start()
+    session.stop(run_post_run=False)
+
+    assert result.live_log_path.name == "live_dcs_P01_T01_20260521_153000.jsonl"
+    assert events == [
+        "preflight",
+        "start:tunnel",
+        "model",
+        "start:vision-sidecar",
+        "start:live-dcs",
+        "stop:live-dcs",
+        "stop:vision-sidecar",
+        "stop:tunnel",
+    ]
+
+
+def test_session_stop_runs_export_then_analysis_after_live_processes_stop(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    events: list[str] = []
+
+    def process_factory(*, name: str, command: list[str], **kwargs: object) -> FakeProcess:
+        return FakeProcess(name=name, command=command, events=events, **kwargs)
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=process_factory,
+        preflight_runner=lambda _settings: FakeReport(ok=True),
+        model_validator=lambda _settings: FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    session.start()
+    session.stop(run_post_run=True)
+
+    assert events == [
+        "start:vision-sidecar",
+        "start:live-dcs",
+        "stop:live-dcs",
+        "stop:vision-sidecar",
+        "start:experiment-export",
+        "wait:experiment-export",
+        "start:experiment-analyze",
+        "wait:experiment-analyze",
+    ]
+
+
+def test_session_stop_allows_user_terminated_live_process_when_log_exists(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    events: list[str] = []
+
+    def process_factory(*, name: str, command: list[str], **kwargs: object) -> FakeProcess:
+        return FakeProcess(
+            name=name,
+            command=command,
+            events=events,
+            stop_returncode=(-15 if name == "live-dcs" else 0),
+            **kwargs,
+        )
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=process_factory,
+        preflight_runner=lambda _settings: FakeReport(ok=True),
+        model_validator=lambda _settings: FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    session.start()
+    session.stop(run_post_run=True)
+
+    assert "start:experiment-export" in events
+
+
+def test_session_rejects_repeated_start_while_live_process_is_running(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    events: list[str] = []
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=lambda **kwargs: FakeProcess(events=events, **kwargs),
+        preflight_runner=lambda _settings: FakeReport(ok=True),
+        model_validator=lambda _settings: FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    session.start()
+
+    with pytest.raises(LauncherSessionError, match="already running"):
+        session.start()
+
+    assert events.count("start:live-dcs") == 1
+
+
+def test_post_run_rejects_live_process_that_is_still_running(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    events: list[str] = []
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=lambda **kwargs: FakeProcess(events=events, **kwargs),
+        preflight_runner=lambda _settings: FakeReport(ok=True),
+        model_validator=lambda _settings: FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    session.start()
+
+    with pytest.raises(LauncherSessionError, match="still running"):
+        session.run_post_run()
+
+    assert "start:experiment-export" not in events
+
+
+def test_preflight_failure_short_circuits_before_live_dcs(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    events: list[str] = []
+
+    def process_factory(*, name: str, command: list[str], **kwargs: object) -> FakeProcess:
+        return FakeProcess(name=name, command=command, events=events, **kwargs)
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=process_factory,
+        preflight_runner=lambda _settings: FakeReport(ok=False, text="missing hook"),
+        model_validator=lambda _settings: events.append("model") or FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    with pytest.raises(LauncherSessionError, match="preflight failed"):
+        session.start()
+
+    assert events == []
+
+
+def test_missing_strict_export_metadata_short_circuits_before_preflight(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    settings.study_id = ""
+    events: list[str] = []
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=lambda **kwargs: FakeProcess(events=events, **kwargs),
+        preflight_runner=lambda _settings: events.append("preflight") or FakeReport(ok=True),
+        model_validator=lambda _settings: events.append("model") or FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    with pytest.raises(LauncherSessionError, match="study_id"):
+        session.start()
+
+    assert events == []
+
+
+def test_model_failure_stops_launcher_owned_tunnel_before_live_dcs(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, model_profile_mode="remote_tunnel")
+    settings.ssh_user = "yz"
+    settings.ssh_host = "example.invalid"
+    events: list[str] = []
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=lambda **kwargs: FakeProcess(events=events, **kwargs),
+        tunnel_factory=lambda received: FakeTunnel(received, events),
+        preflight_runner=lambda _settings: FakeReport(ok=True),
+        model_validator=lambda _settings: FakeReport(ok=False, text="missing model"),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    with pytest.raises(LauncherSessionError, match="model validation failed"):
+        session.start()
+
+    assert events == ["start:tunnel", "stop:tunnel"]
+
+
+def test_stop_blocks_post_run_when_live_log_is_missing(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    events: list[str] = []
+
+    class NoLogProcess(FakeProcess):
+        def start(self) -> None:
+            self.events.append(f"start:{self.name}")
+            self.started = True
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=lambda **kwargs: NoLogProcess(events=events, **kwargs),
+        preflight_runner=lambda _settings: FakeReport(ok=True),
+        model_validator=lambda _settings: FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    session.start()
+
+    with pytest.raises(LauncherSessionError, match="live-dcs log was not written"):
+        session.stop(run_post_run=True)
+
+    assert "start:experiment-export" not in events
+
+
+def test_stop_blocks_post_run_when_live_process_already_failed(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    events: list[str] = []
+
+    def process_factory(*, name: str, command: list[str], **kwargs: object) -> FakeProcess:
+        return FakeProcess(
+            name=name,
+            command=command,
+            events=events,
+            initial_returncode=(1 if name == "live-dcs" else None),
+            **kwargs,
+        )
+
+    session = LauncherExperimentSession(
+        settings,
+        process_factory=process_factory,
+        preflight_runner=lambda _settings: FakeReport(ok=True),
+        model_validator=lambda _settings: FakeReport(ok=True),
+        timestamp=lambda: "20260521_153000",
+    )
+
+    session.start()
+
+    with pytest.raises(LauncherSessionError, match="live-dcs exited with code 1"):
+        session.stop(run_post_run=True)
+
+    assert "start:experiment-export" not in events

--- a/tests/test_launcher_settings.py
+++ b/tests/test_launcher_settings.py
@@ -121,6 +121,14 @@ def test_validate_settings_reports_non_numeric_numbers() -> None:
     assert "max_overlay_targets" in message
 
 
+def test_validate_settings_rejects_invalid_raw_bios_port() -> None:
+    settings = _valid_settings()
+    settings.raw_bios_port = 70000
+
+    with pytest.raises(LauncherSettingsError, match="raw_bios_port"):
+        validate_settings(settings)
+
+
 def test_openai_compat_requires_model_base_url() -> None:
     settings = _valid_settings()
     settings.model_base_url = ""


### PR DESCRIPTION
## Summary
- add launcher session orchestration for preflight, optional tunnel, model validation, vision sidecar, live-dcs, strict export, and analysis
- extend launcher settings/GUI fields for formal experiment metadata and production live-dcs parameters
- add tests for dry-run commands, process ordering, stop/export behavior, failure short-circuiting, unique logs, and launcher validation

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_launcher_session.py tests/test_launcher_settings.py tests/test_launcher_preflight.py tests/test_launcher_model_check.py tests/test_launcher_tunnel.py tests/test_launcher_entry.py tests/test_launcher_processes.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=/tmp/iefmmq-pytest-full -p no:cacheprovider

Closes #367