### PR TITLE
Add passive baseline step inference

### DIFF
--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -17,6 +17,7 @@ import yaml
 from core.gating import GatingEngine
 from core.help_cycle_audit import normalize_help_cycle_audit_fields
 from core.interaction_metrics import InteractionMetrics, compute_interaction_metrics
+from core.vars import VarResolver, VarResolverError
 
 
 def _str_list(raw: Any) -> list[str]:
@@ -1187,12 +1188,16 @@ def _inferred_step_completion_notes(
     return inferred
 
 
+PassiveCompletionNotes = Mapping[str, tuple[Sequence[str], str]]
+
+
 def _build_step_coding(
     events: Sequence[Mapping[str, Any]],
     *,
     meta: SessionMeta,
     help_cycles: Sequence[HelpCycleRecord],
     pack_steps: Sequence[Mapping[str, Any]],
+    passive_completion_notes: PassiveCompletionNotes | None = None,
 ) -> list[StepCodingRecord]:
     completed_steps: set[str] = set()
     activated_steps: set[str] = set()
@@ -1226,7 +1231,14 @@ def _build_step_coding(
         cycles = [cycle for cycle in help_cycles if _help_cycle_matches_step(cycle, step_id)]
         completed = step_id in completed_steps
         inferred_completion = inferred_completion_notes.get(step_id)
+        passive_completion = (
+            passive_completion_notes.get(step_id)
+            if passive_completion_notes is not None
+            else None
+        )
         if not completed and inferred_completion is not None:
+            completed = True
+        if not completed and passive_completion is not None:
             completed = True
         performed = completed or step_id in activated_steps or bool(cycles)
 
@@ -1241,10 +1253,14 @@ def _build_step_coding(
                 evidence_refs.append("frames:" + _join_csv_values(cycle.frame_ids))
         if inferred_completion is not None:
             evidence_refs.append(inferred_completion[0])
+        if passive_completion is not None:
+            evidence_refs.extend(passive_completion[0])
 
         auto_notes: list[str] = ["human_error_columns_blank"]
         if step_id in completed_event_seen:
             auto_notes.append("completed_from_step_completed")
+        elif passive_completion is not None:
+            auto_notes.append(passive_completion[1])
         elif inferred_completion is not None:
             auto_notes.append(inferred_completion[1])
         elif performed:
@@ -1606,6 +1622,175 @@ def _build_action_timeline(
                 last_values[key] = value
 
     return rows
+
+
+def _passive_completion_enabled(
+    *,
+    meta: SessionMeta,
+    scoring: Mapping[str, Any] | None,
+) -> bool:
+    condition = meta.condition.strip().lower()
+    if condition in {"without_tutor", "baseline", "no_tutor"}:
+        return True
+    if isinstance(scoring, Mapping):
+        return _opt_bool(scoring.get("passive_step_inference")) is True
+    return False
+
+
+def _pack_telemetry_map_path(pack_path: str | Path | None) -> Path | None:
+    if pack_path is None:
+        return None
+    candidate = Path(pack_path).parent / "telemetry_map.yaml"
+    return candidate if candidate.exists() else None
+
+
+def _load_var_resolver_for_export(pack_path: str | Path | None) -> VarResolver | None:
+    telemetry_map_path = _pack_telemetry_map_path(pack_path)
+    if telemetry_map_path is None:
+        return None
+    try:
+        return VarResolver.from_yaml(telemetry_map_path)
+    except (OSError, VarResolverError, yaml.YAMLError):
+        return None
+
+
+def _passive_vars_history_by_event(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    pack_path: str | Path | None,
+) -> list[dict[str, Any]]:
+    resolver = _load_var_resolver_for_export(pack_path)
+    current_bios: dict[str, Any] = {}
+    current_vars: dict[str, Any] = {}
+    history: list[dict[str, Any]] = []
+
+    for ev in events:
+        for key, value in _event_bios_map(ev).items():
+            if isinstance(key, str) and key:
+                current_bios[key] = value
+        for key, value in _extract_event_delta_items(ev):
+            current_bios[key] = value
+        for key, value in _event_vars(ev).items():
+            if isinstance(key, str) and key:
+                current_vars[key] = value
+
+        if resolver is not None:
+            try:
+                current_vars.update(
+                    resolver.resolve({"bios": current_bios, "vars": current_vars})
+                )
+            except VarResolverError:
+                pass
+
+        vars_snapshot = dict(current_vars)
+        bios_snapshot = dict(current_bios)
+        history.append(
+            {
+                "vars": vars_snapshot,
+                "bios": bios_snapshot,
+                "payload": {"vars": vars_snapshot, "bios": bios_snapshot},
+            }
+        )
+
+    return history
+
+
+def _actions_by_event_and_step(
+    action_timeline: Sequence[ActionTimelineRecord],
+) -> dict[int, dict[str, list[str]]]:
+    by_event: dict[int, dict[str, list[str]]] = {}
+    for action in action_timeline:
+        raw_key = action.RawKey
+        if not raw_key:
+            continue
+        for step_id in _split_csv_values(action.CandidateStepID):
+            by_event.setdefault(action.EventIndex, {}).setdefault(step_id, [])
+            if raw_key not in by_event[action.EventIndex][step_id]:
+                by_event[action.EventIndex][step_id].append(raw_key)
+    return by_event
+
+
+def _passive_completion_requires_transition(step_id: str) -> bool:
+    return step_id in {"S21", "S23", "S25"}
+
+
+def _passive_completion_prerequisite(step_id: str) -> str | None:
+    return {
+        "S21": "S20",
+        "S23": "S22",
+        "S25": "S24",
+    }.get(step_id)
+
+
+def _gate_rules(raw_rules: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_rules, list) or not raw_rules:
+        return []
+    return [dict(rule) for rule in raw_rules if isinstance(rule, Mapping)]
+
+
+def _passive_gate_refs(step_id: str, rules: Sequence[Mapping[str, Any]]) -> list[str]:
+    refs: list[str] = []
+    for rule in rules:
+        reason_code = _opt_str(rule.get("reason_code"))
+        var_path = _opt_str(rule.get("var"))
+        if reason_code:
+            refs.append(f"passive_gate:{step_id}:{reason_code}")
+        elif var_path:
+            refs.append(f"passive_gate:{step_id}:{var_path}")
+        if var_path:
+            refs.append(f"telemetry_var:{var_path}")
+    return refs
+
+
+def _passive_completion_notes(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    action_timeline: Sequence[ActionTimelineRecord],
+    pack_steps: Sequence[Mapping[str, Any]],
+    pack_path: str | Path | None,
+    scenario_profile: str | None,
+) -> dict[str, tuple[Sequence[str], str]]:
+    gate_config = _load_gate_config_for_export(pack_path, scenario_profile=scenario_profile)
+    completion_gates = gate_config["completion_gates"]
+    if not completion_gates:
+        return {}
+
+    step_ids = [
+        step_id
+        for step in pack_steps
+        if (step_id := _opt_str(step.get("id"))) is not None
+    ]
+    vars_history = _passive_vars_history_by_event(events, pack_path=pack_path)
+    action_refs_by_event = _actions_by_event_and_step(action_timeline)
+    last_allowed: dict[str, bool] = {}
+    notes: dict[str, tuple[Sequence[str], str]] = {}
+
+    for event_index, vars_snapshot in enumerate(vars_history):
+        action_refs_for_event = action_refs_by_event.get(event_index, {})
+        for step_id in step_ids:
+            if step_id in notes:
+                continue
+            rules = _gate_rules(completion_gates.get(step_id))
+            if not rules:
+                continue
+            allowed = GatingEngine(rules).evaluate([vars_snapshot]).allowed
+            previous_allowed = last_allowed.get(step_id)
+            action_refs = action_refs_for_event.get(step_id, [])
+            gate_transition = previous_allowed is False and allowed
+            action_supported = bool(action_refs) and not _passive_completion_requires_transition(step_id)
+            prerequisite = _passive_completion_prerequisite(step_id)
+            if prerequisite is not None and prerequisite not in notes:
+                last_allowed[step_id] = allowed
+                continue
+
+            if allowed and (gate_transition or action_supported):
+                refs = _passive_gate_refs(step_id, rules)
+                refs.extend(f"action:{raw_key}" for raw_key in action_refs)
+                notes[step_id] = (refs, "completed_from_passive_gate")
+
+            last_allowed[step_id] = allowed
+
+    return notes
 
 
 _AUTO_CONFIDENCE_RANK = {"": 0, "low": 1, "medium": 2, "high": 3}
@@ -2293,11 +2478,23 @@ def build_experiment_export(
         bios_to_ui_path=bios_to_ui_path,
         ui_map_path=ui_map_path,
     )
+    passive_completion_notes = (
+        _passive_completion_notes(
+            events,
+            action_timeline=action_timeline,
+            pack_steps=pack_steps,
+            pack_path=pack_path,
+            scenario_profile=meta.scenario_profile,
+        )
+        if _passive_completion_enabled(meta=meta, scoring=scoring)
+        else None
+    )
     step_coding = _build_step_coding(
         events,
         meta=meta,
         help_cycles=help_cycles,
         pack_steps=pack_steps,
+        passive_completion_notes=passive_completion_notes,
     )
     _apply_pre_scoring_candidates(
         events,

--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -1695,31 +1695,15 @@ def _passive_vars_history_by_event(
     return history
 
 
-def _actions_by_event_and_step(
+def _actions_by_event(
     action_timeline: Sequence[ActionTimelineRecord],
-) -> dict[int, dict[str, list[str]]]:
-    by_event: dict[int, dict[str, list[str]]] = {}
+) -> dict[int, list[ActionTimelineRecord]]:
+    by_event: dict[int, list[ActionTimelineRecord]] = {}
     for action in action_timeline:
-        raw_key = action.RawKey
-        if not raw_key:
+        if not action.RawKey:
             continue
-        for step_id in _split_csv_values(action.CandidateStepID):
-            by_event.setdefault(action.EventIndex, {}).setdefault(step_id, [])
-            if raw_key not in by_event[action.EventIndex][step_id]:
-                by_event[action.EventIndex][step_id].append(raw_key)
+        by_event.setdefault(action.EventIndex, []).append(action)
     return by_event
-
-
-def _passive_completion_requires_transition(step_id: str) -> bool:
-    return step_id in {"S21", "S23", "S25"}
-
-
-def _passive_completion_prerequisite(step_id: str) -> str | None:
-    return {
-        "S21": "S20",
-        "S23": "S22",
-        "S25": "S24",
-    }.get(step_id)
 
 
 def _gate_rules(raw_rules: Any) -> list[dict[str, Any]]:
@@ -1760,28 +1744,55 @@ def _passive_completion_notes(
         for step in pack_steps
         if (step_id := _opt_str(step.get("id"))) is not None
     ]
+    step_order = {step_id: idx for idx, step_id in enumerate(step_ids)}
+    rules_by_step = {
+        step_id: rules
+        for step_id in step_ids
+        if (rules := _gate_rules(completion_gates.get(step_id)))
+    }
     vars_history = _passive_vars_history_by_event(events, pack_path=pack_path)
-    action_refs_by_event = _actions_by_event_and_step(action_timeline)
+    actions_by_event = _actions_by_event(action_timeline)
     last_allowed: dict[str, bool] = {}
     notes: dict[str, tuple[Sequence[str], str]] = {}
 
     for event_index, vars_snapshot in enumerate(vars_history):
-        action_refs_for_event = action_refs_by_event.get(event_index, {})
+        allowed_by_step = {
+            step_id: GatingEngine(rules).evaluate([vars_snapshot]).allowed
+            for step_id, rules in rules_by_step.items()
+        }
+        action_candidates_for_event: set[str] = set()
+        action_refs_for_step: dict[str, list[str]] = {}
+        for action in actions_by_event.get(event_index, []):
+            candidates = sorted(
+                _split_csv_values(action.CandidateStepID),
+                key=lambda step_id: step_order.get(step_id, len(step_order)),
+            )
+            action_candidates_for_event.update(candidates)
+            for candidate in candidates:
+                if candidate in notes:
+                    continue
+                if allowed_by_step.get(candidate) is not True:
+                    break
+                action_refs_for_step.setdefault(candidate, [])
+                if action.RawKey not in action_refs_for_step[candidate]:
+                    action_refs_for_step[candidate].append(action.RawKey)
+                break
+
         for step_id in step_ids:
             if step_id in notes:
                 continue
-            rules = _gate_rules(completion_gates.get(step_id))
-            if not rules:
+            rules = rules_by_step.get(step_id)
+            if rules is None:
                 continue
-            allowed = GatingEngine(rules).evaluate([vars_snapshot]).allowed
+            allowed = allowed_by_step[step_id]
             previous_allowed = last_allowed.get(step_id)
-            action_refs = action_refs_for_event.get(step_id, [])
-            gate_transition = previous_allowed is False and allowed
-            action_supported = bool(action_refs) and not _passive_completion_requires_transition(step_id)
-            prerequisite = _passive_completion_prerequisite(step_id)
-            if prerequisite is not None and prerequisite not in notes:
-                last_allowed[step_id] = allowed
-                continue
+            action_refs = action_refs_for_step.get(step_id, [])
+            gate_transition = (
+                previous_allowed is False
+                and allowed
+                and step_id not in action_candidates_for_event
+            )
+            action_supported = bool(action_refs)
 
             if allowed and (gate_transition or action_supported):
                 refs = _passive_gate_refs(step_id, rules)

--- a/docs/wiki/experiment-operation-manual.md
+++ b/docs/wiki/experiment-operation-manual.md
@@ -599,14 +599,14 @@ python -m simtutor extract-live-fixture `
 3. 询问是否继续。
 4. 如果停止，记录 `participant_stop_vr_discomfort`。
 
-### 11.5 Baseline 无法自动导出完整步骤
+### 11.5 Baseline passive export 需要复核
 
-baseline 条件可能没有 help cycles，因此自动 `step_coding.csv` 可能不完整。处理方式：
+baseline 条件通常没有 help cycles，但 `experiment-export` 会优先使用 passive telemetry、derived vars 和 pack completion gates 自动填充 `step_coding.csv`。处理方式：
 
-1. 保留 raw log 和录像。
-2. 用录像人工编码 S01-S33。
-3. 在 `experimenter_notes` 中写明 baseline 使用 video/manual coding。
-4. 分析时把 automatic coding 和 human coding 区分开。
+1. 保留 raw log 和录像，确保自动编码可追溯。
+2. 先检查 `EvidenceRefs` 和 `AutoCodingNotes`；自动完成通常会标记 `completed_from_passive_gate`、`passive_gate:*` 和 `telemetry_var:*`。
+3. 对 telemetry 不足、不可观测动作、实验异常或自动编码明显不符合录像的步骤，再用录像进行人工复核和修正。
+4. 分析时区分自动字段（如 `Completed`、`EvidenceRefs`、`AutoCodingNotes`）和人工字段（如 `Error_*`、`CoderID`、`CoderNotes`）。
 
 ## 12. 实验当天一页清单
 

--- a/docs/wiki/experiment-operation-manual.md
+++ b/docs/wiki/experiment-operation-manual.md
@@ -222,7 +222,11 @@ python .\tools\simtutor_launcher.py
 
 - 不向参与者提供 X1 help 操作。
 - 如果需要 passive logging，可仍启动 launcher，但必须记录“participant did not use tutor help”。
-- 若 baseline log 不能自动推断完整步骤，使用录像和 `step_coding.csv` 人工修正作为主数据。
+- baseline export 会把 DCS-BIOS observation、derived telemetry vars 和 pack completion gates 作为隐藏 passive evidence，用于自动填充可审计的 step completion。
+- passive logging 不会调用 LLM/VLM，不显示 overlay，也不向参与者暴露 step hint。
+- `step_coding.csv` 中 `Completed`、`EvidenceRefs`、`AutoCodingNotes` 可包含自动 gate evidence，例如 `completed_from_passive_gate`、`passive_gate:S01:s01_requires_battery_on`、`telemetry_var:vars.battery_on`。
+- `HelpRequests`、`LLMTriggers`、`VLMCalls`、`OverlayExecuted` 在未请求帮助的 baseline trial 中应保持 0。
+- 人工/录像编码仍用于审计和修正，尤其是不可观测动作、视频可见但 telemetry 不足的步骤，以及 `Error_*` 人工错误类型列。
 
 ### 6.2 Launcher 操作顺序
 

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -1318,6 +1318,166 @@ def test_step_coding_accepts_top_level_step_id_events(tmp_path: Path):
     assert export.trial_summary[0].Completed == "yes"
 
 
+def _make_observation_only_baseline_events() -> list[dict]:
+    t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)
+    return [
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 1,
+                "t_wall": 1.0,
+                "source": "dcs_bios",
+                "bios": {"BATTERY_SW": 2, "L_GEN_SW": 1, "R_GEN_SW": 1},
+                "delta": {"BATTERY_SW": 2},
+            },
+            "metadata": {"seq": 1, "delta_count": 1},
+            "t_wall": 1.0,
+            "timestamp": t0.isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 2,
+                "t_wall": 3.0,
+                "source": "dcs_bios",
+                "bios": {
+                    "BATTERY_SW": 2,
+                    "L_GEN_SW": 1,
+                    "R_GEN_SW": 1,
+                    "APU_CONTROL_SW": 1,
+                    "APU_READY_LT": 1,
+                },
+                "delta": {"APU_CONTROL_SW": 1},
+            },
+            "metadata": {"seq": 2, "delta_count": 1},
+            "t_wall": 3.0,
+            "timestamp": (t0 + timedelta(seconds=2)).isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 3,
+                "t_wall": 5.0,
+                "source": "dcs_bios",
+                "bios": {"PROBE_SW": 1, "EXT_REFUEL_PROBE": 0},
+                "delta": {"PROBE_SW": 1, "EXT_REFUEL_PROBE": 0},
+            },
+            "metadata": {"seq": 3, "delta_count": 2},
+            "t_wall": 5.0,
+            "timestamp": (t0 + timedelta(seconds=4)).isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 4,
+                "t_wall": 8.0,
+                "source": "dcs_bios",
+                "bios": {"PROBE_SW": 1, "EXT_REFUEL_PROBE": 65535},
+                "delta": {"EXT_REFUEL_PROBE": 65535},
+            },
+            "metadata": {"seq": 4, "delta_count": 1},
+            "t_wall": 8.0,
+            "timestamp": (t0 + timedelta(seconds=7)).isoformat(),
+        },
+        {
+            "kind": "observation",
+            "source": "dcs_bios",
+            "payload": {
+                "seq": 5,
+                "t_wall": 11.0,
+                "source": "dcs_bios",
+                "bios": {"PROBE_SW": 1, "EXT_REFUEL_PROBE": 0},
+                "delta": {"EXT_REFUEL_PROBE": 0},
+            },
+            "metadata": {"seq": 5, "delta_count": 1},
+            "t_wall": 11.0,
+            "timestamp": (t0 + timedelta(seconds=10)).isoformat(),
+        },
+    ]
+
+
+def test_without_tutor_export_marks_passive_telemetry_gate_completions() -> None:
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_observation_only_baseline_events(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P_BASE", "condition": "without_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    rows = {row.StepID: row for row in export.step_coding}
+    assert rows["S01"].Completed == "yes"
+    assert rows["S03"].Completed == "yes"
+    assert rows["S20"].Completed == "yes"
+    assert rows["S21"].Completed == "yes"
+    assert "completed_from_passive_gate" in rows["S01"].AutoCodingNotes
+    assert "passive_gate:S01:s01_requires_battery_on" in rows["S01"].EvidenceRefs
+    assert "action:BATTERY_SW" in rows["S01"].EvidenceRefs
+    assert "telemetry_var:vars.ext_refuel_probe_value" in rows["S20"].EvidenceRefs
+
+    trial = export.trial_summary[0]
+    assert trial.HelpRequests == 0
+    assert trial.LLMTriggers == 0
+    assert trial.VLMCalls == 0
+    assert trial.OverlayExecuted == 0
+    assert trial.TotalStepsCompleted >= 4
+    assert trial.StepCompletionAccuracy > 0
+
+
+def test_passive_export_does_not_complete_mapped_action_when_gate_is_unsatisfied() -> None:
+    root = _repo_root()
+    event = _make_observation_only_baseline_events()[0]
+    event["payload"]["bios"] = {"BATTERY_SW": 2}
+    export = build_experiment_export(
+        [event],
+        meta_overrides={"trial_id": "T01", "participant_id": "P_BASE", "condition": "without_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    rows = {row.StepID: row for row in export.step_coding}
+    assert rows["S01"].Completed == "no"
+    assert export.trial_summary[0].TotalStepsCompleted == 0
+
+
+def test_passive_export_does_not_complete_retraction_from_initial_latch_state() -> None:
+    root = _repo_root()
+    event = _make_observation_only_baseline_events()[2]
+    export = build_experiment_export(
+        [event],
+        meta_overrides={"trial_id": "T01", "participant_id": "P_BASE", "condition": "without_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    rows = {row.StepID: row for row in export.step_coding}
+    assert rows["S20"].Completed == "no"
+    assert rows["S21"].Completed == "no"
+
+
+def test_with_tutor_export_does_not_use_passive_baseline_inference() -> None:
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_observation_only_baseline_events(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P_HELP", "condition": "with_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    rows = {row.StepID: row for row in export.step_coding}
+    assert rows["S01"].Completed == "no"
+    assert rows["S03"].Completed == "no"
+    assert export.trial_summary[0].TotalStepsCompleted == 0
+
+
 def test_trial_summary_counts_vlm_calls_once_per_help_cycle():
     events = _make_events_with_help_cycles()
     events[9]["metadata"]["vlm_call_status"] = "called"

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -1462,6 +1462,85 @@ def test_passive_export_does_not_complete_retraction_from_initial_latch_state() 
     assert rows["S21"].Completed == "no"
 
 
+def test_passive_export_assigns_shared_action_to_earliest_uncompleted_candidate() -> None:
+    root = _repo_root()
+    event = {
+        "kind": "observation",
+        "source": "dcs_bios",
+        "payload": {
+            "seq": 1,
+            "t_wall": 1.0,
+            "source": "dcs_bios",
+            "bios": {"FLAP_SW": 2},
+            "delta": {"FLAP_SW": 2},
+        },
+        "metadata": {"seq": 1, "delta_count": 1},
+        "t_wall": 1.0,
+        "timestamp": datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc).isoformat(),
+    }
+
+    export = build_experiment_export(
+        [event],
+        meta_overrides={"trial_id": "T01", "participant_id": "P_BASE", "condition": "without_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    rows = {row.StepID: row for row in export.step_coding}
+    assert rows["S16"].Completed == "yes"
+    assert rows["S27"].Completed == "no"
+
+
+def test_passive_export_respects_completion_gate_profile_overrides() -> None:
+    root = _repo_root()
+    event = {
+        "kind": "observation",
+        "source": "dcs_bios",
+        "payload": {
+            "seq": 1,
+            "t_wall": 1.0,
+            "source": "dcs_bios",
+            "bios": {"RADALT_MIN_HEIGHT_PTR": 4000},
+            "delta": {"RADALT_MIN_HEIGHT_PTR": 4000},
+        },
+        "metadata": {"seq": 1, "delta_count": 1},
+        "t_wall": 1.0,
+        "timestamp": datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc).isoformat(),
+    }
+
+    airfield = build_experiment_export(
+        [event],
+        meta_overrides={
+            "trial_id": "T01",
+            "participant_id": "P_BASE",
+            "condition": "without_tutor",
+            "scenario_profile": "airfield",
+        },
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+    carrier = build_experiment_export(
+        [event],
+        meta_overrides={
+            "trial_id": "T01",
+            "participant_id": "P_BASE",
+            "condition": "without_tutor",
+            "scenario_profile": "carrier",
+        },
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    airfield_rows = {row.StepID: row for row in airfield.step_coding}
+    carrier_rows = {row.StepID: row for row in carrier.step_coding}
+    assert airfield_rows["S31"].Completed == "no"
+    assert carrier_rows["S31"].Completed == "yes"
+    assert "passive_gate:S31:s31_requires_radalt_bug_carrier_40" in carrier_rows["S31"].EvidenceRefs
+
+
 def test_with_tutor_export_does_not_use_passive_baseline_inference() -> None:
     root = _repo_root()
     export = build_experiment_export(


### PR DESCRIPTION
## Summary
- add export-time passive step completion inference for no-help baseline logs
- derive telemetry vars from the pack sibling telemetry map and require completion gates before marking steps complete
- add observation-only baseline tests for S01/S03 and S20/S21 threshold behavior, plus guard tests for unsatisfied gates and with_tutor exports
- document hidden passive baseline logging semantics in the experiment manual

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/test_experiment_analysis.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #372