### PR TITLE
Add baseline visual step review policy

### DIFF
--- a/artifacts/live_fixtures/3465ec45-e87c-48bd-8f1c-5f59d1abeafd.fixture.json
+++ b/artifacts/live_fixtures/3465ec45-e87c-48bd-8f1c-5f59d1abeafd.fixture.json
@@ -1,0 +1,4355 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 4424,
+        "frame_count": 20,
+        "latest_seq": 4443
+      },
+      "vision_fresh_count": 2,
+      "vision_seen_count": 2,
+      "vision_status": "available"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+      "source_observation_seq": 4443,
+      "source_observation_t_wall": 1779186077.9357684,
+      "telemetry_window_first_seq": 4424,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 4443,
+      "telemetry_window_latest_t_wall": 1779186077.9357684,
+      "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+    },
+    "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:65362",
+          "raw_delta_count": 1,
+          "seq": 4443
+        },
+        "observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41327
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 4443,
+          "t_wall": 1779186077.9357684,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": false,
+            "comm1_freq_value": 30500,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": false,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 0,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 0.0,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 0,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 0,
+            "rpm_l_gte_25": false,
+            "rpm_l_gte_60": false,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 10,
+            "temp_r": 302,
+            "throttle_l_not_off": false,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T10:21:17.935768+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 4424,
+      "frame_count": 20,
+      "latest_seq": 4443
+    },
+    "vision": {
+      "frame_ids": [
+        "1779186078097_000169"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779186078097_000169",
+        "frame_ids": [
+          "1779186078097_000169"
+        ],
+        "frame_stale": false,
+        "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+        "observation_seq": 4443,
+        "observation_t_wall_ms": 1779186077936,
+        "observation_t_wall_s": 1779186077.9357684,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779186078097,
+            "channel": "composite_panel",
+            "frame_id": "1779186078097_000169",
+            "frame_seq": 169,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186078097_000169_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186078097_000169.png",
+            "sync_delta_ms": 82,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 82,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779186078097,
+          "channel": "composite_panel",
+          "frame_id": "1779186078097_000169",
+          "frame_seq": 169,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186078097_000169_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186078097_000169.png",
+          "sync_delta_ms": 82,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779186078015,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779186078097_000169"
+        ],
+        "fresh_fact_ids": [
+          "tac_page_visible",
+          "bit_root_page_visible"
+        ],
+        "not_seen_fact_ids": [
+          "supt_page_visible",
+          "fcs_page_visible",
+          "fcs_page_x_marks_visible",
+          "fcsmc_page_visible",
+          "fcsmc_intermediate_result_visible",
+          "fcsmc_in_test_visible",
+          "fcsmc_final_go_result_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "seen_fact_ids": [
+          "tac_page_visible",
+          "bit_root_page_visible"
+        ],
+        "status": "available",
+        "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": [
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "tac_page_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "supt_page_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "fcs_page_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "fcs_page_x_marks_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "bit_root_page_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "fcsmc_page_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "fcsmc_intermediate_result_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "fcsmc_in_test_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 600000,
+          "expires_at_wall_ms": 1779186678015,
+          "fact_id": "fcsmc_final_go_result_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": true
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "hsi_page_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "hsi_map_layer_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "ins_grnd_alignment_text_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186080015,
+          "fact_id": "ins_ok_text_visible",
+          "observed_at_wall_ms": 1779186078015,
+          "source_frame_id": "1779186078097_000169",
+          "state": "not_seen",
+          "sticky": false
+        }
+      ]
+    },
+    "vision_fact_observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "frame_ids": [
+            "1779186078097_000169"
+          ],
+          "observation_kind": "vision_fact"
+        },
+        "observation_id": "8042d0cf-4588-45ce-b5d9-0b7d62a07289",
+        "payload": {
+          "facts": [
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "tac_page_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "supt_page_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_x_marks_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "bit_root_page_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_page_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_intermediate_result_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_in_test_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 600000,
+              "fact_id": "fcsmc_final_go_result_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": true
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_page_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_map_layer_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_grnd_alignment_text_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_ok_text_visible",
+              "observed_at_wall_ms": 1779186078015,
+              "result_kind": null,
+              "source_frame_id": "1779186078097_000169",
+              "state": "not_seen",
+              "sticky": false
+            }
+          ],
+          "frame_ids": [
+            "1779186078097_000169"
+          ],
+          "metadata": {
+            "coerced_source_frame_fact_ids": [],
+            "coerced_source_frame_fact_ids_alias_of": "ignored_legacy_source_frame_fact_ids",
+            "configured_fact_count": 13,
+            "ignored_legacy_source_frame_fact_ids": [],
+            "ignored_model_fact_fields": {},
+            "raw_fact_count": 13,
+            "raw_llm_text": "{\"facts\":[{\"fact_id\":\"tac_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"supt_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_x_marks_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"bit_root_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_intermediate_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_in_test_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_final_go_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_map_layer_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_grnd_alignment_text_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_ok_text_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"}]}",
+            "sanitized_fact_count": 13,
+            "skipped_incomplete_mapping_fact_count": 0,
+            "skipped_non_mapping_fact_count": 0,
+            "skipped_unknown_fact_id_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186078097_000169"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            }
+          },
+          "observation_id": "8042d0cf-4588-45ce-b5d9-0b7d62a07289",
+          "schema_version": "v2",
+          "session_id": "sess-live",
+          "source": "vision_fact_extractor",
+          "summary": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "timestamp": "2026-05-19T10:21:24.955361+00:00",
+          "trigger_wall_ms": 1779186078015
+        },
+        "procedure_hint": null,
+        "source": "vision_fact_extractor",
+        "tags": [],
+        "timestamp": "2026-05-19T10:21:24.955361+00:00",
+        "version": "v1"
+      }
+    ]
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "kind": "tutor_request",
+        "lineno": 4887,
+        "metadata": {
+          "frame_id": "1779186078097_000169",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 82,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_status": "available",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S08",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S08",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "visual_action_hint": {
+                "target": "left_mdi_pb18"
+              }
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 4424,
+                "frame_count": 20,
+                "latest_seq": 4443
+              },
+              "vision_fresh_count": 2,
+              "vision_seen_count": 2,
+              "vision_status": "available"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+              "source_observation_seq": 4443,
+              "source_observation_t_wall": 1779186077.9357684,
+              "telemetry_window_first_seq": 4424,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4443,
+              "telemetry_window_latest_t_wall": 1779186077.9357684,
+              "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 24.68020444405941,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_5",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+                "score": 18.8448804259338,
+                "section": "Phase P3 – Displays & Communications (S08–S09)",
+                "snippet_id": "Appendix - Training Task Syllabus_5"
+              },
+              {
+                "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+                "doc_id": "fa18c_fcs_bit_procedure_note",
+                "score": 16.6046650051719,
+                "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_8",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q8. Displays and Pages",
+                "score": 14.680311339813862,
+                "section": "Q8. Displays and Pages",
+                "snippet_id": "fa18c_coldstart_quiz_8"
+              },
+              {
+                "chunk_id": "fa18c_scoring_sheet_template_2",
+                "doc_id": "fa18c_scoring_sheet_template",
+                "page_or_heading": "2. Step-Level Coding",
+                "score": 13.885103733356358,
+                "section": "2. Step-Level Coding",
+                "snippet_id": "fa18c_scoring_sheet_template_2"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vision_facts.fcs_page_visible==seen"
+                ],
+                "overlay_step_id": "S08",
+                "role": "candidate_not_authoritative",
+                "step_id": "S08"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 4443,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 4424,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4443,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 4443,
+                "latest_t_wall": 1779186077.9357684,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.215
+              },
+              "vision_evidence": {
+                "confidence": "high",
+                "fresh_fact_ids": [
+                  "bit_root_page_visible",
+                  "tac_page_visible"
+                ],
+                "late_display_anchors": [
+                  "bit_root_page_visible",
+                  "tac_page_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible",
+                  "supt_page_visible"
+                ],
+                "seen_fact_ids": [
+                  "bit_root_page_visible",
+                  "tac_page_visible"
+                ],
+                "source_status": "available",
+                "visual_candidate_steps": [
+                  "S08",
+                  "S09"
+                ]
+              }
+            },
+            "vision": {
+              "frame_id": "1779186078097_000169",
+              "frame_ids": [
+                "1779186078097_000169"
+              ],
+              "frame_stale": false,
+              "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+              "observation_seq": 4443,
+              "observation_t_wall_ms": 1779186077936,
+              "observation_t_wall_s": 1779186077.9357684,
+              "status": "partial",
+              "sync_delta_ms": 82,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779186078015,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186078097_000169"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "fact_id": "tac_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "supt_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_x_marks_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "bit_root_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_in_test_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_map_layer_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_ok_text_visible",
+                "frame_ids": null,
+                "status": null
+              }
+            ]
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 4424,
+                "frame_count": 20,
+                "latest_seq": 4443
+              },
+              "vision_fresh_count": 2,
+              "vision_seen_count": 2,
+              "vision_status": "available"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+              "source_observation_seq": 4443,
+              "source_observation_t_wall": 1779186077.9357684,
+              "telemetry_window_first_seq": 4424,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4443,
+              "telemetry_window_latest_t_wall": 1779186077.9357684,
+              "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "frame_id": "1779186078097_000169",
+            "fused_missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "fused_step_id": "S08",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_startup_master_1"
+            ],
+            "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+            "prompt_tokens_est": 1133,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "source_chunk_refs": [
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+              "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_8",
+              "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 82,
+            "vision_fact_seen_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186078097_000169"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779186078097_000169"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+          "request_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "timestamp": "2026-05-19T10:21:24.995959+00:00",
+          "version": "v1"
+        },
+        "related_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "vision_refs": [
+          "1779186078097_000169"
+        ]
+      },
+      {
+        "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "kind": "overlay_requested",
+        "lineno": 4888,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779186078097_000169",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 82,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "e8aa10a8-4dbd-45a6-b158-92dce3f69b87",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779186078097_000169",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 82,
+          "target": "pnt_203",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "kind": "overlay_requested",
+        "lineno": 4889,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779186078097_000169",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 82,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "9e8a33c9-3e2d-421f-841f-000fd0e1303c",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779186078097_000169",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 82,
+          "target": "pnt_124",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "kind": "tutor_response",
+        "lineno": 4890,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779186078097_000169",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 82,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "frame_id": "1779186078097_000169",
+              "fused_missing_conditions": [
+                "vision_facts.fcs_page_visible==seen"
+              ],
+              "fused_step_id": "S08",
+              "generation_mode": "model",
+              "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 82,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779186078097_000169"
+                ],
+                "fresh_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "supt_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "S08 的最新证据已经满足。现在进入 S09。"
+          ],
+          "in_reply_to": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "message": "S08 的最新证据已经满足。现在进入 S09。",
+          "metadata": {
+            "allowed_evidence_ref_count": 129,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "a8060033-b39e-4c88-b397-e4ea83ff404b",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "S08 的最新证据已经满足。现在进入 S09。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S09"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+              "source_observation_seq": 4443,
+              "source_observation_t_wall": 1779186077.9357684,
+              "telemetry_window_first_seq": 4424,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4443,
+              "telemetry_window_latest_t_wall": 1779186077.9357684,
+              "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "overlay_step_id": "S09",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 129,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "next": {
+                "step_id": "S09"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_original_actions": [
+              {
+                "element_id": "pnt_51",
+                "evidence_refs": [
+                  "VISION_FACTS.tac_page_visible@1779186078097_000169"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "left_mdi_brightness_selector",
+                "type": "overlay"
+              }
+            ],
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S09",
+            "final_evidence_consistency_reasons": [
+              "completion_gate_already_satisfied:S08"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_124",
+                  "evidence_refs": [
+                    "VARS.left_ddi_on"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_comm1_channel_selector_pull"
+                  ],
+                  "frame_id": "1779186078097_000169",
+                  "fused_missing_conditions": [
+                    "vision_facts.fcs_page_visible==seen"
+                  ],
+                  "fused_step_id": "S08",
+                  "generation_mode": "model",
+                  "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 82,
+                  "target": "ufc_comm1_channel_selector_pull",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_ignored_count": 0,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779186078097_000169"
+                    ],
+                    "fresh_fact_ids": [
+                      "tac_page_visible",
+                      "bit_root_page_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "supt_page_visible",
+                      "fcs_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible",
+                      "fcsmc_final_go_result_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "tac_page_visible",
+                      "bit_root_page_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "S08 的最新证据已经满足。现在进入 S09。"
+              ],
+              "message": "S08 的最新证据已经满足。现在进入 S09。",
+              "next": {
+                "step_id": "S09"
+              }
+            },
+            "frame_id": "1779186078097_000169",
+            "fused_missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "fused_step_id": "S08",
+            "generation_mode": "model",
+            "generation_prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+            "generation_prompt_tokens_est": 1133,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S09",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_brightness_selector",
+                    "right_mdi_brightness_selector",
+                    "ampcd_off_brightness_knob",
+                    "hud_symbology_brightness_knob",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15",
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.tac_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.tac_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_brightness_selector",
+                    "right_mdi_brightness_selector",
+                    "ampcd_off_brightness_knob",
+                    "hud_symbology_brightness_knob",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15",
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "GATES.S09.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": [
+                    "GATES.S10.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S11",
+                  "supporting_evidence_refs": [
+                    "GATES.S11.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.86,
+                "proposed_next_action_target_ids": [
+                  "ufc_comm1_channel_selector_pull",
+                  "ufc_key_1",
+                  "ufc_key_3",
+                  "ufc_key_4",
+                  "ufc_key_0",
+                  "ufc_ent_button"
+                ],
+                "role": "candidate",
+                "source": "visual_anchor",
+                "step_id": "S09",
+                "supporting_evidence_refs": [
+                  "VISION_FACTS.bit_root_page_visible",
+                  "VISION_FACTS.tac_page_visible"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 4424,
+                  "frame_count": 20,
+                  "latest_seq": 4443
+                },
+                "vision_fresh_count": 2,
+                "vision_seen_count": 2,
+                "vision_status": "available"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+                "source_observation_seq": 4443,
+                "source_observation_t_wall": 1779186077.9357684,
+                "telemetry_window_first_seq": 4424,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 4443,
+                "telemetry_window_latest_t_wall": 1779186077.9357684,
+                "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "overlay_step_id": "S09",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S09",
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "VISION_FACTS.tac_page_visible@1779186078097_000169"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "left_mdi_brightness_selector"
+                ],
+                "status": "ok",
+                "step_id": "S08"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S08"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+                "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "completion_gate_already_satisfied:S08"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S08"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": true,
+                "extractor_used": true,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779186078097_000169"
+                ],
+                "ignored_fact_count": 0,
+                "reason": "missing_pre_trigger_frame",
+                "status": "called",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 82,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "available",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "completion_gate_already_satisfied:S08"
+            ],
+            "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "S08 的最新证据已经满足。现在进入 S09。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.left_ddi_on",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "explanations": [
+                "当前左 DDI 显示 TAC 页面，S08 要求进入 FCS 页面。请操作 left_mdi_brightness_selector 或相关导航控件切换页面。"
+              ],
+              "next": {
+                "step_id": "S08"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.tac_page_visible@1779186078097_000169",
+                    "target": "left_mdi_brightness_selector",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "left_mdi_brightness_selector"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4570,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S08"
+            },
+            "model_raw_explanations": [
+              "当前左 DDI 显示 TAC 页面，S08 要求进入 FCS 页面。请操作 left_mdi_brightness_selector 或相关导航控件切换页面。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "explanations": [
+                "当前左 DDI 显示 TAC 页面，S08 要求进入 FCS 页面。请操作 left_mdi_brightness_selector 或相关导航控件切换页面。"
+              ],
+              "next": {
+                "step_id": "S08"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.tac_page_visible@1779186078097_000169",
+                    "target": "left_mdi_brightness_selector",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "left_mdi_brightness_selector"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S08"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779186078097_000169"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779186078097_000169",
+            "next": {
+              "step_id": "S09"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 907,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "VISION_FACTS.tac_page_visible@1779186078097_000169",
+                "VISION_FACTS.supt_page_visible@1779186078097_000169"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 3,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": null,
+              "prompt_chars": 4531,
+              "prompt_tokens_est": 1133,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 1,
+              "rag_snippet_ids": [
+                "fa18c_startup_master_1"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [
+                "S08",
+                "S09"
+              ],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_overlay_enum",
+                "trimmed_rag_snippets",
+                "compact_template"
+              ],
+              "vision_fact_seen_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "vision_fact_status": "available"
+            },
+            "prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+            "prompt_tokens_est": 1133,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "rejected_model_step_id": "S08",
+            "rejected_model_target": "left_mdi_brightness_selector",
+            "rejected_model_targets": [
+              "left_mdi_brightness_selector"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+            "request_prompt_tokens_est": 1133,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 129,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "next": {
+                "step_id": "S08"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+              "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+            },
+            "state_key": "77cede1b822c73a43e375ea19198699e3fed9d977d56738134ae914287bdd2e1",
+            "sync_delta_ms": 82,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779186078097_000169",
+              "frame_ids": [
+                "1779186078097_000169"
+              ],
+              "frame_stale": false,
+              "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+              "observation_seq": 4443,
+              "observation_t_wall_ms": 1779186077936,
+              "observation_t_wall_s": 1779186077.9357684,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779186078097,
+                  "channel": "composite_panel",
+                  "frame_id": "1779186078097_000169",
+                  "frame_seq": 169,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186078097_000169_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186078097_000169.png",
+                  "sync_delta_ms": 82,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 82,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779186078097,
+                "channel": "composite_panel",
+                "frame_id": "1779186078097_000169",
+                "frame_seq": 169,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186078097_000169_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186078097_000169.png",
+                "sync_delta_ms": 82,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779186078015,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S08"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": true,
+            "vision_fact_ignored_count": 0,
+            "vision_fact_status": "available",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186078097_000169"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "tac_page_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "supt_page_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "fcs_page_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "fcs_page_x_marks_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "bit_root_page_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "fcsmc_page_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "fcsmc_in_test_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 600000,
+                "expires_at_wall_ms": 1779186678015,
+                "fact_id": "fcsmc_final_go_result_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": true
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "hsi_page_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "hsi_map_layer_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186080015,
+                "fact_id": "ins_ok_text_visible",
+                "observed_at_wall_ms": 1779186078015,
+                "source_frame_id": "1779186078097_000169",
+                "state": "not_seen",
+                "sticky": false
+              }
+            ],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779186078097_000169"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "missing_pre_trigger_frame",
+            "vlm_call_status": "called"
+          },
+          "response_id": "6f097e7b-2f02-43a4-ad46-0a8da6de0a08",
+          "status": "ok",
+          "timestamp": "2026-05-19T10:21:29.567419+00:00",
+          "version": "v1"
+        },
+        "related_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "vision_refs": [
+          "1779186078097_000169"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S08",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S08",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "visual_action_hint": {
+            "target": "left_mdi_pb18"
+          }
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 4424,
+            "frame_count": 20,
+            "latest_seq": 4443
+          },
+          "vision_fresh_count": 2,
+          "vision_seen_count": 2,
+          "vision_status": "available"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+          "source_observation_seq": 4443,
+          "source_observation_t_wall": 1779186077.9357684,
+          "telemetry_window_first_seq": 4424,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4443,
+          "telemetry_window_latest_t_wall": 1779186077.9357684,
+          "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 24.68020444405941,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_5",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+            "score": 18.8448804259338,
+            "section": "Phase P3 – Displays & Communications (S08–S09)",
+            "snippet_id": "Appendix - Training Task Syllabus_5"
+          },
+          {
+            "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+            "doc_id": "fa18c_fcs_bit_procedure_note",
+            "score": 16.6046650051719,
+            "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_8",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q8. Displays and Pages",
+            "score": 14.680311339813862,
+            "section": "Q8. Displays and Pages",
+            "snippet_id": "fa18c_coldstart_quiz_8"
+          },
+          {
+            "chunk_id": "fa18c_scoring_sheet_template_2",
+            "doc_id": "fa18c_scoring_sheet_template",
+            "page_or_heading": "2. Step-Level Coding",
+            "score": 13.885103733356358,
+            "section": "2. Step-Level Coding",
+            "snippet_id": "fa18c_scoring_sheet_template_2"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "overlay_step_id": "S08",
+            "role": "candidate_not_authoritative",
+            "step_id": "S08"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 4443,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 4424,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4443,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 4443,
+            "latest_t_wall": 1779186077.9357684,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.215
+          },
+          "vision_evidence": {
+            "confidence": "high",
+            "fresh_fact_ids": [
+              "bit_root_page_visible",
+              "tac_page_visible"
+            ],
+            "late_display_anchors": [
+              "bit_root_page_visible",
+              "tac_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible",
+              "supt_page_visible"
+            ],
+            "seen_fact_ids": [
+              "bit_root_page_visible",
+              "tac_page_visible"
+            ],
+            "source_status": "available",
+            "visual_candidate_steps": [
+              "S08",
+              "S09"
+            ]
+          }
+        },
+        "vision": {
+          "frame_id": "1779186078097_000169",
+          "frame_ids": [
+            "1779186078097_000169"
+          ],
+          "frame_stale": false,
+          "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+          "observation_seq": 4443,
+          "observation_t_wall_ms": 1779186077936,
+          "observation_t_wall_s": 1779186077.9357684,
+          "status": "partial",
+          "sync_delta_ms": 82,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779186078015,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779186078097_000169"
+          ],
+          "fresh_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible"
+          ],
+          "not_seen_fact_ids": [
+            "supt_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "fact_id": "tac_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "supt_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_x_marks_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "bit_root_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_in_test_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_map_layer_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_ok_text_visible",
+            "frame_ids": null,
+            "status": null
+          }
+        ]
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 4424,
+            "frame_count": 20,
+            "latest_seq": 4443
+          },
+          "vision_fresh_count": 2,
+          "vision_seen_count": 2,
+          "vision_status": "available"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+          "source_observation_seq": 4443,
+          "source_observation_t_wall": 1779186077.9357684,
+          "telemetry_window_first_seq": 4424,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4443,
+          "telemetry_window_latest_t_wall": 1779186077.9357684,
+          "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "frame_id": "1779186078097_000169",
+        "fused_missing_conditions": [
+          "vision_facts.fcs_page_visible==seen"
+        ],
+        "fused_step_id": "S08",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_startup_master_1"
+        ],
+        "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+        "prompt_tokens_est": 1133,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "source_chunk_refs": [
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+          "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_8",
+          "fa18c_scoring_sheet_template/fa18c_scoring_sheet_template_2"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 82,
+        "vision_fact_seen_ids": [
+          "tac_page_visible",
+          "bit_root_page_visible"
+        ],
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779186078097_000169"
+          ],
+          "fresh_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible"
+          ],
+          "not_seen_fact_ids": [
+            "supt_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779186078097_000169"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+      "request_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+      "timestamp": "2026-05-19T10:21:24.995959+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_124",
+          "evidence_refs": [
+            "VARS.left_ddi_on"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779186078097_000169",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 82,
+          "target": "ufc_comm1_channel_selector_pull",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "S08 的最新证据已经满足。现在进入 S09。"
+      ],
+      "in_reply_to": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+      "message": "S08 的最新证据已经满足。现在进入 S09。",
+      "metadata": {
+        "allowed_evidence_ref_count": 129,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "a8060033-b39e-4c88-b397-e4ea83ff404b",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "S08 的最新证据已经满足。现在进入 S09。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S09"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+          "source_observation_seq": 4443,
+          "source_observation_t_wall": 1779186077.9357684,
+          "telemetry_window_first_seq": 4424,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4443,
+          "telemetry_window_latest_t_wall": 1779186077.9357684,
+          "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "overlay_step_id": "S09",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 129,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "next": {
+            "step_id": "S09"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_original_actions": [
+          {
+            "element_id": "pnt_51",
+            "evidence_refs": [
+              "VISION_FACTS.tac_page_visible@1779186078097_000169"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "left_mdi_brightness_selector",
+            "type": "overlay"
+          }
+        ],
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S09",
+        "final_evidence_consistency_reasons": [
+          "completion_gate_already_satisfied:S08"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "frame_id": "1779186078097_000169",
+              "fused_missing_conditions": [
+                "vision_facts.fcs_page_visible==seen"
+              ],
+              "fused_step_id": "S08",
+              "generation_mode": "model",
+              "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 82,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779186078097_000169"
+                ],
+                "fresh_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "supt_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "S08 的最新证据已经满足。现在进入 S09。"
+          ],
+          "message": "S08 的最新证据已经满足。现在进入 S09。",
+          "next": {
+            "step_id": "S09"
+          }
+        },
+        "frame_id": "1779186078097_000169",
+        "fused_missing_conditions": [
+          "vision_facts.fcs_page_visible==seen"
+        ],
+        "fused_step_id": "S08",
+        "generation_mode": "model",
+        "generation_prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+        "generation_prompt_tokens_est": 1133,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S09",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S08",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.tac_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.tac_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S08",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "GATES.S09.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S10",
+              "supporting_evidence_refs": [
+                "GATES.S10.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S11",
+              "supporting_evidence_refs": [
+                "GATES.S11.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.86,
+            "proposed_next_action_target_ids": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0",
+              "ufc_ent_button"
+            ],
+            "role": "candidate",
+            "source": "visual_anchor",
+            "step_id": "S09",
+            "supporting_evidence_refs": [
+              "VISION_FACTS.bit_root_page_visible",
+              "VISION_FACTS.tac_page_visible"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 4424,
+              "frame_count": 20,
+              "latest_seq": 4443
+            },
+            "vision_fresh_count": 2,
+            "vision_seen_count": 2,
+            "vision_status": "available"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+            "source_observation_seq": 4443,
+            "source_observation_t_wall": 1779186077.9357684,
+            "telemetry_window_first_seq": 4424,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 4443,
+            "telemetry_window_latest_t_wall": 1779186077.9357684,
+            "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "overlay_step_id": "S09",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S09",
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "VISION_FACTS.tac_page_visible@1779186078097_000169"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "left_mdi_brightness_selector"
+            ],
+            "status": "ok",
+            "step_id": "S08"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S08"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+            "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "completion_gate_already_satisfied:S08"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S08"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": true,
+            "extractor_used": true,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779186078097_000169"
+            ],
+            "ignored_fact_count": 0,
+            "reason": "missing_pre_trigger_frame",
+            "status": "called",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 82,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "available",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "completion_gate_already_satisfied:S08"
+        ],
+        "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "S08 的最新证据已经满足。现在进入 S09。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.left_ddi_on",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "explanations": [
+            "当前左 DDI 显示 TAC 页面，S08 要求进入 FCS 页面。请操作 left_mdi_brightness_selector 或相关导航控件切换页面。"
+          ],
+          "next": {
+            "step_id": "S08"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.tac_page_visible@1779186078097_000169",
+                "target": "left_mdi_brightness_selector",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "left_mdi_brightness_selector"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4570,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S08"
+        },
+        "model_raw_explanations": [
+          "当前左 DDI 显示 TAC 页面，S08 要求进入 FCS 页面。请操作 left_mdi_brightness_selector 或相关导航控件切换页面。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "explanations": [
+            "当前左 DDI 显示 TAC 页面，S08 要求进入 FCS 页面。请操作 left_mdi_brightness_selector 或相关导航控件切换页面。"
+          ],
+          "next": {
+            "step_id": "S08"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.tac_page_visible@1779186078097_000169",
+                "target": "left_mdi_brightness_selector",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "left_mdi_brightness_selector"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S08"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779186078097_000169"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779186078097_000169",
+        "next": {
+          "step_id": "S09"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 907,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "VISION_FACTS.tac_page_visible@1779186078097_000169",
+            "VISION_FACTS.supt_page_visible@1779186078097_000169"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 3,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": null,
+          "prompt_chars": 4531,
+          "prompt_tokens_est": 1133,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 1,
+          "rag_snippet_ids": [
+            "fa18c_startup_master_1"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [
+            "S08",
+            "S09"
+          ],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_overlay_enum",
+            "trimmed_rag_snippets",
+            "compact_template"
+          ],
+          "vision_fact_seen_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible"
+          ],
+          "vision_fact_status": "available"
+        },
+        "prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+        "prompt_tokens_est": 1133,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vision_facts.fcs_page_visible==seen"
+        ],
+        "rejected_model_step_id": "S08",
+        "rejected_model_target": "left_mdi_brightness_selector",
+        "rejected_model_targets": [
+          "left_mdi_brightness_selector"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "0b542f9811a3b26f26cc7fce0f3d5ff61063352fef1ff7159aa2a13dade4c61c",
+        "request_prompt_tokens_est": 1133,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 129,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "next": {
+            "step_id": "S08"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+          "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+        },
+        "state_key": "77cede1b822c73a43e375ea19198699e3fed9d977d56738134ae914287bdd2e1",
+        "sync_delta_ms": 82,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779186078097_000169",
+          "frame_ids": [
+            "1779186078097_000169"
+          ],
+          "frame_stale": false,
+          "observation_ref": "01b0a858-1433-4987-8614-dab814b0c15d",
+          "observation_seq": 4443,
+          "observation_t_wall_ms": 1779186077936,
+          "observation_t_wall_s": 1779186077.9357684,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779186078097,
+              "channel": "composite_panel",
+              "frame_id": "1779186078097_000169",
+              "frame_seq": 169,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186078097_000169_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186078097_000169.png",
+              "sync_delta_ms": 82,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 82,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779186078097,
+            "channel": "composite_panel",
+            "frame_id": "1779186078097_000169",
+            "frame_seq": 169,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186078097_000169_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186078097_000169.png",
+            "sync_delta_ms": 82,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779186078015,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S08"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": true,
+        "vision_fact_ignored_count": 0,
+        "vision_fact_status": "available",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779186078097_000169"
+          ],
+          "fresh_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible"
+          ],
+          "not_seen_fact_ids": [
+            "supt_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=tac_page_visible,bit_root_page_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "tac_page_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "supt_page_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "fcs_page_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "fcs_page_x_marks_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "bit_root_page_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "fcsmc_page_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "fcsmc_in_test_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 600000,
+            "expires_at_wall_ms": 1779186678015,
+            "fact_id": "fcsmc_final_go_result_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": true
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "hsi_page_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "hsi_map_layer_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186080015,
+            "fact_id": "ins_ok_text_visible",
+            "observed_at_wall_ms": 1779186078015,
+            "source_frame_id": "1779186078097_000169",
+            "state": "not_seen",
+            "sticky": false
+          }
+        ],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779186078097_000169"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "missing_pre_trigger_frame",
+        "vlm_call_status": "called"
+      },
+      "response_id": "6f097e7b-2f02-43a4-ad46-0a8da6de0a08",
+      "status": "ok",
+      "timestamp": "2026-05-19T10:21:29.567419+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S09",
+    "expected_overlay_target_ids": [
+      "ufc_comm1_channel_selector_pull"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "called"
+  },
+  "extraction_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "left_mdi_brightness_selector",
+          "right_mdi_brightness_selector",
+          "ampcd_off_brightness_knob",
+          "hud_symbology_brightness_knob",
+          "left_mdi_pb18",
+          "left_mdi_pb15",
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S08",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.tac_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.tac_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "left_mdi_brightness_selector",
+          "right_mdi_brightness_selector",
+          "ampcd_off_brightness_knob",
+          "hud_symbology_brightness_knob",
+          "left_mdi_pb18",
+          "left_mdi_pb15",
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S08",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "GATES.S09.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S11",
+        "supporting_evidence_refs": [
+          "GATES.S11.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+      "overlay_step_id": "S09",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S09",
+      "targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VISION_FACTS.tac_page_visible@1779186078097_000169"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "left_mdi_brightness_selector"
+      ],
+      "status": "ok",
+      "step_id": "S08"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S08",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.tac_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.tac_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S08",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "GATES.S09.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S10",
+          "supporting_evidence_refs": [
+            "GATES.S10.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S11",
+          "supporting_evidence_refs": [
+            "GATES.S11.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.tac_page_visible"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 4424,
+          "frame_count": 20,
+          "latest_seq": 4443
+        },
+        "vision_fresh_count": 2,
+        "vision_seen_count": 2,
+        "vision_status": "available"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "final_decision_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "model_request_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "source_observation_id": "01b0a858-1433-4987-8614-dab814b0c15d",
+        "source_observation_seq": 4443,
+        "source_observation_t_wall": 1779186077.9357684,
+        "telemetry_window_first_seq": 4424,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 4443,
+        "telemetry_window_latest_t_wall": 1779186077.9357684,
+        "validator_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "overlay_step_id": "S09",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S09",
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "VISION_FACTS.tac_page_visible@1779186078097_000169"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "left_mdi_brightness_selector"
+        ],
+        "status": "ok",
+        "step_id": "S08"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S08"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "final_decision": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "model_request": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157",
+        "validator": "fb9627a403e6bd80299840fa1c334fc390888757040a5d4646908cc9a9d58157"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "completion_gate_already_satisfied:S08"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S08"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": true,
+        "extractor_used": true,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779186078097_000169"
+        ],
+        "ignored_fact_count": 0,
+        "reason": "missing_pre_trigger_frame",
+        "status": "called",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 82,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "available",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "completion_gate_already_satisfied:S08"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S08"
+    }
+  },
+  "help_cycle_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "S08 的最新证据已经满足。现在进入 S09。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.left_ddi_on",
+            "target": "ufc_comm1_channel_selector_pull",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S08"
+      },
+      "explanations": [
+        "当前左 DDI 显示 TAC 页面，S08 要求进入 FCS 页面。请操作 left_mdi_brightness_selector 或相关导航控件切换页面。"
+      ],
+      "next": {
+        "step_id": "S08"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VISION_FACTS.tac_page_visible@1779186078097_000169",
+            "target": "left_mdi_brightness_selector",
+            "type": "visual"
+          }
+        ],
+        "targets": [
+          "left_mdi_brightness_selector"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "3465ec45-e87c-48bd-8f1c-5f59d1abeafd",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 9258,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_101353.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/9608382d-ee62-486f-9d90-0c9d74997241.fixture.json
+++ b/artifacts/live_fixtures/9608382d-ee62-486f-9d90-0c9d74997241.fixture.json
@@ -1,0 +1,4466 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 6949,
+        "frame_count": 20,
+        "latest_seq": 6968
+      },
+      "vision_fresh_count": 5,
+      "vision_seen_count": 5,
+      "vision_status": "available"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+      "source_observation_seq": 6968,
+      "source_observation_t_wall": 1779186209.5005546,
+      "telemetry_window_first_seq": 6949,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 6968,
+      "telemetry_window_latest_t_wall": 1779186209.5005546,
+      "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+    },
+    "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:65362",
+          "raw_delta_count": 1,
+          "seq": 6968
+        },
+        "observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41499
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 6968,
+          "t_wall": 1779186209.5005546,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": false,
+            "apu_ready": false,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": true,
+            "comm1_freq_value": 13400,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": true,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": true,
+            "fcs_reset_pressed": false,
+            "ff_l": 700,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": true,
+            "flap_configured": true,
+            "flap_full": false,
+            "flap_half": false,
+            "flap_mode_value": 2,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": true,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 2,
+            "ins_mode_cv_or_gnd": true,
+            "ins_mode_set": true,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": true,
+            "left_engine_nominal_start_params": true,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 76.3103685053788,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": true,
+            "obogs_switch_on": true,
+            "oil_l": 60,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": true,
+            "radar_on": true,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 64,
+            "rpm_l_gte_25": true,
+            "rpm_l_gte_60": true,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": true,
+            "temp_l": 314,
+            "temp_r": 302,
+            "throttle_l_not_off": true,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T10:23:29.500554+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 6949,
+      "frame_count": 20,
+      "latest_seq": 6968
+    },
+    "vision": {
+      "frame_ids": [
+        "1779186209644_000178"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779186209644_000178",
+        "frame_ids": [
+          "1779186209644_000178"
+        ],
+        "frame_stale": false,
+        "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+        "observation_seq": 6968,
+        "observation_t_wall_ms": 1779186209501,
+        "observation_t_wall_s": 1779186209.5005546,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779186209644,
+            "channel": "composite_panel",
+            "frame_id": "1779186209644_000178",
+            "frame_seq": 178,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186209644_000178_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186209644_000178.png",
+            "sync_delta_ms": 84,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 84,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779186209644,
+          "channel": "composite_panel",
+          "frame_id": "1779186209644_000178",
+          "frame_seq": 178,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186209644_000178_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186209644_000178.png",
+          "sync_delta_ms": 84,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779186209560,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779186209644_000178"
+        ],
+        "fresh_fact_ids": [
+          "tac_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible"
+        ],
+        "not_seen_fact_ids": [
+          "supt_page_visible",
+          "fcs_page_visible",
+          "fcs_page_x_marks_visible",
+          "fcsmc_page_visible",
+          "fcsmc_intermediate_result_visible",
+          "fcsmc_in_test_visible",
+          "fcsmc_final_go_result_visible",
+          "ins_ok_text_visible"
+        ],
+        "seen_fact_ids": [
+          "tac_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible"
+        ],
+        "status": "available",
+        "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": [
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "tac_page_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "supt_page_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "fcs_page_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "fcs_page_x_marks_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "bit_root_page_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "fcsmc_page_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "fcsmc_intermediate_result_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "fcsmc_in_test_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 600000,
+          "expires_at_wall_ms": 1779186809560,
+          "fact_id": "fcsmc_final_go_result_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": true
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "hsi_page_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "hsi_map_layer_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "ins_grnd_alignment_text_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779186211560,
+          "fact_id": "ins_ok_text_visible",
+          "observed_at_wall_ms": 1779186209560,
+          "source_frame_id": "1779186209644_000178",
+          "state": "not_seen",
+          "sticky": false
+        }
+      ]
+    },
+    "vision_fact_observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "frame_ids": [
+            "1779186209644_000178"
+          ],
+          "observation_kind": "vision_fact"
+        },
+        "observation_id": "b3ee65fc-55b6-4f26-8f9e-89491611e3cb",
+        "payload": {
+          "facts": [
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "tac_page_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "supt_page_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_x_marks_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "bit_root_page_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_page_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_intermediate_result_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_in_test_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 600000,
+              "fact_id": "fcsmc_final_go_result_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": true
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_page_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_map_layer_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_grnd_alignment_text_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_ok_text_visible",
+              "observed_at_wall_ms": 1779186209560,
+              "result_kind": null,
+              "source_frame_id": "1779186209644_000178",
+              "state": "not_seen",
+              "sticky": false
+            }
+          ],
+          "frame_ids": [
+            "1779186209644_000178"
+          ],
+          "metadata": {
+            "coerced_source_frame_fact_ids": [],
+            "coerced_source_frame_fact_ids_alias_of": "ignored_legacy_source_frame_fact_ids",
+            "configured_fact_count": 13,
+            "ignored_legacy_source_frame_fact_ids": [],
+            "ignored_model_fact_fields": {},
+            "raw_fact_count": 13,
+            "raw_llm_text": "{\"facts\":[{\"fact_id\":\"tac_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"supt_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_x_marks_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"bit_root_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_intermediate_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_in_test_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_final_go_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_map_layer_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_grnd_alignment_text_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_ok_text_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"}]}",
+            "sanitized_fact_count": 13,
+            "skipped_incomplete_mapping_fact_count": 0,
+            "skipped_non_mapping_fact_count": 0,
+            "skipped_unknown_fact_id_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186209644_000178"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            }
+          },
+          "observation_id": "b3ee65fc-55b6-4f26-8f9e-89491611e3cb",
+          "schema_version": "v2",
+          "session_id": "sess-live",
+          "source": "vision_fact_extractor",
+          "summary": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+          "timestamp": "2026-05-19T10:23:36.496159+00:00",
+          "trigger_wall_ms": 1779186209560
+        },
+        "procedure_hint": null,
+        "source": "vision_fact_extractor",
+        "tags": [],
+        "timestamp": "2026-05-19T10:23:36.496159+00:00",
+        "version": "v1"
+      }
+    ]
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "kind": "tutor_request",
+        "lineno": 7462,
+        "metadata": {
+          "frame_id": "1779186209644_000178",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 84,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_status": "available",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "right_mdi_pb5"
+              },
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S18",
+              "missing_conditions_count": 1,
+              "observability": "partial",
+              "observability_status": "partial",
+              "overlay_step_id": "S18",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": true,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 6949,
+                "frame_count": 20,
+                "latest_seq": 6968
+              },
+              "vision_fresh_count": 5,
+              "vision_seen_count": 5,
+              "vision_status": "available"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+              "source_observation_seq": 6968,
+              "source_observation_t_wall": 1779186209.5005546,
+              "telemetry_window_first_seq": 6949,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 6968,
+              "telemetry_window_latest_t_wall": 1779186209.5005546,
+              "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+                "doc_id": "fa18c_fcs_bit_procedure_note",
+                "score": 18.196064173149253,
+                "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 17.171315153473643,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.29554266378183,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_10",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "3. Step Criticality",
+                "score": 12.835512117111474,
+                "section": "3. Step Criticality",
+                "snippet_id": "fa18c_error_coding_guide_10"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 93,
+                "score": 10.553560644586302,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vision_facts.fcsmc_page_visible==seen"
+                ],
+                "overlay_step_id": "S18",
+                "role": "candidate_not_authoritative",
+                "step_id": "S18"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 6968,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 6949,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "flap_auto"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 6968,
+                    "var": "mpcd_on"
+                  }
+                ],
+                "latest_seq": 6968,
+                "latest_t_wall": 1779186209.5005546,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "flap_auto",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.49
+              },
+              "vision_evidence": {
+                "confidence": "high",
+                "fresh_fact_ids": [
+                  "bit_root_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "tac_page_visible"
+                ],
+                "late_display_anchors": [
+                  "bit_root_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "tac_page_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_page_visible",
+                  "ins_ok_text_visible",
+                  "supt_page_visible"
+                ],
+                "seen_fact_ids": [
+                  "bit_root_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "tac_page_visible"
+                ],
+                "source_status": "available",
+                "visual_candidate_steps": [
+                  "S08",
+                  "S09",
+                  "S12",
+                  "S13"
+                ]
+              }
+            },
+            "vision": {
+              "frame_id": "1779186209644_000178",
+              "frame_ids": [
+                "1779186209644_000178"
+              ],
+              "frame_stale": false,
+              "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+              "observation_seq": 6968,
+              "observation_t_wall_ms": 1779186209501,
+              "observation_t_wall_s": 1779186209.5005546,
+              "status": "partial",
+              "sync_delta_ms": 84,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779186209560,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186209644_000178"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "fact_id": "tac_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "supt_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_x_marks_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "bit_root_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_in_test_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_map_layer_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_ok_text_visible",
+                "frame_ids": null,
+                "status": null
+              }
+            ]
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 6949,
+                "frame_count": 20,
+                "latest_seq": 6968
+              },
+              "vision_fresh_count": 5,
+              "vision_seen_count": 5,
+              "vision_status": "available"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+              "source_observation_seq": 6968,
+              "source_observation_t_wall": 1779186209.5005546,
+              "telemetry_window_first_seq": 6949,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 6968,
+              "telemetry_window_latest_t_wall": 1779186209.5005546,
+              "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "frame_id": "1779186209644_000178",
+            "fused_missing_conditions": [
+              "vision_facts.fcsmc_page_visible==seen"
+            ],
+            "fused_step_id": "S18",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_fcs_bit_procedure_note_0"
+            ],
+            "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+            "prompt_tokens_est": 1094,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "source_chunk_refs": [
+              "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 84,
+            "vision_fact_seen_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186209644_000178"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779186209644_000178"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+          "request_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "timestamp": "2026-05-19T10:23:36.526699+00:00",
+          "version": "v1"
+        },
+        "related_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "vision_refs": [
+          "1779186209644_000178"
+        ]
+      },
+      {
+        "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "kind": "overlay_requested",
+        "lineno": 7463,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb5"
+          ],
+          "frame_id": "1779186209644_000178",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 84,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "c95a1e9d-ec89-4f5a-88e7-d980940f0f91",
+          "final_overlay_targets": [
+            "right_mdi_pb5"
+          ],
+          "frame_id": "1779186209644_000178",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 84,
+          "target": "pnt_346",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "kind": "overlay_requested",
+        "lineno": 7464,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb5"
+          ],
+          "frame_id": "1779186209644_000178",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 84,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "168c50d1-8de3-4a10-aa0d-a594e9e405df",
+          "final_overlay_targets": [
+            "right_mdi_pb5"
+          ],
+          "frame_id": "1779186209644_000178",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 84,
+          "target": "pnt_83",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "kind": "tutor_response",
+        "lineno": 7465,
+        "metadata": {
+          "final_overlay_targets": [
+            "right_mdi_pb5"
+          ],
+          "frame_id": "1779186209644_000178",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "sync_delta_ms": 84,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_83",
+              "evidence_refs": [
+                "GATES.S18.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "right_mdi_pb5"
+              ],
+              "frame_id": "1779186209644_000178",
+              "fused_missing_conditions": [
+                "vision_facts.fcsmc_page_visible==seen"
+              ],
+              "fused_step_id": "S18",
+              "generation_mode": "model",
+              "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 84,
+              "target": "right_mdi_pb5",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779186209644_000178"
+                ],
+                "fresh_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "supt_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": "vision_conflict_unresolved",
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。"
+          ],
+          "in_reply_to": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "message": "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。",
+          "metadata": {
+            "allowed_evidence_ref_count": 129,
+            "completion_conflict_original_actions": [
+              {
+                "element_id": "pnt_96",
+                "evidence_refs": [
+                  "VISION_FACTS.tac_page_visible@1779186209644_000178"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "right_mdi_pb18",
+                "type": "overlay"
+              }
+            ],
+            "completion_conflict_original_explanations": [
+              "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。",
+              "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+            ],
+            "completion_conflict_original_message": "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。",
+            "completion_conflict_original_next": {
+              "step_id": "S08"
+            },
+            "completion_conflict_overlay_cleared": true,
+            "completion_conflict_rewritten": true,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "50e80b5b-f9f1-4802-8662-d181868cb1da",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S18"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+              "source_observation_seq": 6968,
+              "source_observation_t_wall": 1779186209.5005546,
+              "telemetry_window_first_seq": 6949,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 6968,
+              "telemetry_window_latest_t_wall": 1779186209.5005546,
+              "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "evidence_strength": "limited",
+            "failure_code": "vision_conflict_unresolved",
+            "failure_codes": [
+              "vision_conflict_unresolved"
+            ],
+            "failure_stage": "vision",
+            "fallback_explanations": [
+              "请先操作 right_mdi_pb5。",
+              "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+            ],
+            "fallback_message": "请先操作 right_mdi_pb5。",
+            "fallback_overlay_reason": "validator_action_hint",
+            "fallback_overlay_used": true,
+            "fallback_response_mapping": {
+              "allowed_evidence_ref_count": 129,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S18"
+              },
+              "evidence_strength": "limited",
+              "next": {
+                "step_id": "S18"
+              },
+              "observability_status": "partial",
+              "requires_visual_confirmation": true
+            },
+            "final_action_plan": {
+              "evidence_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "overlay_step_id": "S18",
+              "source": "validator_action_hint",
+              "step_id": "S18",
+              "targets": [
+                "right_mdi_pb5"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "validator_action_hint",
+            "final_overlay_targets": [
+              "right_mdi_pb5"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_83",
+                  "evidence_refs": [
+                    "GATES.S18.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "right_mdi_pb5"
+                  ],
+                  "frame_id": "1779186209644_000178",
+                  "fused_missing_conditions": [
+                    "vision_facts.fcsmc_page_visible==seen"
+                  ],
+                  "fused_step_id": "S18",
+                  "generation_mode": "model",
+                  "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "completion_conflict_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 84,
+                  "target": "right_mdi_pb5",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_ignored_count": 0,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779186209644_000178"
+                    ],
+                    "fresh_fact_ids": [
+                      "tac_page_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "supt_page_visible",
+                      "fcs_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible",
+                      "fcsmc_final_go_result_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "tac_page_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible",
+                      "ins_grnd_alignment_text_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": "vision_conflict_unresolved",
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。"
+              ],
+              "message": "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。",
+              "next": {
+                "step_id": "S18"
+              }
+            },
+            "frame_id": "1779186209644_000178",
+            "fused_missing_conditions": [
+              "vision_facts.fcsmc_page_visible==seen"
+            ],
+            "fused_step_id": "S18",
+            "generation_mode": "model",
+            "generation_prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+            "generation_prompt_tokens_est": 1094,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S18",
+              "source": "validator_action_hint",
+              "step_id": "S18",
+              "targets": [
+                "right_mdi_pb5"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_brightness_selector",
+                    "right_mdi_brightness_selector",
+                    "ampcd_off_brightness_knob",
+                    "hud_symbology_brightness_knob",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15",
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.tac_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.tac_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.tac_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.ins_grnd_alignment_text_visible",
+                    "VISION_FACTS.tac_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S18",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "refuel_probe_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S20",
+                  "supporting_evidence_refs": [
+                    "GATES.S20.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "launch_bar_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S22",
+                  "supporting_evidence_refs": [
+                    "GATES.S22.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "arresting_hook_handle"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S25",
+                  "supporting_evidence_refs": [
+                    "GATES.S25.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "right_mdi_pb18",
+                  "right_mdi_pb5"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S18",
+                "supporting_evidence_refs": []
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 6949,
+                  "frame_count": 20,
+                  "latest_seq": 6968
+                },
+                "vision_fresh_count": 5,
+                "vision_seen_count": 5,
+                "vision_status": "available"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+                "source_observation_seq": 6968,
+                "source_observation_t_wall": 1779186209.5005546,
+                "telemetry_window_first_seq": 6949,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 6968,
+                "telemetry_window_latest_t_wall": 1779186209.5005546,
+                "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "overlay_step_id": "S18",
+                "source": "validator_action_hint",
+                "step_id": "S18",
+                "targets": [
+                  "right_mdi_pb5"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "right_mdi_pb5"
+              ],
+              "message_category": "completion_conflict_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "VISION_FACTS.tac_page_visible@1779186209644_000178"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "right_mdi_pb18"
+                ],
+                "status": "ok",
+                "step_id": "S08"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "validator_action_hint"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+                "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "validator_action_hint",
+                "fallback_overlay_used": true,
+                "reasons": [],
+                "rejected": false,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": true,
+                "extractor_used": true,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779186209644_000178"
+                ],
+                "ignored_fact_count": 0,
+                "reason": "missing_pre_trigger_frame",
+                "status": "called",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 84,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "available",
+                "vision_status": "partial"
+              }
+            },
+            "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S18"
+              },
+              "explanations": [
+                "请先操作 right_mdi_pb5。"
+              ],
+              "next": {
+                "step_id": "S18"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S18.completion",
+                    "target": "right_mdi_pb5",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "right_mdi_pb5"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "explanations": [
+                "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。"
+              ],
+              "next": {
+                "step_id": "S08"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.tac_page_visible@1779186209644_000178",
+                    "target": "right_mdi_pb18",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "right_mdi_pb18"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 5220,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "completion_conflict_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S08"
+            },
+            "model_raw_explanations": [
+              "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "explanations": [
+                "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。"
+              ],
+              "next": {
+                "step_id": "S08"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.tac_page_visible@1779186209644_000178",
+                    "target": "right_mdi_pb18",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "right_mdi_pb18"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S08"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779186209644_000178"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779186209644_000178",
+            "next": {
+              "step_id": "S18"
+            },
+            "observability_status": "partial",
+            "presentation_fallback_plan_source": "validator_action_hint",
+            "presentation_fallback_reason": "deterministic_step:S18",
+            "prompt_budget_used": 5560,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "RAG_SNIPPETS.fa18c_fcs_bit_procedure_note_0",
+                "VISION_FACTS.tac_page_visible@1779186209644_000178",
+                "VISION_FACTS.supt_page_visible@1779186209644_000178"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 3,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "right_mdi_pb5",
+              "prompt_chars": 4375,
+              "prompt_tokens_est": 1094,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 1,
+              "rag_snippet_ids": [
+                "fa18c_fcs_bit_procedure_note_0"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [
+                "S08",
+                "S09",
+                "S12",
+                "S13"
+              ],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_overlay_enum",
+                "trimmed_rag_snippets",
+                "compact_template"
+              ],
+              "vision_fact_seen_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "vision_fact_status": "available"
+            },
+            "prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+            "prompt_tokens_est": 1094,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "repair_applied": false,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+            "request_prompt_tokens_est": 1094,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": true,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 129,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "evidence_strength": "limited",
+              "next": {
+                "step_id": "S08"
+              },
+              "observability_status": "partial",
+              "requires_visual_confirmation": true
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+              "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+            },
+            "state_key": "55021cdb90ef6a187d5f242e8553dbd4803177faa8a3660bb6854c50a3211cc1",
+            "sync_delta_ms": 84,
+            "vision": {
+              "frame_id": "1779186209644_000178",
+              "frame_ids": [
+                "1779186209644_000178"
+              ],
+              "frame_stale": false,
+              "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+              "observation_seq": 6968,
+              "observation_t_wall_ms": 1779186209501,
+              "observation_t_wall_s": 1779186209.5005546,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779186209644,
+                  "channel": "composite_panel",
+                  "frame_id": "1779186209644_000178",
+                  "frame_seq": 178,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186209644_000178_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186209644_000178.png",
+                  "sync_delta_ms": 84,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 84,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779186209644,
+                "channel": "composite_panel",
+                "frame_id": "1779186209644_000178",
+                "frame_seq": 178,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186209644_000178_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186209644_000178.png",
+                "sync_delta_ms": 84,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779186209560,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S18"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": true,
+            "vision_fact_ignored_count": 0,
+            "vision_fact_status": "available",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779186209644_000178"
+              ],
+              "fresh_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "not_seen_fact_ids": [
+                "supt_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "tac_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible",
+                "ins_grnd_alignment_text_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "tac_page_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "supt_page_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "fcs_page_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "fcs_page_x_marks_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "bit_root_page_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "fcsmc_page_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "fcsmc_in_test_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 600000,
+                "expires_at_wall_ms": 1779186809560,
+                "fact_id": "fcsmc_final_go_result_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": true
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "hsi_page_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "hsi_map_layer_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779186211560,
+                "fact_id": "ins_ok_text_visible",
+                "observed_at_wall_ms": 1779186209560,
+                "source_frame_id": "1779186209644_000178",
+                "state": "not_seen",
+                "sticky": false
+              }
+            ],
+            "vision_fallback_reason": "vision_conflict_unresolved",
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779186209644_000178"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "missing_pre_trigger_frame",
+            "vlm_call_status": "called"
+          },
+          "response_id": "cbb5ff64-9733-435c-8946-3628dc0d4d37",
+          "status": "ok",
+          "timestamp": "2026-05-19T10:23:41.749317+00:00",
+          "version": "v1"
+        },
+        "related_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "vision_refs": [
+          "1779186209644_000178"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "right_mdi_pb5"
+          },
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S18",
+          "missing_conditions_count": 1,
+          "observability": "partial",
+          "observability_status": "partial",
+          "overlay_step_id": "S18",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": true,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 6949,
+            "frame_count": 20,
+            "latest_seq": 6968
+          },
+          "vision_fresh_count": 5,
+          "vision_seen_count": 5,
+          "vision_status": "available"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+          "source_observation_seq": 6968,
+          "source_observation_t_wall": 1779186209.5005546,
+          "telemetry_window_first_seq": 6949,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 6968,
+          "telemetry_window_latest_t_wall": 1779186209.5005546,
+          "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+            "doc_id": "fa18c_fcs_bit_procedure_note",
+            "score": 18.196064173149253,
+            "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 17.171315153473643,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.29554266378183,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_10",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "3. Step Criticality",
+            "score": 12.835512117111474,
+            "section": "3. Step Criticality",
+            "snippet_id": "fa18c_error_coding_guide_10"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 93,
+            "score": 10.553560644586302,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vision_facts.fcsmc_page_visible==seen"
+            ],
+            "overlay_step_id": "S18",
+            "role": "candidate_not_authoritative",
+            "step_id": "S18"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 6968,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 6949,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "flap_auto"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 6968,
+                "var": "mpcd_on"
+              }
+            ],
+            "latest_seq": 6968,
+            "latest_t_wall": 1779186209.5005546,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "flap_auto",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.49
+          },
+          "vision_evidence": {
+            "confidence": "high",
+            "fresh_fact_ids": [
+              "bit_root_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "tac_page_visible"
+            ],
+            "late_display_anchors": [
+              "bit_root_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "tac_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_page_visible",
+              "ins_ok_text_visible",
+              "supt_page_visible"
+            ],
+            "seen_fact_ids": [
+              "bit_root_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "tac_page_visible"
+            ],
+            "source_status": "available",
+            "visual_candidate_steps": [
+              "S08",
+              "S09",
+              "S12",
+              "S13"
+            ]
+          }
+        },
+        "vision": {
+          "frame_id": "1779186209644_000178",
+          "frame_ids": [
+            "1779186209644_000178"
+          ],
+          "frame_stale": false,
+          "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+          "observation_seq": 6968,
+          "observation_t_wall_ms": 1779186209501,
+          "observation_t_wall_s": 1779186209.5005546,
+          "status": "partial",
+          "sync_delta_ms": 84,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779186209560,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779186209644_000178"
+          ],
+          "fresh_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "supt_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "fact_id": "tac_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "supt_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_x_marks_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "bit_root_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_in_test_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_map_layer_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_ok_text_visible",
+            "frame_ids": null,
+            "status": null
+          }
+        ]
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 6949,
+            "frame_count": 20,
+            "latest_seq": 6968
+          },
+          "vision_fresh_count": 5,
+          "vision_seen_count": 5,
+          "vision_status": "available"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+          "source_observation_seq": 6968,
+          "source_observation_t_wall": 1779186209.5005546,
+          "telemetry_window_first_seq": 6949,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 6968,
+          "telemetry_window_latest_t_wall": 1779186209.5005546,
+          "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "frame_id": "1779186209644_000178",
+        "fused_missing_conditions": [
+          "vision_facts.fcsmc_page_visible==seen"
+        ],
+        "fused_step_id": "S18",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_fcs_bit_procedure_note_0"
+        ],
+        "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+        "prompt_tokens_est": 1094,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "source_chunk_refs": [
+          "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 84,
+        "vision_fact_seen_ids": [
+          "tac_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible",
+          "ins_grnd_alignment_text_visible"
+        ],
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779186209644_000178"
+          ],
+          "fresh_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "supt_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779186209644_000178"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+      "request_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+      "timestamp": "2026-05-19T10:23:36.526699+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_83",
+          "evidence_refs": [
+            "GATES.S18.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "right_mdi_pb5"
+          ],
+          "frame_id": "1779186209644_000178",
+          "fused_missing_conditions": [
+            "vision_facts.fcsmc_page_visible==seen"
+          ],
+          "fused_step_id": "S18",
+          "generation_mode": "model",
+          "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "completion_conflict_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 84,
+          "target": "right_mdi_pb5",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "fresh_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "not_seen_fact_ids": [
+              "supt_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "tac_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible",
+              "ins_grnd_alignment_text_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": "vision_conflict_unresolved",
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。"
+      ],
+      "in_reply_to": "9608382d-ee62-486f-9d90-0c9d74997241",
+      "message": "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。",
+      "metadata": {
+        "allowed_evidence_ref_count": 129,
+        "completion_conflict_original_actions": [
+          {
+            "element_id": "pnt_96",
+            "evidence_refs": [
+              "VISION_FACTS.tac_page_visible@1779186209644_000178"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "right_mdi_pb18",
+            "type": "overlay"
+          }
+        ],
+        "completion_conflict_original_explanations": [
+          "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。",
+          "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+        ],
+        "completion_conflict_original_message": "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。",
+        "completion_conflict_original_next": {
+          "step_id": "S08"
+        },
+        "completion_conflict_overlay_cleared": true,
+        "completion_conflict_rewritten": true,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "50e80b5b-f9f1-4802-8662-d181868cb1da",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S18"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+          "source_observation_seq": 6968,
+          "source_observation_t_wall": 1779186209.5005546,
+          "telemetry_window_first_seq": 6949,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 6968,
+          "telemetry_window_latest_t_wall": 1779186209.5005546,
+          "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "evidence_strength": "limited",
+        "failure_code": "vision_conflict_unresolved",
+        "failure_codes": [
+          "vision_conflict_unresolved"
+        ],
+        "failure_stage": "vision",
+        "fallback_explanations": [
+          "请先操作 right_mdi_pb5。",
+          "待视觉确认：当前步骤只有部分可观测证据，请按高亮执行后进行目视确认。"
+        ],
+        "fallback_message": "请先操作 right_mdi_pb5。",
+        "fallback_overlay_reason": "validator_action_hint",
+        "fallback_overlay_used": true,
+        "fallback_response_mapping": {
+          "allowed_evidence_ref_count": 129,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S18"
+          },
+          "evidence_strength": "limited",
+          "next": {
+            "step_id": "S18"
+          },
+          "observability_status": "partial",
+          "requires_visual_confirmation": true
+        },
+        "final_action_plan": {
+          "evidence_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "overlay_step_id": "S18",
+          "source": "validator_action_hint",
+          "step_id": "S18",
+          "targets": [
+            "right_mdi_pb5"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "validator_action_hint",
+        "final_overlay_targets": [
+          "right_mdi_pb5"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_83",
+              "evidence_refs": [
+                "GATES.S18.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "right_mdi_pb5"
+              ],
+              "frame_id": "1779186209644_000178",
+              "fused_missing_conditions": [
+                "vision_facts.fcsmc_page_visible==seen"
+              ],
+              "fused_step_id": "S18",
+              "generation_mode": "model",
+              "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "completion_conflict_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 84,
+              "target": "right_mdi_pb5",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779186209644_000178"
+                ],
+                "fresh_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "supt_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "tac_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible",
+                  "ins_grnd_alignment_text_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": "vision_conflict_unresolved",
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。"
+          ],
+          "message": "当前 S18 尚未完成。请先操作 right_mdi_pb18，并确认该步骤条件已满足。",
+          "next": {
+            "step_id": "S18"
+          }
+        },
+        "frame_id": "1779186209644_000178",
+        "fused_missing_conditions": [
+          "vision_facts.fcsmc_page_visible==seen"
+        ],
+        "fused_step_id": "S18",
+        "generation_mode": "model",
+        "generation_prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+        "generation_prompt_tokens_est": 1094,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S18",
+          "source": "validator_action_hint",
+          "step_id": "S18",
+          "targets": [
+            "right_mdi_pb5"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S08",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.tac_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.tac_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.tac_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.ins_grnd_alignment_text_visible",
+                "VISION_FACTS.tac_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S18",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "refuel_probe_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S20",
+              "supporting_evidence_refs": [
+                "GATES.S20.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "launch_bar_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S22",
+              "supporting_evidence_refs": [
+                "GATES.S22.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "arresting_hook_handle"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S25",
+              "supporting_evidence_refs": [
+                "GATES.S25.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "right_mdi_pb18",
+              "right_mdi_pb5"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S18",
+            "supporting_evidence_refs": []
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 6949,
+              "frame_count": 20,
+              "latest_seq": 6968
+            },
+            "vision_fresh_count": 5,
+            "vision_seen_count": 5,
+            "vision_status": "available"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+            "source_observation_seq": 6968,
+            "source_observation_t_wall": 1779186209.5005546,
+            "telemetry_window_first_seq": 6949,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 6968,
+            "telemetry_window_latest_t_wall": 1779186209.5005546,
+            "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "overlay_step_id": "S18",
+            "source": "validator_action_hint",
+            "step_id": "S18",
+            "targets": [
+              "right_mdi_pb5"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "right_mdi_pb5"
+          ],
+          "message_category": "completion_conflict_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "VISION_FACTS.tac_page_visible@1779186209644_000178"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "right_mdi_pb18"
+            ],
+            "status": "ok",
+            "step_id": "S08"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "validator_action_hint"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+            "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "validator_action_hint",
+            "fallback_overlay_used": true,
+            "reasons": [],
+            "rejected": false,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": true,
+            "extractor_used": true,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779186209644_000178"
+            ],
+            "ignored_fact_count": 0,
+            "reason": "missing_pre_trigger_frame",
+            "status": "called",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 84,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "available",
+            "vision_status": "partial"
+          }
+        },
+        "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S18"
+          },
+          "explanations": [
+            "请先操作 right_mdi_pb5。"
+          ],
+          "next": {
+            "step_id": "S18"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S18.completion",
+                "target": "right_mdi_pb5",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "right_mdi_pb5"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "explanations": [
+            "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。"
+          ],
+          "next": {
+            "step_id": "S08"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.tac_page_visible@1779186209644_000178",
+                "target": "right_mdi_pb18",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "right_mdi_pb18"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 5220,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "completion_conflict_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S08"
+        },
+        "model_raw_explanations": [
+          "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "explanations": [
+            "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。"
+          ],
+          "next": {
+            "step_id": "S08"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.tac_page_visible@1779186209644_000178",
+                "target": "right_mdi_pb18",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "right_mdi_pb18"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S08"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779186209644_000178"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779186209644_000178",
+        "next": {
+          "step_id": "S18"
+        },
+        "observability_status": "partial",
+        "presentation_fallback_plan_source": "validator_action_hint",
+        "presentation_fallback_reason": "deterministic_step:S18",
+        "prompt_budget_used": 5560,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "RAG_SNIPPETS.fa18c_fcs_bit_procedure_note_0",
+            "VISION_FACTS.tac_page_visible@1779186209644_000178",
+            "VISION_FACTS.supt_page_visible@1779186209644_000178"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 3,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "right_mdi_pb5",
+          "prompt_chars": 4375,
+          "prompt_tokens_est": 1094,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 1,
+          "rag_snippet_ids": [
+            "fa18c_fcs_bit_procedure_note_0"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [
+            "S08",
+            "S09",
+            "S12",
+            "S13"
+          ],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_overlay_enum",
+            "trimmed_rag_snippets",
+            "compact_template"
+          ],
+          "vision_fact_seen_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible"
+          ],
+          "vision_fact_status": "available"
+        },
+        "prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+        "prompt_tokens_est": 1094,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "repair_applied": false,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "578988c3d8f5ddf449d095a3adab483f11afb84aac58bdb00726bf5fa29cbcbc",
+        "request_prompt_tokens_est": 1094,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": true,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 129,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "evidence_strength": "limited",
+          "next": {
+            "step_id": "S08"
+          },
+          "observability_status": "partial",
+          "requires_visual_confirmation": true
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+          "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+        },
+        "state_key": "55021cdb90ef6a187d5f242e8553dbd4803177faa8a3660bb6854c50a3211cc1",
+        "sync_delta_ms": 84,
+        "vision": {
+          "frame_id": "1779186209644_000178",
+          "frame_ids": [
+            "1779186209644_000178"
+          ],
+          "frame_stale": false,
+          "observation_ref": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+          "observation_seq": 6968,
+          "observation_t_wall_ms": 1779186209501,
+          "observation_t_wall_s": 1779186209.5005546,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779186209644,
+              "channel": "composite_panel",
+              "frame_id": "1779186209644_000178",
+              "frame_seq": 178,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186209644_000178_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186209644_000178.png",
+              "sync_delta_ms": 84,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 84,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779186209644,
+            "channel": "composite_panel",
+            "frame_id": "1779186209644_000178",
+            "frame_seq": 178,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779186209644_000178_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779186209644_000178.png",
+            "sync_delta_ms": 84,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779186209560,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S18"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": true,
+        "vision_fact_ignored_count": 0,
+        "vision_fact_status": "available",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779186209644_000178"
+          ],
+          "fresh_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible"
+          ],
+          "not_seen_fact_ids": [
+            "supt_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "tac_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible",
+            "ins_grnd_alignment_text_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=tac_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible,ins_grnd_alignment_text_visible; not_seen=supt_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "tac_page_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "supt_page_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "fcs_page_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "fcs_page_x_marks_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "bit_root_page_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "fcsmc_page_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "fcsmc_in_test_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 600000,
+            "expires_at_wall_ms": 1779186809560,
+            "fact_id": "fcsmc_final_go_result_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": true
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "hsi_page_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "hsi_map_layer_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779186211560,
+            "fact_id": "ins_ok_text_visible",
+            "observed_at_wall_ms": 1779186209560,
+            "source_frame_id": "1779186209644_000178",
+            "state": "not_seen",
+            "sticky": false
+          }
+        ],
+        "vision_fallback_reason": "vision_conflict_unresolved",
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779186209644_000178"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "missing_pre_trigger_frame",
+        "vlm_call_status": "called"
+      },
+      "response_id": "cbb5ff64-9733-435c-8946-3628dc0d4d37",
+      "status": "ok",
+      "timestamp": "2026-05-19T10:23:41.749317+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S18",
+    "expected_overlay_target_ids": [
+      "right_mdi_pb5"
+    ],
+    "final_response_source": "validator_action_hint",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "called"
+  },
+  "extraction_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "left_mdi_brightness_selector",
+          "right_mdi_brightness_selector",
+          "ampcd_off_brightness_knob",
+          "hud_symbology_brightness_knob",
+          "left_mdi_pb18",
+          "left_mdi_pb15",
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S08",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.tac_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.tac_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.tac_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.ins_grnd_alignment_text_visible",
+          "VISION_FACTS.tac_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S18",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "refuel_probe_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S20",
+        "supporting_evidence_refs": [
+          "GATES.S20.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "launch_bar_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S22",
+        "supporting_evidence_refs": [
+          "GATES.S22.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "arresting_hook_handle"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S25",
+        "supporting_evidence_refs": [
+          "GATES.S25.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+      "overlay_step_id": "S18",
+      "source": "validator_action_hint",
+      "step_id": "S18",
+      "targets": [
+        "right_mdi_pb5"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VISION_FACTS.tac_page_visible@1779186209644_000178"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "right_mdi_pb18"
+      ],
+      "status": "ok",
+      "step_id": "S08"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "validator_action_hint"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S08",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.tac_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.tac_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.tac_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.ins_grnd_alignment_text_visible",
+            "VISION_FACTS.tac_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S18",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "refuel_probe_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S20",
+          "supporting_evidence_refs": [
+            "GATES.S20.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "launch_bar_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S22",
+          "supporting_evidence_refs": [
+            "GATES.S22.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "arresting_hook_handle"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S25",
+          "supporting_evidence_refs": [
+            "GATES.S25.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S18",
+        "supporting_evidence_refs": []
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 6949,
+          "frame_count": 20,
+          "latest_seq": 6968
+        },
+        "vision_fresh_count": 5,
+        "vision_seen_count": 5,
+        "vision_status": "available"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "final_decision_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "model_request_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "source_observation_id": "c8917aaf-ef3b-430d-b2e8-32f3b7323d4c",
+        "source_observation_seq": 6968,
+        "source_observation_t_wall": 1779186209.5005546,
+        "telemetry_window_first_seq": 6949,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 6968,
+        "telemetry_window_latest_t_wall": 1779186209.5005546,
+        "validator_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "overlay_step_id": "S18",
+        "source": "validator_action_hint",
+        "step_id": "S18",
+        "targets": [
+          "right_mdi_pb5"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "right_mdi_pb5"
+      ],
+      "message_category": "completion_conflict_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "VISION_FACTS.tac_page_visible@1779186209644_000178"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "right_mdi_pb18"
+        ],
+        "status": "ok",
+        "step_id": "S08"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "validator_action_hint"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "final_decision": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "model_request": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5",
+        "validator": "bedf40fa67a499a83d4f40c9aabcd7921053950c2f21c0807afe1d246350e2f5"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "validator_action_hint",
+        "fallback_overlay_used": true,
+        "reasons": [],
+        "rejected": false,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": true,
+        "extractor_used": true,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779186209644_000178"
+        ],
+        "ignored_fact_count": 0,
+        "reason": "missing_pre_trigger_frame",
+        "status": "called",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 84,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "available",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "validator_action_hint",
+      "fallback_overlay_used": true,
+      "reasons": [],
+      "rejected": false,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S18"
+      },
+      "explanations": [
+        "请先操作 right_mdi_pb5。"
+      ],
+      "next": {
+        "step_id": "S18"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S18.completion",
+            "target": "right_mdi_pb5",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "right_mdi_pb5"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S08"
+      },
+      "explanations": [
+        "左 DDI 当前显示 TAC 页面，无法直接访问 FCS。请左键点击右 MDI PB18 进入 SUPT 页面，随后再寻找 FCS 入口。"
+      ],
+      "next": {
+        "step_id": "S08"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VISION_FACTS.tac_page_visible@1779186209644_000178",
+            "target": "right_mdi_pb18",
+            "type": "visual"
+          }
+        ],
+        "targets": [
+          "right_mdi_pb18"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "9608382d-ee62-486f-9d90-0c9d74997241",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 9258,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_101353.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/ce8512ef-901a-4f08-a339-af10893b744f.fixture.json
+++ b/artifacts/live_fixtures/ce8512ef-901a-4f08-a339-af10893b744f.fixture.json
@@ -1,0 +1,4110 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 7,
+      "conflicts": [],
+      "recent_action_count": 0,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 4725,
+        "frame_count": 20,
+        "latest_seq": 4744
+      },
+      "vision_fresh_count": 0,
+      "vision_seen_count": 0,
+      "vision_status": "vision_not_required"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+      "source_observation_seq": 4744,
+      "source_observation_t_wall": 1779191719.037806,
+      "telemetry_window_first_seq": 4725,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 4744,
+      "telemetry_window_latest_t_wall": 1779191719.037806,
+      "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+    },
+    "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:56245",
+          "raw_delta_count": 1,
+          "seq": 4744
+        },
+        "observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41421
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 4744,
+          "t_wall": 1779191719.037806,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": false,
+            "comm1_freq_value": 30500,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": false,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 0,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 0.0,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 0,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 0,
+            "rpm_l_gte_25": false,
+            "rpm_l_gte_60": false,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 10,
+            "temp_r": 296,
+            "throttle_l_not_off": false,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T11:55:19.037806+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 4725,
+      "frame_count": 20,
+      "latest_seq": 4744
+    },
+    "vision": {
+      "frame_ids": [
+        "1779191719223_000195"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779191719223_000195",
+        "frame_ids": [
+          "1779191719223_000195"
+        ],
+        "frame_stale": false,
+        "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+        "observation_seq": 4744,
+        "observation_t_wall_ms": 1779191719038,
+        "observation_t_wall_s": 1779191719.037806,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779191719223,
+            "channel": "composite_panel",
+            "frame_id": "1779191719223_000195",
+            "frame_seq": 195,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191719223_000195_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191719223_000195.png",
+            "sync_delta_ms": 102,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 102,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779191719223,
+          "channel": "composite_panel",
+          "frame_id": "1779191719223_000195",
+          "frame_seq": 195,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191719223_000195_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191719223_000195.png",
+          "sync_delta_ms": 102,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779191719121,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779191719223_000195"
+        ],
+        "fresh_fact_ids": [],
+        "not_seen_fact_ids": [],
+        "seen_fact_ids": [],
+        "status": "vision_not_required",
+        "summary_text": "no_active_vision_facts",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": []
+    },
+    "vision_fact_observations": []
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "kind": "tutor_request",
+        "lineno": 5239,
+        "metadata": {
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 102,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_status": "vision_not_required",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "action_hint": {
+                "target": "ufc_comm1_channel_selector_pull"
+              },
+              "gate_blocker_count": 1,
+              "inferred_step_id": "S09",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S09",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ]
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 4725,
+                "frame_count": 20,
+                "latest_seq": 4744
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+              "source_observation_seq": 4744,
+              "source_observation_t_wall": 1779191719.037806,
+              "telemetry_window_first_seq": 4725,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4744,
+              "telemetry_window_latest_t_wall": 1779191719.037806,
+              "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_coldstart_quiz_1",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q1. Overall Goal",
+                "score": 13.29554266378183,
+                "section": "Q1. Overall Goal",
+                "snippet_id": "fa18c_coldstart_quiz_1"
+              },
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 13.182159039373342,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_10",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "3. Step Criticality",
+                "score": 13.120994677243015,
+                "section": "3. Step Criticality",
+                "snippet_id": "fa18c_error_coding_guide_10"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_5",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+                "score": 12.704192866546279,
+                "section": "Phase P3 – Displays & Communications (S08–S09)",
+                "snippet_id": "Appendix - Training Task Syllabus_5"
+              },
+              {
+                "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+                "doc_id": "DCS FA-18C Early Access Guide EN",
+                "page_or_heading": 93,
+                "score": 10.553560644586302,
+                "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vars.comm1_freq_134_000==true"
+                ],
+                "overlay_step_id": "S09",
+                "role": "candidate_not_authoritative",
+                "step_id": "S09"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 4744,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 4725,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 4744,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 4744,
+                "latest_t_wall": 1779191719.037806,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 1.246
+              },
+              "vision_evidence": {
+                "confidence": "low",
+                "fresh_fact_ids": [],
+                "late_display_anchors": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "source_status": "vision_not_required",
+                "visual_candidate_steps": []
+              }
+            },
+            "vision": {
+              "frame_id": "1779191719223_000195",
+              "frame_ids": [
+                "1779191719223_000195"
+              ],
+              "frame_stale": false,
+              "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+              "observation_seq": 4744,
+              "observation_t_wall_ms": 1779191719038,
+              "observation_t_wall_s": 1779191719.037806,
+              "status": "partial",
+              "sync_delta_ms": 102,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779191719121,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191719223_000195"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": []
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 7,
+              "conflicts": [],
+              "recent_action_count": 0,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 4725,
+                "frame_count": 20,
+                "latest_seq": 4744
+              },
+              "vision_fresh_count": 0,
+              "vision_seen_count": 0,
+              "vision_status": "vision_not_required"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+              "source_observation_seq": 4744,
+              "source_observation_t_wall": 1779191719.037806,
+              "telemetry_window_first_seq": 4725,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4744,
+              "telemetry_window_latest_t_wall": 1779191719.037806,
+              "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "frame_id": "1779191719223_000195",
+            "fused_missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "fused_step_id": "S09",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_coldstart_quiz_1",
+              "fa18c_startup_master_1",
+              "fa18c_error_coding_guide_10",
+              "Appendix - Training Task Syllabus_5",
+              "DCS FA-18C Early Access Guide EN_92"
+            ],
+            "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+            "prompt_tokens_est": 5489,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "source_chunk_refs": [
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+              "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 102,
+            "vision_fact_seen_ids": [],
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191719223_000195"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779191719223_000195"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+          "request_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "timestamp": "2026-05-19T11:55:19.912684+00:00",
+          "version": "v1"
+        },
+        "related_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "vision_refs": [
+          "1779191719223_000195"
+        ]
+      },
+      {
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "kind": "overlay_requested",
+        "lineno": 5240,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 102,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "5e785587-ff22-40a0-bcea-37a6defc3978",
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 102,
+          "target": "pnt_111",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "kind": "overlay_requested",
+        "lineno": 5241,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 102,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "884a2407-0ea6-40c5-8639-7a8c28c8f090",
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 102,
+          "target": "pnt_113",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "kind": "overlay_requested",
+        "lineno": 5242,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 102,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "480f7cbd-6e29-41e7-8fe4-c241a2b309e2",
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 102,
+          "target": "pnt_114",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "kind": "overlay_requested",
+        "lineno": 5243,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 102,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "31c0c644-f531-42e4-8e1b-a1e04a37bf1e",
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 102,
+          "target": "pnt_120",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "kind": "tutor_response",
+        "lineno": 5244,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 102,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_111",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_1",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            },
+            {
+              "element_id": "pnt_113",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_3",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            },
+            {
+              "element_id": "pnt_114",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_4",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            },
+            {
+              "element_id": "pnt_120",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_0",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+          ],
+          "in_reply_to": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "message": "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。",
+          "metadata": {
+            "allowed_evidence_ref_count": 116,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "08befab4-56f6-470b-b059-2fa875a3d0be",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen",
+                "vision_facts.bit_root_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S09"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+              "source_observation_seq": 4744,
+              "source_observation_t_wall": 1779191719.037806,
+              "telemetry_window_first_seq": 4725,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 4744,
+              "telemetry_window_latest_t_wall": 1779191719.037806,
+              "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "fallback_overlay_reason": "state_action_planner",
+            "fallback_overlay_used": true,
+            "final_action_plan": {
+              "evidence_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "overlay_step_id": "S09",
+              "source": "state_action_planner",
+              "step_id": "S09",
+              "targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "state_action_planner",
+            "final_overlay_targets": [
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_111",
+                  "evidence_refs": [
+                    "GATES.S09.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0"
+                  ],
+                  "frame_id": "1779191719223_000195",
+                  "fused_missing_conditions": [
+                    "vars.comm1_freq_134_000==true"
+                  ],
+                  "fused_step_id": "S09",
+                  "generation_mode": "model",
+                  "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 102,
+                  "target": "ufc_key_1",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779191719223_000195"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                },
+                {
+                  "element_id": "pnt_113",
+                  "evidence_refs": [
+                    "GATES.S09.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0"
+                  ],
+                  "frame_id": "1779191719223_000195",
+                  "fused_missing_conditions": [
+                    "vars.comm1_freq_134_000==true"
+                  ],
+                  "fused_step_id": "S09",
+                  "generation_mode": "model",
+                  "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 102,
+                  "target": "ufc_key_3",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779191719223_000195"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                },
+                {
+                  "element_id": "pnt_114",
+                  "evidence_refs": [
+                    "GATES.S09.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0"
+                  ],
+                  "frame_id": "1779191719223_000195",
+                  "fused_missing_conditions": [
+                    "vars.comm1_freq_134_000==true"
+                  ],
+                  "fused_step_id": "S09",
+                  "generation_mode": "model",
+                  "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 102,
+                  "target": "ufc_key_4",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779191719223_000195"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                },
+                {
+                  "element_id": "pnt_120",
+                  "evidence_refs": [
+                    "GATES.S09.completion"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0"
+                  ],
+                  "frame_id": "1779191719223_000195",
+                  "fused_missing_conditions": [
+                    "vars.comm1_freq_134_000==true"
+                  ],
+                  "fused_step_id": "S09",
+                  "generation_mode": "model",
+                  "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 102,
+                  "target": "ufc_key_0",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": false,
+                  "vision_fact_ignored_count": 1,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779191719223_000195"
+                    ],
+                    "fresh_fact_ids": [],
+                    "not_seen_fact_ids": [],
+                    "seen_fact_ids": [],
+                    "status": "vision_not_required",
+                    "summary_text": "no_active_vision_facts",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "vision_not_required_for_step",
+                  "vlm_call_status": "not_required"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+              ],
+              "message": "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。",
+              "next": {
+                "step_id": "S09"
+              }
+            },
+            "frame_id": "1779191719223_000195",
+            "fused_missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "fused_step_id": "S09",
+            "generation_mode": "model",
+            "generation_prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+            "generation_prompt_tokens_est": 5489,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S09",
+              "source": "state_action_planner",
+              "step_id": "S09",
+              "targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "GATES.S09.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "GATES.S09.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": [
+                    "GATES.S10.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S11",
+                  "supporting_evidence_refs": [
+                    "GATES.S11.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "GATES.S12.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "GATES.S13.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.55,
+                "proposed_next_action_target_ids": [
+                  "ufc_comm1_channel_selector_pull",
+                  "ufc_key_1",
+                  "ufc_key_3",
+                  "ufc_key_4",
+                  "ufc_key_0",
+                  "ufc_ent_button"
+                ],
+                "role": "candidate_not_authoritative",
+                "source": "deterministic",
+                "step_id": "S09",
+                "supporting_evidence_refs": [
+                  "GATES.S09.completion"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 7,
+                "conflicts": [],
+                "recent_action_count": 0,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 4725,
+                  "frame_count": 20,
+                  "latest_seq": 4744
+                },
+                "vision_fresh_count": 0,
+                "vision_seen_count": 0,
+                "vision_status": "vision_not_required"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+                "source_observation_seq": 4744,
+                "source_observation_t_wall": 1779191719.037806,
+                "telemetry_window_first_seq": 4725,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 4744,
+                "telemetry_window_latest_t_wall": 1779191719.037806,
+                "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "overlay_step_id": "S09",
+                "source": "state_action_planner",
+                "step_id": "S09",
+                "targets": [
+                  "ufc_key_1",
+                  "ufc_key_3",
+                  "ufc_key_4",
+                  "ufc_key_0"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "GATES.S09.completion"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ],
+                "status": "ok",
+                "step_id": "S09"
+              },
+              "rejected_candidates": [],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "state_action_planner"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+                "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "state_action_planner",
+                "fallback_overlay_used": true,
+                "reasons": [
+                  "action_hint_incomplete_for_state_plan:ufc_comm1_channel_selector_pull",
+                  "s09_numeric_sequence_targets_selector_maybe_needed",
+                  "state_action_target_mismatch:ufc_comm1_channel_selector_pull"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": null
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": false,
+                "extractor_used": false,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "ignored_fact_count": 1,
+                "reason": "vision_not_required_for_step",
+                "status": "not_required",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 102,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "vision_not_required",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "action_hint_incomplete_for_state_plan:ufc_comm1_channel_selector_pull",
+              "s09_numeric_sequence_targets_selector_maybe_needed",
+              "state_action_target_mismatch:ufc_comm1_channel_selector_pull"
+            ],
+            "harness_validator_fallback_reason": "deterministic_step:S09",
+            "harness_validator_mapping": {
+              "allowed_evidence_ref_count": 116,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "next": {
+                "step_id": "S09"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "harness_validator_original_actions": [
+              {
+                "element_id": "pnt_124",
+                "evidence_refs": [
+                  "GATES.S09.completion"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "overlay"
+              }
+            ],
+            "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S09.completion",
+                    "target": "ufc_key_1",
+                    "type": "gate"
+                  },
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S09.completion",
+                    "target": "ufc_key_3",
+                    "type": "gate"
+                  },
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S09.completion",
+                    "target": "ufc_key_4",
+                    "type": "gate"
+                  },
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S09.completion",
+                    "target": "ufc_key_0",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ufc_key_1",
+                  "ufc_key_3",
+                  "ufc_key_4",
+                  "ufc_key_0"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S09.completion",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4735,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S09"
+            },
+            "model_raw_explanations": [
+              "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.95,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "GATES.S09.completion",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "gate"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S09"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779191719223_000195"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779191719223_000195",
+            "next": {
+              "step_id": "S09"
+            },
+            "observability_status": "observable",
+            "procedural_guidance_original_explanations": [
+              "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+            ],
+            "procedural_guidance_original_message": "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。",
+            "procedural_guidance_rewrite_reason": "s09_comm1_frequency_guidance",
+            "procedural_guidance_rewritten": true,
+            "prompt_budget_used": 5605,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "VARS.annunciator_panel_activity",
+                "VARS.apu_on",
+                "VARS.apu_ready",
+                "VARS.apu_start_support_complete",
+                "VARS.comm1_freq_134_000",
+                "GATES.S09.completion",
+                "GATES.S09.precondition",
+                "GATES.S10.completion",
+                "GATES.S11.completion",
+                "GATES.S11.precondition",
+                "GATES.S12.completion",
+                "GATES.S12.precondition",
+                "GATES.S13.completion",
+                "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "RAG_SNIPPETS.fa18c_error_coding_guide_10",
+                "RAG_SNIPPETS.Appendix - Training Task Syllabus_5",
+                "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_92"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 18,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "ufc_comm1_channel_selector_pull",
+              "prompt_chars": 21953,
+              "prompt_tokens_est": 5489,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 5,
+              "rag_snippet_ids": [
+                "fa18c_coldstart_quiz_1",
+                "fa18c_startup_master_1",
+                "fa18c_error_coding_guide_10",
+                "Appendix - Training Task Syllabus_5",
+                "DCS FA-18C Early Access Guide EN_92"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars"
+              ],
+              "vision_fact_seen_ids": [],
+              "vision_fact_status": "vision_not_required"
+            },
+            "prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+            "prompt_tokens_est": 5489,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_model_target": "ufc_comm1_channel_selector_pull",
+            "rejected_model_targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+            "request_prompt_tokens_est": 5489,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 116,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S09"
+              },
+              "next": {
+                "step_id": "S09"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+              "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+            },
+            "state_key": "4a8d82ccfaf0a2a21e3a241525c4943d732ab7bb7af6f35a887eaf7227ff6f23",
+            "sync_delta_ms": 102,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779191719223_000195",
+              "frame_ids": [
+                "1779191719223_000195"
+              ],
+              "frame_stale": false,
+              "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+              "observation_seq": 4744,
+              "observation_t_wall_ms": 1779191719038,
+              "observation_t_wall_s": 1779191719.037806,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779191719223,
+                  "channel": "composite_panel",
+                  "frame_id": "1779191719223_000195",
+                  "frame_seq": 195,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191719223_000195_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191719223_000195.png",
+                  "sync_delta_ms": 102,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 102,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779191719223,
+                "channel": "composite_panel",
+                "frame_id": "1779191719223_000195",
+                "frame_seq": 195,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191719223_000195_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191719223_000195.png",
+                "sync_delta_ms": 102,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779191719121,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S09"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": false,
+            "vision_fact_ignored_count": 1,
+            "vision_fact_status": "vision_not_required",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191719223_000195"
+              ],
+              "fresh_fact_ids": [],
+              "not_seen_fact_ids": [],
+              "seen_fact_ids": [],
+              "status": "vision_not_required",
+              "summary_text": "no_active_vision_facts",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779191719223_000195"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "vision_not_required_for_step",
+            "vlm_call_status": "not_required"
+          },
+          "response_id": "a90a10f1-9b40-44e2-a686-64f3fb622417",
+          "status": "ok",
+          "timestamp": "2026-05-19T11:55:24.648960+00:00",
+          "version": "v1"
+        },
+        "related_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "vision_refs": [
+          "1779191719223_000195"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "action_hint": {
+            "target": "ufc_comm1_channel_selector_pull"
+          },
+          "gate_blocker_count": 1,
+          "inferred_step_id": "S09",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S09",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ]
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 4725,
+            "frame_count": 20,
+            "latest_seq": 4744
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+          "source_observation_seq": 4744,
+          "source_observation_t_wall": 1779191719.037806,
+          "telemetry_window_first_seq": 4725,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4744,
+          "telemetry_window_latest_t_wall": 1779191719.037806,
+          "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_coldstart_quiz_1",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q1. Overall Goal",
+            "score": 13.29554266378183,
+            "section": "Q1. Overall Goal",
+            "snippet_id": "fa18c_coldstart_quiz_1"
+          },
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 13.182159039373342,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_10",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "3. Step Criticality",
+            "score": 13.120994677243015,
+            "section": "3. Step Criticality",
+            "snippet_id": "fa18c_error_coding_guide_10"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_5",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+            "score": 12.704192866546279,
+            "section": "Phase P3 – Displays & Communications (S08–S09)",
+            "snippet_id": "Appendix - Training Task Syllabus_5"
+          },
+          {
+            "chunk_id": "DCS FA-18C Early Access Guide EN_92",
+            "doc_id": "DCS FA-18C Early Access Guide EN",
+            "page_or_heading": 93,
+            "score": 10.553560644586302,
+            "snippet_id": "DCS FA-18C Early Access Guide EN_92"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vars.comm1_freq_134_000==true"
+            ],
+            "overlay_step_id": "S09",
+            "role": "candidate_not_authoritative",
+            "step_id": "S09"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 4744,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 4725,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 4744,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 4744,
+            "latest_t_wall": 1779191719.037806,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 1.246
+          },
+          "vision_evidence": {
+            "confidence": "low",
+            "fresh_fact_ids": [],
+            "late_display_anchors": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "source_status": "vision_not_required",
+            "visual_candidate_steps": []
+          }
+        },
+        "vision": {
+          "frame_id": "1779191719223_000195",
+          "frame_ids": [
+            "1779191719223_000195"
+          ],
+          "frame_stale": false,
+          "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+          "observation_seq": 4744,
+          "observation_t_wall_ms": 1779191719038,
+          "observation_t_wall_s": 1779191719.037806,
+          "status": "partial",
+          "sync_delta_ms": 102,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779191719121,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191719223_000195"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": []
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 7,
+          "conflicts": [],
+          "recent_action_count": 0,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 4725,
+            "frame_count": 20,
+            "latest_seq": 4744
+          },
+          "vision_fresh_count": 0,
+          "vision_seen_count": 0,
+          "vision_status": "vision_not_required"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+          "source_observation_seq": 4744,
+          "source_observation_t_wall": 1779191719.037806,
+          "telemetry_window_first_seq": 4725,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4744,
+          "telemetry_window_latest_t_wall": 1779191719.037806,
+          "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "frame_id": "1779191719223_000195",
+        "fused_missing_conditions": [
+          "vars.comm1_freq_134_000==true"
+        ],
+        "fused_step_id": "S09",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_coldstart_quiz_1",
+          "fa18c_startup_master_1",
+          "fa18c_error_coding_guide_10",
+          "Appendix - Training Task Syllabus_5",
+          "DCS FA-18C Early Access Guide EN_92"
+        ],
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+        "prompt_tokens_est": 5489,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "source_chunk_refs": [
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_1",
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_10",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+          "DCS FA-18C Early Access Guide EN/DCS FA-18C Early Access Guide EN_92"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 102,
+        "vision_fact_seen_ids": [],
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191719223_000195"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779191719223_000195"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+      "request_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+      "timestamp": "2026-05-19T11:55:19.912684+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_111",
+          "evidence_refs": [
+            "GATES.S09.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 102,
+          "target": "ufc_key_1",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        {
+          "element_id": "pnt_113",
+          "evidence_refs": [
+            "GATES.S09.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 102,
+          "target": "ufc_key_3",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        {
+          "element_id": "pnt_114",
+          "evidence_refs": [
+            "GATES.S09.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 102,
+          "target": "ufc_key_4",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        },
+        {
+          "element_id": "pnt_120",
+          "evidence_refs": [
+            "GATES.S09.completion"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "frame_id": "1779191719223_000195",
+          "fused_missing_conditions": [
+            "vars.comm1_freq_134_000==true"
+          ],
+          "fused_step_id": "S09",
+          "generation_mode": "model",
+          "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 102,
+          "target": "ufc_key_0",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": false,
+          "vision_fact_ignored_count": 1,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "fresh_fact_ids": [],
+            "not_seen_fact_ids": [],
+            "seen_fact_ids": [],
+            "status": "vision_not_required",
+            "summary_text": "no_active_vision_facts",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "vision_not_required_for_step",
+          "vlm_call_status": "not_required"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+      ],
+      "in_reply_to": "ce8512ef-901a-4f08-a339-af10893b744f",
+      "message": "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。",
+      "metadata": {
+        "allowed_evidence_ref_count": 116,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "08befab4-56f6-470b-b059-2fa875a3d0be",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen",
+            "vision_facts.bit_root_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S09"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+          "source_observation_seq": 4744,
+          "source_observation_t_wall": 1779191719.037806,
+          "telemetry_window_first_seq": 4725,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 4744,
+          "telemetry_window_latest_t_wall": 1779191719.037806,
+          "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "fallback_overlay_reason": "state_action_planner",
+        "fallback_overlay_used": true,
+        "final_action_plan": {
+          "evidence_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "overlay_step_id": "S09",
+          "source": "state_action_planner",
+          "step_id": "S09",
+          "targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "state_action_planner",
+        "final_overlay_targets": [
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_111",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_1",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            },
+            {
+              "element_id": "pnt_113",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_3",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            },
+            {
+              "element_id": "pnt_114",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_4",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            },
+            {
+              "element_id": "pnt_120",
+              "evidence_refs": [
+                "GATES.S09.completion"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0"
+              ],
+              "frame_id": "1779191719223_000195",
+              "fused_missing_conditions": [
+                "vars.comm1_freq_134_000==true"
+              ],
+              "fused_step_id": "S09",
+              "generation_mode": "model",
+              "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 102,
+              "target": "ufc_key_0",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": false,
+              "vision_fact_ignored_count": 1,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191719223_000195"
+                ],
+                "fresh_fact_ids": [],
+                "not_seen_fact_ids": [],
+                "seen_fact_ids": [],
+                "status": "vision_not_required",
+                "summary_text": "no_active_vision_facts",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "vision_not_required_for_step",
+              "vlm_call_status": "not_required"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+          ],
+          "message": "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。",
+          "next": {
+            "step_id": "S09"
+          }
+        },
+        "frame_id": "1779191719223_000195",
+        "fused_missing_conditions": [
+          "vars.comm1_freq_134_000==true"
+        ],
+        "fused_step_id": "S09",
+        "generation_mode": "model",
+        "generation_prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+        "generation_prompt_tokens_est": 5489,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S09",
+          "source": "state_action_planner",
+          "step_id": "S09",
+          "targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "GATES.S09.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "GATES.S09.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S10",
+              "supporting_evidence_refs": [
+                "GATES.S10.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S11",
+              "supporting_evidence_refs": [
+                "GATES.S11.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "GATES.S12.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "GATES.S13.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.55,
+            "proposed_next_action_target_ids": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0",
+              "ufc_ent_button"
+            ],
+            "role": "candidate_not_authoritative",
+            "source": "deterministic",
+            "step_id": "S09",
+            "supporting_evidence_refs": [
+              "GATES.S09.completion"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 7,
+            "conflicts": [],
+            "recent_action_count": 0,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 4725,
+              "frame_count": 20,
+              "latest_seq": 4744
+            },
+            "vision_fresh_count": 0,
+            "vision_seen_count": 0,
+            "vision_status": "vision_not_required"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+            "source_observation_seq": 4744,
+            "source_observation_t_wall": 1779191719.037806,
+            "telemetry_window_first_seq": 4725,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 4744,
+            "telemetry_window_latest_t_wall": 1779191719.037806,
+            "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "overlay_step_id": "S09",
+            "source": "state_action_planner",
+            "step_id": "S09",
+            "targets": [
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "GATES.S09.completion"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "status": "ok",
+            "step_id": "S09"
+          },
+          "rejected_candidates": [],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "state_action_planner"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+            "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "state_action_planner",
+            "fallback_overlay_used": true,
+            "reasons": [
+              "action_hint_incomplete_for_state_plan:ufc_comm1_channel_selector_pull",
+              "s09_numeric_sequence_targets_selector_maybe_needed",
+              "state_action_target_mismatch:ufc_comm1_channel_selector_pull"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": null
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": false,
+            "extractor_used": false,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779191719223_000195"
+            ],
+            "ignored_fact_count": 1,
+            "reason": "vision_not_required_for_step",
+            "status": "not_required",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 102,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "vision_not_required",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "action_hint_incomplete_for_state_plan:ufc_comm1_channel_selector_pull",
+          "s09_numeric_sequence_targets_selector_maybe_needed",
+          "state_action_target_mismatch:ufc_comm1_channel_selector_pull"
+        ],
+        "harness_validator_fallback_reason": "deterministic_step:S09",
+        "harness_validator_mapping": {
+          "allowed_evidence_ref_count": 116,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "next": {
+            "step_id": "S09"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "harness_validator_original_actions": [
+          {
+            "element_id": "pnt_124",
+            "evidence_refs": [
+              "GATES.S09.completion"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "ufc_comm1_channel_selector_pull",
+            "type": "overlay"
+          }
+        ],
+        "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S09.completion",
+                "target": "ufc_key_1",
+                "type": "gate"
+              },
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S09.completion",
+                "target": "ufc_key_3",
+                "type": "gate"
+              },
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S09.completion",
+                "target": "ufc_key_4",
+                "type": "gate"
+              },
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S09.completion",
+                "target": "ufc_key_0",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S09.completion",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4735,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S09"
+        },
+        "model_raw_explanations": [
+          "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.95,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "GATES.S09.completion",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "gate"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S09"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779191719223_000195"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779191719223_000195",
+        "next": {
+          "step_id": "S09"
+        },
+        "observability_status": "observable",
+        "procedural_guidance_original_explanations": [
+          "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+        ],
+        "procedural_guidance_original_message": "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。",
+        "procedural_guidance_rewrite_reason": "s09_comm1_frequency_guidance",
+        "procedural_guidance_rewritten": true,
+        "prompt_budget_used": 5605,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "VARS.annunciator_panel_activity",
+            "VARS.apu_on",
+            "VARS.apu_ready",
+            "VARS.apu_start_support_complete",
+            "VARS.comm1_freq_134_000",
+            "GATES.S09.completion",
+            "GATES.S09.precondition",
+            "GATES.S10.completion",
+            "GATES.S11.completion",
+            "GATES.S11.precondition",
+            "GATES.S12.completion",
+            "GATES.S12.precondition",
+            "GATES.S13.completion",
+            "RAG_SNIPPETS.fa18c_coldstart_quiz_1",
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "RAG_SNIPPETS.fa18c_error_coding_guide_10",
+            "RAG_SNIPPETS.Appendix - Training Task Syllabus_5",
+            "RAG_SNIPPETS.DCS FA-18C Early Access Guide EN_92"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 18,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "ufc_comm1_channel_selector_pull",
+          "prompt_chars": 21953,
+          "prompt_tokens_est": 5489,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 5,
+          "rag_snippet_ids": [
+            "fa18c_coldstart_quiz_1",
+            "fa18c_startup_master_1",
+            "fa18c_error_coding_guide_10",
+            "Appendix - Training Task Syllabus_5",
+            "DCS FA-18C Early Access Guide EN_92"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars"
+          ],
+          "vision_fact_seen_ids": [],
+          "vision_fact_status": "vision_not_required"
+        },
+        "prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+        "prompt_tokens_est": 5489,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_model_target": "ufc_comm1_channel_selector_pull",
+        "rejected_model_targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "50bb2f4fb4f54f7128cf3cf3bf7ad68a5677387615a596864c13ab195fe937c3",
+        "request_prompt_tokens_est": 5489,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 116,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S09"
+          },
+          "next": {
+            "step_id": "S09"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+          "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+        },
+        "state_key": "4a8d82ccfaf0a2a21e3a241525c4943d732ab7bb7af6f35a887eaf7227ff6f23",
+        "sync_delta_ms": 102,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779191719223_000195",
+          "frame_ids": [
+            "1779191719223_000195"
+          ],
+          "frame_stale": false,
+          "observation_ref": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+          "observation_seq": 4744,
+          "observation_t_wall_ms": 1779191719038,
+          "observation_t_wall_s": 1779191719.037806,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779191719223,
+              "channel": "composite_panel",
+              "frame_id": "1779191719223_000195",
+              "frame_seq": 195,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191719223_000195_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191719223_000195.png",
+              "sync_delta_ms": 102,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 102,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779191719223,
+            "channel": "composite_panel",
+            "frame_id": "1779191719223_000195",
+            "frame_seq": 195,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191719223_000195_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191719223_000195.png",
+            "sync_delta_ms": 102,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779191719121,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S09"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": false,
+        "vision_fact_ignored_count": 1,
+        "vision_fact_status": "vision_not_required",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191719223_000195"
+          ],
+          "fresh_fact_ids": [],
+          "not_seen_fact_ids": [],
+          "seen_fact_ids": [],
+          "status": "vision_not_required",
+          "summary_text": "no_active_vision_facts",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779191719223_000195"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "vision_not_required_for_step",
+        "vlm_call_status": "not_required"
+      },
+      "response_id": "a90a10f1-9b40-44e2-a686-64f3fb622417",
+      "status": "ok",
+      "timestamp": "2026-05-19T11:55:24.648960+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S09",
+    "expected_overlay_target_ids": [
+      "ufc_key_1",
+      "ufc_key_3",
+      "ufc_key_4",
+      "ufc_key_0"
+    ],
+    "final_response_source": "state_action_planner",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "not_required"
+  },
+  "extraction_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "GATES.S09.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "GATES.S09.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S11",
+        "supporting_evidence_refs": [
+          "GATES.S11.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "GATES.S12.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "GATES.S13.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+      "overlay_step_id": "S09",
+      "source": "state_action_planner",
+      "step_id": "S09",
+      "targets": [
+        "ufc_key_1",
+        "ufc_key_3",
+        "ufc_key_4",
+        "ufc_key_0"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "GATES.S09.completion"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "status": "ok",
+      "step_id": "S09"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "state_action_planner"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "GATES.S09.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "GATES.S09.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S10",
+          "supporting_evidence_refs": [
+            "GATES.S10.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S11",
+          "supporting_evidence_refs": [
+            "GATES.S11.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "GATES.S12.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "GATES.S13.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "GATES.S09.completion"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 7,
+        "conflicts": [],
+        "recent_action_count": 0,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 4725,
+          "frame_count": 20,
+          "latest_seq": 4744
+        },
+        "vision_fresh_count": 0,
+        "vision_seen_count": 0,
+        "vision_status": "vision_not_required"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "final_decision_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "model_request_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "source_observation_id": "c60d05ff-d886-432d-8c78-a388a6b3ef9e",
+        "source_observation_seq": 4744,
+        "source_observation_t_wall": 1779191719.037806,
+        "telemetry_window_first_seq": 4725,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 4744,
+        "telemetry_window_latest_t_wall": 1779191719.037806,
+        "validator_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "overlay_step_id": "S09",
+        "source": "state_action_planner",
+        "step_id": "S09",
+        "targets": [
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ufc_key_1",
+        "ufc_key_3",
+        "ufc_key_4",
+        "ufc_key_0"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "GATES.S09.completion"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "status": "ok",
+        "step_id": "S09"
+      },
+      "rejected_candidates": [],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "state_action_planner"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "final_decision": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "model_request": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03",
+        "validator": "34da79cc5d76193bf5c2dc0d0a1eea759dac27e6d971d1a4aaf5a1bed43d5f03"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "state_action_planner",
+        "fallback_overlay_used": true,
+        "reasons": [
+          "action_hint_incomplete_for_state_plan:ufc_comm1_channel_selector_pull",
+          "s09_numeric_sequence_targets_selector_maybe_needed",
+          "state_action_target_mismatch:ufc_comm1_channel_selector_pull"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": null
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": false,
+        "extractor_used": false,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779191719223_000195"
+        ],
+        "ignored_fact_count": 1,
+        "reason": "vision_not_required_for_step",
+        "status": "not_required",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 102,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "vision_not_required",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "state_action_planner",
+      "fallback_overlay_used": true,
+      "reasons": [
+        "action_hint_incomplete_for_state_plan:ufc_comm1_channel_selector_pull",
+        "s09_numeric_sequence_targets_selector_maybe_needed",
+        "state_action_target_mismatch:ufc_comm1_channel_selector_pull"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": null
+    }
+  },
+  "help_cycle_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "如需要，请先拉出 UFC 的 COMM1 selector；然后输入 COMM1 频率 134.000：按 1-3-4-0-0-0，再按 ENT。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S09.completion",
+            "target": "ufc_key_1",
+            "type": "gate"
+          },
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S09.completion",
+            "target": "ufc_key_3",
+            "type": "gate"
+          },
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S09.completion",
+            "target": "ufc_key_4",
+            "type": "gate"
+          },
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S09.completion",
+            "target": "ufc_key_0",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "当前处于 S09 步骤，需将 COMM1 频率设置为 134.000 MHz。请先左键点击 UFC COMM1 频道选择旋钮以拉出，然后输入频率。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.95,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "GATES.S09.completion",
+            "target": "ufc_comm1_channel_selector_pull",
+            "type": "gate"
+          }
+        ],
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "ce8512ef-901a-4f08-a339-af10893b744f",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 12408,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_115004.jsonl"
+  }
+}

--- a/artifacts/live_fixtures/e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad.fixture.json
+++ b/artifacts/live_fixtures/e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad.fixture.json
@@ -1,0 +1,4517 @@
+{
+  "context": {
+    "evidence_packet_summary": {
+      "blocked_gate_count": 6,
+      "conflicts": [],
+      "recent_action_count": 1,
+      "telemetry_missing_source_count": 4,
+      "telemetry_status": "nominal",
+      "telemetry_window_digest": {
+        "changed_var_count": 0,
+        "contradiction_count": 0,
+        "first_seq": 3534,
+        "frame_count": 20,
+        "latest_seq": 3553
+      },
+      "vision_fresh_count": 4,
+      "vision_seen_count": 4,
+      "vision_status": "available"
+    },
+    "evidence_snapshot": {
+      "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "schema_version": "evidence_snapshot.v1",
+      "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+      "source_observation_seq": 3553,
+      "source_observation_t_wall": 1779191635.122316,
+      "telemetry_window_first_seq": 3534,
+      "telemetry_window_frame_count": 20,
+      "telemetry_window_latest_seq": 3553,
+      "telemetry_window_latest_t_wall": 1779191635.122316,
+      "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+    },
+    "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+    "observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "delta_count": 1,
+          "delta_dropped_count": 0,
+          "from_addr": "192.168.0.105:56245",
+          "raw_delta_count": 1,
+          "seq": 3553
+        },
+        "observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+        "payload": {
+          "delta_summary": {
+            "changed_keys_sample": [
+              "HYD_IND_BRAKE"
+            ],
+            "delta_count": 1,
+            "dropped_stats": {
+              "dropped_by_reason": {},
+              "dropped_total": 0
+            },
+            "raw_delta_count": 1,
+            "recent_key_changes_topk": [
+              {
+                "count": 1,
+                "importance": 1,
+                "key": "HYD_IND_BRAKE",
+                "ui_targets": [],
+                "value": 41568
+              }
+            ],
+            "truncated": false
+          },
+          "recent_ui_targets": [],
+          "seq": 3553,
+          "t_wall": 1779191635.122316,
+          "vars": {
+            "annunciator_panel_activity": true,
+            "apu_on": true,
+            "apu_ready": true,
+            "apu_start_support_complete": true,
+            "attitude_source_auto": true,
+            "battery_on": true,
+            "bingo_fuel_set": false,
+            "bleed_air_cycle_complete": true,
+            "bleed_air_norm": true,
+            "comm1_channel_numeric": 1,
+            "comm1_freq_134_000": false,
+            "comm1_freq_value": 30500,
+            "comm2_channel_numeric": 1,
+            "comm2_freq_value": 30500,
+            "engine_crank_left": false,
+            "engine_crank_left_complete": false,
+            "engine_crank_right": false,
+            "engine_crank_right_complete": true,
+            "ext_pwr_on": true,
+            "ext_refuel_probe_value": 0,
+            "fcs_bit_switch_up": false,
+            "fcs_reset_complete": false,
+            "fcs_reset_pressed": false,
+            "ff_l": 0,
+            "ff_r": 700,
+            "fire_test_a_active": false,
+            "fire_test_a_complete": true,
+            "fire_test_active": false,
+            "fire_test_b_active": false,
+            "fire_test_b_complete": true,
+            "fire_test_complete": true,
+            "flap_auto": false,
+            "flap_configured": false,
+            "flap_full": true,
+            "flap_half": false,
+            "flap_mode_value": 0,
+            "hook_extended": true,
+            "hook_handle_value": 1,
+            "hook_retracted": false,
+            "hud_on": true,
+            "ins_fast_align_complete": false,
+            "ins_fast_align_pressed": false,
+            "ins_mode": 0,
+            "ins_mode_cv_or_gnd": false,
+            "ins_mode_set": false,
+            "l_gen_on": true,
+            "launch_bar_extended": false,
+            "launch_bar_retracted": true,
+            "launch_bar_switch_value": 0,
+            "left_ddi_on": true,
+            "left_engine_idle_ready": false,
+            "left_engine_nominal_start_params": false,
+            "lights_test_active": false,
+            "lights_test_complete": true,
+            "mpcd_on": true,
+            "noz_l": 0.0,
+            "noz_r": 76.3103685053788,
+            "obogs_flow_on": true,
+            "obogs_ready": false,
+            "obogs_switch_on": false,
+            "oil_l": 0,
+            "oil_r": 60,
+            "parking_brake_released": false,
+            "pitot_heat_on": false,
+            "power_available": true,
+            "probe_cycle_complete": true,
+            "probe_extended": false,
+            "probe_retracted": true,
+            "probe_switch_value": 1,
+            "r_gen_on": true,
+            "radar_altimeter_bug_set": false,
+            "radar_altimeter_bug_value": 0.0,
+            "radar_mode_opr": false,
+            "radar_on": false,
+            "right_ddi_on": true,
+            "right_engine_nominal_start_params": true,
+            "rpm_l": 0,
+            "rpm_l_gte_25": false,
+            "rpm_l_gte_60": false,
+            "rpm_r": 64,
+            "rpm_r_gte_25": true,
+            "rpm_r_gte_60": true,
+            "standby_altimeter_set": true,
+            "standby_attitude_uncaged": false,
+            "takeoff_trim_pressed": false,
+            "takeoff_trim_set": false,
+            "temp_l": 10,
+            "temp_r": 296,
+            "throttle_l_not_off": false,
+            "throttle_r_idle_complete": true,
+            "throttle_r_not_off": true,
+            "ufc_comm1_pull_pressed": false,
+            "ufc_ent_pressed": false,
+            "ufc_key_0_pressed": false,
+            "ufc_key_1_pressed": false,
+            "ufc_key_3_pressed": false,
+            "ufc_key_4_pressed": false,
+            "ufc_scratchpad_number_display": "        ",
+            "ufc_scratchpad_string_1_display": "  ",
+            "ufc_scratchpad_string_2_display": "  ",
+            "vars_source_missing": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ]
+          }
+        },
+        "procedure_hint": null,
+        "source": "dcs_bios_raw",
+        "tags": [],
+        "timestamp": "2026-05-19T11:53:55.122315+00:00",
+        "version": "v1"
+      }
+    ],
+    "snapshot_ids": {
+      "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+    },
+    "telemetry_window_digest": {
+      "changed_var_count": 0,
+      "contradiction_count": 0,
+      "first_seq": 3534,
+      "frame_count": 20,
+      "latest_seq": 3553
+    },
+    "vision": {
+      "frame_ids": [
+        "1779191635181_000191"
+      ],
+      "request": null,
+      "response": {
+        "frame_id": "1779191635181_000191",
+        "frame_ids": [
+          "1779191635181_000191"
+        ],
+        "frame_stale": false,
+        "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+        "observation_seq": 3553,
+        "observation_t_wall_ms": 1779191635122,
+        "observation_t_wall_s": 1779191635.122316,
+        "pre_trigger_frame": null,
+        "selected_frames": [
+          {
+            "capture_wall_ms": 1779191635181,
+            "channel": "composite_panel",
+            "frame_id": "1779191635181_000191",
+            "frame_seq": 191,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191635181_000191_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191635181_000191.png",
+            "sync_delta_ms": 59,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          }
+        ],
+        "status": "partial",
+        "sync_delta_ms": 59,
+        "sync_miss_reason": "missing_pre_trigger_frame",
+        "sync_status": "matched_future_fallback",
+        "sync_window_ms": 250,
+        "trigger_frame": {
+          "capture_wall_ms": 1779191635181,
+          "channel": "composite_panel",
+          "frame_id": "1779191635181_000191",
+          "frame_seq": 191,
+          "frame_stale": false,
+          "height": 1440,
+          "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191635181_000191_vlm.png",
+          "layout_id": "fa18c_composite_panel_v2",
+          "role": "trigger_frame",
+          "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191635181_000191.png",
+          "sync_delta_ms": 59,
+          "sync_miss_reason": null,
+          "sync_status": "matched_future_fallback",
+          "width": 3440
+        },
+        "trigger_wall_ms": 1779191635122,
+        "vision_used": true
+      },
+      "vision_fact_summary": {
+        "frame_ids": [
+          "1779191635181_000191"
+        ],
+        "fresh_fact_ids": [
+          "supt_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible"
+        ],
+        "not_seen_fact_ids": [
+          "tac_page_visible",
+          "fcs_page_visible",
+          "fcs_page_x_marks_visible",
+          "fcsmc_page_visible",
+          "fcsmc_intermediate_result_visible",
+          "fcsmc_in_test_visible",
+          "fcsmc_final_go_result_visible",
+          "ins_grnd_alignment_text_visible",
+          "ins_ok_text_visible"
+        ],
+        "seen_fact_ids": [
+          "supt_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible"
+        ],
+        "status": "available",
+        "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+        "uncertain_fact_ids": []
+      },
+      "vision_facts": [
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "tac_page_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "supt_page_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "fcs_page_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "fcs_page_x_marks_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "bit_root_page_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "fcsmc_page_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "fcsmc_intermediate_result_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "fcsmc_in_test_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 600000,
+          "expires_at_wall_ms": 1779192235122,
+          "fact_id": "fcsmc_final_go_result_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": true
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "hsi_page_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "hsi_map_layer_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "ins_grnd_alignment_text_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        },
+        {
+          "evidence_note": "",
+          "expires_after_ms": 2000,
+          "expires_at_wall_ms": 1779191637122,
+          "fact_id": "ins_ok_text_visible",
+          "observed_at_wall_ms": 1779191635122,
+          "source_frame_id": "1779191635181_000191",
+          "state": "not_seen",
+          "sticky": false
+        }
+      ]
+    },
+    "vision_fact_observations": [
+      {
+        "attachments": [],
+        "metadata": {
+          "frame_ids": [
+            "1779191635181_000191"
+          ],
+          "observation_kind": "vision_fact"
+        },
+        "observation_id": "f7dfc18c-0300-4d64-ba1c-79d48a44748d",
+        "payload": {
+          "facts": [
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "tac_page_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "supt_page_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcs_page_x_marks_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "bit_root_page_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_page_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_intermediate_result_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "fcsmc_in_test_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 600000,
+              "fact_id": "fcsmc_final_go_result_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": true
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_page_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "hsi_map_layer_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_grnd_alignment_text_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            },
+            {
+              "evidence_note": "",
+              "expires_after_ms": 2000,
+              "fact_id": "ins_ok_text_visible",
+              "observed_at_wall_ms": 1779191635122,
+              "result_kind": null,
+              "source_frame_id": "1779191635181_000191",
+              "state": "not_seen",
+              "sticky": false
+            }
+          ],
+          "frame_ids": [
+            "1779191635181_000191"
+          ],
+          "metadata": {
+            "coerced_source_frame_fact_ids": [],
+            "coerced_source_frame_fact_ids_alias_of": "ignored_legacy_source_frame_fact_ids",
+            "configured_fact_count": 13,
+            "ignored_legacy_source_frame_fact_ids": [],
+            "ignored_model_fact_fields": {},
+            "raw_fact_count": 13,
+            "raw_llm_text": "{\"facts\":[{\"fact_id\":\"tac_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"supt_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcs_page_x_marks_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"bit_root_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_page_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_intermediate_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_in_test_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"fcsmc_final_go_result_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_page_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"hsi_map_layer_visible\",\"state\":\"seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_grnd_alignment_text_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"},{\"fact_id\":\"ins_ok_text_visible\",\"state\":\"not_seen\",\"evidence_note\":\"\"}]}",
+            "sanitized_fact_count": 13,
+            "skipped_incomplete_mapping_fact_count": 0,
+            "skipped_non_mapping_fact_count": 0,
+            "skipped_unknown_fact_id_count": 0,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191635181_000191"
+              ],
+              "fresh_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            }
+          },
+          "observation_id": "f7dfc18c-0300-4d64-ba1c-79d48a44748d",
+          "schema_version": "v2",
+          "session_id": "sess-live",
+          "source": "vision_fact_extractor",
+          "summary": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "timestamp": "2026-05-19T11:54:01.975083+00:00",
+          "trigger_wall_ms": 1779191635122
+        },
+        "procedure_hint": null,
+        "source": "vision_fact_extractor",
+        "tags": [],
+        "timestamp": "2026-05-19T11:54:01.975083+00:00",
+        "version": "v1"
+      }
+    ]
+  },
+  "cycle": {
+    "events": [
+      {
+        "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "kind": "tutor_request",
+        "lineno": 4021,
+        "metadata": {
+          "frame_id": "1779191635181_000191",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "layout_id": "fa18c_composite_panel_v2",
+          "sync_delta_ms": 59,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_status": "available",
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "fresh_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_status": "partial",
+          "vision_used": true
+        },
+        "payload": {
+          "actor": "learner",
+          "context": {
+            "delta_dropped_count": 0,
+            "deterministic_step_hint": {
+              "gate_blocker_count": 0,
+              "inferred_step_id": "S08",
+              "missing_conditions_count": 1,
+              "observability": "observable",
+              "observability_status": "observable",
+              "overlay_step_id": "S08",
+              "recent_ui_targets": [
+                "left_mdi_pb18"
+              ],
+              "requires_visual_confirmation": false,
+              "scenario_profile": "airfield",
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "visual_action_hint": {
+                "target": "left_mdi_pb15"
+              }
+            },
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 3534,
+                "frame_count": 20,
+                "latest_seq": 3553
+              },
+              "vision_fresh_count": 4,
+              "vision_seen_count": 4,
+              "vision_status": "available"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+              "source_observation_seq": 3553,
+              "source_observation_t_wall": 1779191635.122316,
+              "telemetry_window_first_seq": 3534,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 3553,
+              "telemetry_window_latest_t_wall": 1779191635.122316,
+              "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "grounding_missing": false,
+            "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+            "grounding_reason": null,
+            "rag_topk": [
+              {
+                "chunk_id": "fa18c_startup_master_1",
+                "doc_id": "fa18c_startup_master",
+                "page_or_heading": "Master Step Table",
+                "score": 27.483645499655296,
+                "section": "Master Step Table",
+                "snippet_id": "fa18c_startup_master_1"
+              },
+              {
+                "chunk_id": "Appendix - Training Task Syllabus_5",
+                "doc_id": "Appendix - Training Task Syllabus",
+                "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+                "score": 20.699647560075256,
+                "section": "Phase P3 – Displays & Communications (S08–S09)",
+                "snippet_id": "Appendix - Training Task Syllabus_5"
+              },
+              {
+                "chunk_id": "fa18c_coldstart_quiz_8",
+                "doc_id": "fa18c_coldstart_quiz",
+                "page_or_heading": "Q8. Displays and Pages",
+                "score": 17.438278465832695,
+                "section": "Q8. Displays and Pages",
+                "snippet_id": "fa18c_coldstart_quiz_8"
+              },
+              {
+                "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+                "doc_id": "fa18c_fcs_bit_procedure_note",
+                "score": 16.6046650051719,
+                "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+              },
+              {
+                "chunk_id": "fa18c_error_coding_guide_5",
+                "doc_id": "fa18c_error_coding_guide",
+                "page_or_heading": "2.3 Order Error (OR)",
+                "score": 15.663994692502675,
+                "section": "2.3 Order Error (OR)",
+                "snippet_id": "fa18c_error_coding_guide_5"
+              }
+            ],
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "state_harness": {
+              "conflicts": [],
+              "deterministic_candidate": {
+                "missing_conditions": [
+                  "vision_facts.fcs_page_visible==seen"
+                ],
+                "overlay_step_id": "S08",
+                "role": "candidate_not_authoritative",
+                "step_id": "S08"
+              },
+              "telemetry_evidence": {
+                "confidence": "medium",
+                "early_vars": {
+                  "battery_on": true,
+                  "fire_test_a_complete": true,
+                  "fire_test_b_complete": true,
+                  "power_available": true
+                },
+                "observation_seq": 3553,
+                "source_status": "nominal",
+                "vars_source_missing_count": 4
+              },
+              "telemetry_window_digest": {
+                "changed_vars": [],
+                "contradictions": [],
+                "first_frame_only_values": [],
+                "first_seq": 3534,
+                "frame_count": 20,
+                "last_seen_true": [
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "battery_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "fire_test_a_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "fire_test_b_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "fire_test_complete"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "hud_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "left_ddi_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "mpcd_on"
+                  },
+                  {
+                    "age_s": 0.0,
+                    "seq": 3553,
+                    "var": "power_available"
+                  }
+                ],
+                "latest_seq": 3553,
+                "latest_t_wall": 1779191635.122316,
+                "stable_false_vars": [
+                  "fcs_bit_switch_up",
+                  "flap_auto",
+                  "pitot_heat_on"
+                ],
+                "stable_true_vars": [
+                  "battery_on",
+                  "fire_test_a_complete",
+                  "fire_test_b_complete",
+                  "fire_test_complete",
+                  "hud_on",
+                  "left_ddi_on",
+                  "mpcd_on",
+                  "power_available",
+                  "right_ddi_on"
+                ],
+                "unknown_or_missing_vars": [
+                  "ins_fast_align_pressed",
+                  "ufc_scratchpad_number_display",
+                  "ufc_scratchpad_string_1_display",
+                  "ufc_scratchpad_string_2_display"
+                ],
+                "window_duration_s": 0.709
+              },
+              "vision_evidence": {
+                "confidence": "high",
+                "fresh_fact_ids": [
+                  "bit_root_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "supt_page_visible"
+                ],
+                "late_display_anchors": [
+                  "bit_root_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "supt_page_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_final_go_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_page_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible",
+                  "tac_page_visible"
+                ],
+                "seen_fact_ids": [
+                  "bit_root_page_visible",
+                  "hsi_map_layer_visible",
+                  "hsi_page_visible",
+                  "supt_page_visible"
+                ],
+                "source_status": "available",
+                "visual_candidate_steps": [
+                  "S08",
+                  "S09",
+                  "S12",
+                  "S13"
+                ]
+              }
+            },
+            "vision": {
+              "frame_id": "1779191635181_000191",
+              "frame_ids": [
+                "1779191635181_000191"
+              ],
+              "frame_stale": false,
+              "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+              "observation_seq": 3553,
+              "observation_t_wall_ms": 1779191635122,
+              "observation_t_wall_s": 1779191635.122316,
+              "status": "partial",
+              "sync_delta_ms": 59,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_wall_ms": 1779191635122,
+              "vision_used": true
+            },
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191635181_000191"
+              ],
+              "fresh_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "fact_id": "tac_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "supt_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcs_page_x_marks_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "bit_root_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_in_test_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "fcsmc_final_go_result_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_page_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "hsi_map_layer_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "frame_ids": null,
+                "status": null
+              },
+              {
+                "fact_id": "ins_ok_text_visible",
+                "frame_ids": null,
+                "status": null
+              }
+            ]
+          },
+          "intent": "help",
+          "message": "[REDACTED_USER_MESSAGE]",
+          "metadata": {
+            "evidence_packet_summary": {
+              "blocked_gate_count": 6,
+              "conflicts": [],
+              "recent_action_count": 1,
+              "telemetry_missing_source_count": 4,
+              "telemetry_status": "nominal",
+              "telemetry_window_digest": {
+                "changed_var_count": 0,
+                "contradiction_count": 0,
+                "first_seq": 3534,
+                "frame_count": 20,
+                "latest_seq": 3553
+              },
+              "vision_fresh_count": 4,
+              "vision_seen_count": 4,
+              "vision_status": "available"
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+              "source_observation_seq": 3553,
+              "source_observation_t_wall": 1779191635.122316,
+              "telemetry_window_first_seq": 3534,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 3553,
+              "telemetry_window_latest_t_wall": 1779191635.122316,
+              "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "frame_id": "1779191635181_000191",
+            "fused_missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "fused_step_id": "S08",
+            "grounding_cache_hit": false,
+            "grounding_error_type": null,
+            "grounding_missing": false,
+            "grounding_missing_requested": false,
+            "grounding_policy_filtered_out_count": 0,
+            "grounding_policy_id": null,
+            "grounding_policy_version": null,
+            "grounding_reason": null,
+            "grounding_reason_requested": null,
+            "grounding_snippet_ids": [
+              "fa18c_startup_master_1"
+            ],
+            "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+            "layout_id": "fa18c_composite_panel_v2",
+            "prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+            "prompt_tokens_est": 1146,
+            "prompt_trimmed": true,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "source_chunk_refs": [
+              "fa18c_startup_master/fa18c_startup_master_1",
+              "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+              "fa18c_coldstart_quiz/fa18c_coldstart_quiz_8",
+              "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0",
+              "fa18c_error_coding_guide/fa18c_error_coding_guide_5"
+            ],
+            "state_harness_conflicts": [],
+            "state_harness_telemetry_status": "nominal",
+            "sync_delta_ms": 59,
+            "vision_fact_seen_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "vision_fact_status": "available",
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191635181_000191"
+              ],
+              "fresh_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_fallback_reason": null,
+            "vision_frame_ids": [
+              "1779191635181_000191"
+            ],
+            "vision_status": "partial",
+            "vision_used": true
+          },
+          "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+          "request_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "timestamp": "2026-05-19T11:54:02.017119+00:00",
+          "version": "v1"
+        },
+        "related_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "vision_refs": [
+          "1779191635181_000191"
+        ]
+      },
+      {
+        "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "kind": "overlay_requested",
+        "lineno": 4022,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779191635181_000191",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 59,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "fresh_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "clear",
+          "attempt_count": 1,
+          "cmd_id": "3a3e1ea2-57f1-412e-a844-61d0906ac12b",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779191635181_000191",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 59,
+          "target": "pnt_72",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "fresh_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "kind": "overlay_requested",
+        "lineno": 4023,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779191635181_000191",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 59,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "fresh_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "action": "highlight",
+          "attempt_count": 1,
+          "cmd_id": "f384ba8d-e5b3-4722-865c-63f1972255f6",
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779191635181_000191",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "schema_version": "v2",
+          "sync_delta_ms": 59,
+          "target": "pnt_124",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "fresh_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "related_id": null,
+        "vision_refs": []
+      },
+      {
+        "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "kind": "tutor_response",
+        "lineno": 4024,
+        "metadata": {
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779191635181_000191",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "sync_delta_ms": 59,
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "fresh_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        },
+        "payload": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "frame_id": "1779191635181_000191",
+              "fused_missing_conditions": [
+                "vision_facts.fcs_page_visible==seen"
+              ],
+              "fused_step_id": "S08",
+              "generation_mode": "model",
+              "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 59,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191635181_000191"
+                ],
+                "fresh_fact_ids": [
+                  "supt_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "supt_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "actor": "tutor",
+          "explanations": [
+            "S08 的最新证据已经满足。现在进入 S09。"
+          ],
+          "in_reply_to": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "message": "S08 的最新证据已经满足。现在进入 S09。",
+          "metadata": {
+            "allowed_evidence_ref_count": 131,
+            "dcs_tutor_text": {
+              "clear_view": false,
+              "cmd_id": "ce82bc47-8b79-4061-a3de-b68d720b5451",
+              "display_time_s": 12.0,
+              "reason": null,
+              "status": "ok",
+              "text": "S08 的最新证据已经满足。现在进入 S09。"
+            },
+            "delta_dropped_count": 0,
+            "deterministic_inference_error": null,
+            "deterministic_step_hint": {
+              "inferred_step_id": "S08",
+              "missing_conditions": [
+                "vision_facts.fcs_page_visible==seen"
+              ],
+              "observability": "observable",
+              "observability_status": "observable",
+              "recent_ui_targets": [
+                "left_mdi_pb18"
+              ],
+              "requires_visual_confirmation": false,
+              "step_evidence_requirements": [
+                "var",
+                "gate",
+                "delta"
+              ],
+              "step_ui_targets": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "superseded_by_snapshot": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "diagnosis": {
+              "error_category": "OM",
+              "step_id": "S09"
+            },
+            "evidence_guardrail_applied": false,
+            "evidence_guardrail_reasons": [],
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "evidence_snapshot": {
+              "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "schema_version": "evidence_snapshot.v1",
+              "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+              "source_observation_seq": 3553,
+              "source_observation_t_wall": 1779191635.122316,
+              "telemetry_window_first_seq": 3534,
+              "telemetry_window_frame_count": 20,
+              "telemetry_window_latest_seq": 3553,
+              "telemetry_window_latest_t_wall": 1779191635.122316,
+              "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "evidence_snapshot_consistency": {
+              "deterministic_hint_matches_request": false,
+              "final_action_plan_matches_snapshot": true,
+              "superseded_by_snapshot": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "final_action_plan": {
+              "evidence_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "overlay_step_id": "S09",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "text_only": false
+            },
+            "final_action_plan_source": "final_evidence_consistency_validator",
+            "final_evidence_consistency_mapping": {
+              "allowed_evidence_ref_count": 131,
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "next": {
+                "step_id": "S09"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "final_evidence_consistency_original_actions": [
+              {
+                "element_id": "pnt_72",
+                "evidence_refs": [
+                  "VISION_FACTS.tac_page_visible@1779191635181_000191"
+                ],
+                "evidence_required": true,
+                "intent": "highlight",
+                "style": {
+                  "color": "#00ffcc",
+                  "style": "highlight",
+                  "thickness": 2
+                },
+                "target": "left_mdi_pb18",
+                "type": "overlay"
+              }
+            ],
+            "final_evidence_consistency_overlay_applied": true,
+            "final_evidence_consistency_overlay_reason": "deterministic_step:S09",
+            "final_evidence_consistency_reasons": [
+              "completion_gate_already_satisfied:S08"
+            ],
+            "final_evidence_consistency_repair_applied": true,
+            "final_evidence_consistency_validator_applied": true,
+            "final_overlay_targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "final_public_response": {
+              "actions": [
+                {
+                  "element_id": "pnt_124",
+                  "evidence_refs": [
+                    "VARS.left_ddi_on"
+                  ],
+                  "evidence_required": true,
+                  "final_overlay_targets": [
+                    "ufc_comm1_channel_selector_pull"
+                  ],
+                  "frame_id": "1779191635181_000191",
+                  "fused_missing_conditions": [
+                    "vision_facts.fcs_page_visible==seen"
+                  ],
+                  "fused_step_id": "S08",
+                  "generation_mode": "model",
+                  "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+                  "intent": "highlight",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "message_category": "harness_validator_repair",
+                  "style": {
+                    "color": "#00ffcc",
+                    "style": "highlight",
+                    "thickness": 2
+                  },
+                  "sync_delta_ms": 59,
+                  "target": "ufc_comm1_channel_selector_pull",
+                  "type": "overlay",
+                  "vision_fact_cached_count": 1,
+                  "vision_fact_extractor_used": true,
+                  "vision_fact_ignored_count": 0,
+                  "vision_fact_sticky_count": 1,
+                  "vision_fact_summary": {
+                    "frame_ids": [
+                      "1779191635181_000191"
+                    ],
+                    "fresh_fact_ids": [
+                      "supt_page_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible"
+                    ],
+                    "not_seen_fact_ids": [
+                      "tac_page_visible",
+                      "fcs_page_visible",
+                      "fcs_page_x_marks_visible",
+                      "fcsmc_page_visible",
+                      "fcsmc_intermediate_result_visible",
+                      "fcsmc_in_test_visible",
+                      "fcsmc_final_go_result_visible",
+                      "ins_grnd_alignment_text_visible",
+                      "ins_ok_text_visible"
+                    ],
+                    "seen_fact_ids": [
+                      "supt_page_visible",
+                      "bit_root_page_visible",
+                      "hsi_page_visible",
+                      "hsi_map_layer_visible"
+                    ],
+                    "status": "available",
+                    "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                    "uncertain_fact_ids": []
+                  },
+                  "vision_fallback_reason": null,
+                  "vision_frame_capture_selected": true,
+                  "vision_used": true,
+                  "vlm_call_reason": "missing_pre_trigger_frame",
+                  "vlm_call_status": "called"
+                }
+              ],
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "S08 的最新证据已经满足。现在进入 S09。"
+              ],
+              "message": "S08 的最新证据已经满足。现在进入 S09。",
+              "next": {
+                "step_id": "S09"
+              }
+            },
+            "frame_id": "1779191635181_000191",
+            "fused_missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "fused_step_id": "S08",
+            "generation_mode": "model",
+            "generation_prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+            "generation_prompt_tokens_est": 1146,
+            "generation_prompt_trimmed": true,
+            "harness_action_plan": {
+              "overlay_step_id": "S09",
+              "source": "final_evidence_consistency_validator",
+              "step_id": "S09",
+              "targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "text_only": false
+            },
+            "harness_trace": {
+              "candidates": [
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_brightness_selector",
+                    "right_mdi_brightness_selector",
+                    "ampcd_off_brightness_knob",
+                    "hud_symbology_brightness_knob",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15",
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.supt_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.supt_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "ins_mode_knob",
+                    "ampcd_pb19"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S12",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.supt_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.86,
+                  "proposed_next_action_target_ids": [
+                    "radar_mode_knob"
+                  ],
+                  "role": "candidate",
+                  "source": "visual_anchor",
+                  "step_id": "S13",
+                  "supporting_evidence_refs": [
+                    "VISION_FACTS.bit_root_page_visible",
+                    "VISION_FACTS.hsi_map_layer_visible",
+                    "VISION_FACTS.hsi_page_visible",
+                    "VISION_FACTS.supt_page_visible"
+                  ]
+                },
+                {
+                  "confidence": 0.55,
+                  "proposed_next_action_target_ids": [
+                    "left_mdi_brightness_selector",
+                    "right_mdi_brightness_selector",
+                    "ampcd_off_brightness_knob",
+                    "hud_symbology_brightness_knob",
+                    "left_mdi_pb18",
+                    "left_mdi_pb15",
+                    "right_mdi_pb18",
+                    "right_mdi_pb5"
+                  ],
+                  "role": "candidate_not_authoritative",
+                  "source": "deterministic",
+                  "step_id": "S08",
+                  "supporting_evidence_refs": []
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "ufc_comm1_channel_selector_pull",
+                    "ufc_key_1",
+                    "ufc_key_3",
+                    "ufc_key_4",
+                    "ufc_key_0",
+                    "ufc_ent_button"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S09",
+                  "supporting_evidence_refs": [
+                    "GATES.S09.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [
+                    "eng_crank_switch"
+                  ],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S10",
+                  "supporting_evidence_refs": [
+                    "GATES.S10.completion"
+                  ]
+                },
+                {
+                  "confidence": 0.66,
+                  "proposed_next_action_target_ids": [],
+                  "role": "candidate",
+                  "source": "gate_blocker",
+                  "step_id": "S11",
+                  "supporting_evidence_refs": [
+                    "GATES.S11.completion"
+                  ]
+                }
+              ],
+              "chosen_candidate": {
+                "confidence": 0.86,
+                "proposed_next_action_target_ids": [
+                  "ufc_comm1_channel_selector_pull",
+                  "ufc_key_1",
+                  "ufc_key_3",
+                  "ufc_key_4",
+                  "ufc_key_0",
+                  "ufc_ent_button"
+                ],
+                "role": "candidate",
+                "source": "visual_anchor",
+                "step_id": "S09",
+                "supporting_evidence_refs": [
+                  "VISION_FACTS.bit_root_page_visible",
+                  "VISION_FACTS.hsi_map_layer_visible",
+                  "VISION_FACTS.hsi_page_visible",
+                  "VISION_FACTS.supt_page_visible"
+                ]
+              },
+              "evidence_packet_summary": {
+                "blocked_gate_count": 6,
+                "conflicts": [],
+                "recent_action_count": 1,
+                "telemetry_missing_source_count": 4,
+                "telemetry_status": "nominal",
+                "telemetry_window_digest": {
+                  "changed_var_count": 0,
+                  "contradiction_count": 0,
+                  "first_seq": 3534,
+                  "frame_count": 20,
+                  "latest_seq": 3553
+                },
+                "vision_fresh_count": 4,
+                "vision_seen_count": 4,
+                "vision_status": "available"
+              },
+              "evidence_snapshot": {
+                "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "schema_version": "evidence_snapshot.v1",
+                "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+                "source_observation_seq": 3553,
+                "source_observation_t_wall": 1779191635.122316,
+                "telemetry_window_first_seq": 3534,
+                "telemetry_window_frame_count": 20,
+                "telemetry_window_latest_seq": 3553,
+                "telemetry_window_latest_t_wall": 1779191635.122316,
+                "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+              },
+              "evidence_snapshot_consistency": {
+                "deterministic_hint_matches_request": false,
+                "final_action_plan_matches_snapshot": true,
+                "superseded_by_snapshot": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+              },
+              "final_action_plan": {
+                "evidence_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "overlay_step_id": "S09",
+                "source": "final_evidence_consistency_validator",
+                "step_id": "S09",
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ],
+                "text_only": false
+              },
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "message_category": "harness_validator_repair",
+              "model_decision": {
+                "evidence_refs": [
+                  "VISION_FACTS.tac_page_visible@1779191635181_000191"
+                ],
+                "generation_mode": "model",
+                "overlay_targets": [
+                  "left_mdi_pb18"
+                ],
+                "status": "ok",
+                "step_id": "S08"
+              },
+              "rejected_candidates": [
+                {
+                  "step_id": "S08"
+                }
+              ],
+              "repair_result": {
+                "applied": true,
+                "evidence_ref_repair": {
+                  "details": [],
+                  "repair_applied": false
+                },
+                "json_repaired": false,
+                "path": "final_evidence_consistency_validator"
+              },
+              "schema_version": "v1",
+              "snapshot_ids": {
+                "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+                "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+              },
+              "validator_result": {
+                "fallback_overlay_reason": "not_needed",
+                "fallback_overlay_used": false,
+                "reasons": [
+                  "completion_gate_already_satisfied:S08"
+                ],
+                "rejected": true,
+                "rejected_model_step_id": "S08"
+              },
+              "vlm_call": {
+                "cached_fact_count": 1,
+                "extractor_called": true,
+                "extractor_used": true,
+                "frame_capture_selected": true,
+                "frame_ids": [
+                  "1779191635181_000191"
+                ],
+                "ignored_fact_count": 0,
+                "reason": "missing_pre_trigger_frame",
+                "status": "called",
+                "sticky_fact_count": 1,
+                "sync_delta_ms": 59,
+                "sync_status": "matched_future_fallback",
+                "vision_fact_status": "available",
+                "vision_status": "partial"
+              }
+            },
+            "harness_validation_reasons": [
+              "completion_gate_already_satisfied:S08"
+            ],
+            "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+            "help_response": {
+              "diagnosis": {
+                "error_category": "OM",
+                "step_id": "S09"
+              },
+              "explanations": [
+                "S08 的最新证据已经满足。现在进入 S09。"
+              ],
+              "next": {
+                "step_id": "S09"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.51,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VARS.left_ddi_on",
+                    "target": "ufc_comm1_channel_selector_pull",
+                    "type": "var"
+                  }
+                ],
+                "targets": [
+                  "ufc_comm1_channel_selector_pull"
+                ]
+              }
+            },
+            "help_response_pre_guardrail": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "explanations": [
+                "当前左 DDI 显示 TAC 页面，需按左 MDI PB18 切换至 FCS 页面以完成 S08。"
+              ],
+              "next": {
+                "step_id": "S08"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.tac_page_visible@1779191635181_000191",
+                    "target": "left_mdi_pb18",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "left_mdi_pb18"
+                ]
+              }
+            },
+            "json_repair_reasons": [],
+            "json_repaired": false,
+            "latency_ms": 4461,
+            "layout_id": "fa18c_composite_panel_v2",
+            "main_help_multimodal_input_enabled": false,
+            "message_category": "harness_validator_repair",
+            "model": "simtutor-base",
+            "model_raw_diagnosis": {
+              "error_category": "CO",
+              "step_id": "S08"
+            },
+            "model_raw_explanations": [
+              "当前左 DDI 显示 TAC 页面，需按左 MDI PB18 切换至 FCS 页面以完成 S08。"
+            ],
+            "model_raw_help_response": {
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "explanations": [
+                "当前左 DDI 显示 TAC 页面，需按左 MDI PB18 切换至 FCS 页面以完成 S08。"
+              ],
+              "next": {
+                "step_id": "S08"
+              },
+              "overlay": {
+                "evidence": [
+                  {
+                    "grounding_confidence": 0.9,
+                    "quote": "[REDACTED_SOURCE_QUOTE]",
+                    "ref": "VISION_FACTS.tac_page_visible@1779191635181_000191",
+                    "target": "left_mdi_pb18",
+                    "type": "visual"
+                  }
+                ],
+                "targets": [
+                  "left_mdi_pb18"
+                ]
+              }
+            },
+            "model_raw_next": {
+              "step_id": "S08"
+            },
+            "multimodal_candidate_frame_ids": [
+              "1779191635181_000191"
+            ],
+            "multimodal_capability_enabled": true,
+            "multimodal_failed_frame_ids": [],
+            "multimodal_failure_reason": null,
+            "multimodal_fallback_to_text": false,
+            "multimodal_frame_failures": {},
+            "multimodal_frame_ids": [],
+            "multimodal_image_count": 0,
+            "multimodal_images_built": false,
+            "multimodal_input_present": true,
+            "multimodal_path_attempted": false,
+            "multimodal_path_success": false,
+            "multimodal_primary_frame_id": "1779191635181_000191",
+            "next": {
+              "step_id": "S09"
+            },
+            "observability_status": "observable",
+            "prompt_budget_used": 920,
+            "prompt_build": {
+              "allowed_evidence_refs": [
+                "RAG_SNIPPETS.fa18c_startup_master_1",
+                "VISION_FACTS.tac_page_visible@1779191635181_000191",
+                "VISION_FACTS.supt_page_visible@1779191635181_000191"
+              ],
+              "delta_summary_items": 0,
+              "delta_summary_top_k": 20,
+              "evidence_refs_count": 3,
+              "grounding_applied": true,
+              "grounding_missing": false,
+              "grounding_missing_requested": false,
+              "grounding_reason": null,
+              "max_overlay_targets": 4,
+              "max_prompt_chars": 9000,
+              "max_prompt_tokens_est": 2400,
+              "preferred_overlay_target": "left_mdi_pb18",
+              "prompt_chars": 4582,
+              "prompt_tokens_est": 1146,
+              "prompt_trimmed": true,
+              "rag_snippet_count": 1,
+              "rag_snippet_ids": [
+                "fa18c_startup_master_1"
+              ],
+              "state_harness_conflicts": [],
+              "state_harness_telemetry_status": "nominal",
+              "state_harness_visual_candidate_steps": [
+                "S08",
+                "S09",
+                "S12",
+                "S13"
+              ],
+              "trim_reasons": [
+                "trimmed_delta_summary",
+                "trimmed_step_enum",
+                "trimmed_vars",
+                "trimmed_overlay_enum",
+                "trimmed_rag_snippets",
+                "compact_template"
+              ],
+              "vision_fact_seen_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "vision_fact_status": "available"
+            },
+            "prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+            "prompt_tokens_est": 1146,
+            "prompt_trimmed": true,
+            "provider": "openai_compat",
+            "rejected_missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "rejected_model_step_id": "S08",
+            "rejected_model_target": "left_mdi_pb18",
+            "rejected_model_targets": [
+              "left_mdi_pb18"
+            ],
+            "repair_applied": true,
+            "repair_details": {
+              "details": [],
+              "dropped_unrepairable_evidence": 0,
+              "repair_applied": false,
+              "repaired_evidence_types": 0
+            },
+            "request_prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+            "request_prompt_tokens_est": 1146,
+            "request_prompt_trimmed": true,
+            "requires_visual_confirmation": false,
+            "response_mapping": {
+              "allowed_evidence_ref_count": 131,
+              "diagnosis": {
+                "error_category": "CO",
+                "step_id": "S08"
+              },
+              "next": {
+                "step_id": "S08"
+              },
+              "observability_status": "observable",
+              "requires_visual_confirmation": false
+            },
+            "retry_count": 0,
+            "retry_reason": null,
+            "scenario_profile": "airfield",
+            "snapshot_ids": {
+              "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+              "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+            },
+            "state_key": "82d7e34954e2617ce25e1147d5110549fddbe9f7b9debe33d67c0d0fa0d7a15e",
+            "sync_delta_ms": 59,
+            "validator_rejected": true,
+            "vision": {
+              "frame_id": "1779191635181_000191",
+              "frame_ids": [
+                "1779191635181_000191"
+              ],
+              "frame_stale": false,
+              "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+              "observation_seq": 3553,
+              "observation_t_wall_ms": 1779191635122,
+              "observation_t_wall_s": 1779191635.122316,
+              "pre_trigger_frame": null,
+              "selected_frames": [
+                {
+                  "capture_wall_ms": 1779191635181,
+                  "channel": "composite_panel",
+                  "frame_id": "1779191635181_000191",
+                  "frame_seq": 191,
+                  "frame_stale": false,
+                  "height": 1440,
+                  "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191635181_000191_vlm.png",
+                  "layout_id": "fa18c_composite_panel_v2",
+                  "role": "trigger_frame",
+                  "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191635181_000191.png",
+                  "sync_delta_ms": 59,
+                  "sync_miss_reason": null,
+                  "sync_status": "matched_future_fallback",
+                  "width": 3440
+                }
+              ],
+              "status": "partial",
+              "sync_delta_ms": 59,
+              "sync_miss_reason": "missing_pre_trigger_frame",
+              "sync_status": "matched_future_fallback",
+              "sync_window_ms": 250,
+              "trigger_frame": {
+                "capture_wall_ms": 1779191635181,
+                "channel": "composite_panel",
+                "frame_id": "1779191635181_000191",
+                "frame_seq": 191,
+                "frame_stale": false,
+                "height": 1440,
+                "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191635181_000191_vlm.png",
+                "layout_id": "fa18c_composite_panel_v2",
+                "role": "trigger_frame",
+                "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191635181_000191.png",
+                "sync_delta_ms": 59,
+                "sync_miss_reason": null,
+                "sync_status": "matched_future_fallback",
+                "width": 3440
+              },
+              "trigger_wall_ms": 1779191635122,
+              "vision_used": true
+            },
+            "vision_fact_active_step_ids": [
+              "S08"
+            ],
+            "vision_fact_cached_count": 1,
+            "vision_fact_extractor_used": true,
+            "vision_fact_ignored_count": 0,
+            "vision_fact_status": "available",
+            "vision_fact_sticky_count": 1,
+            "vision_fact_summary": {
+              "frame_ids": [
+                "1779191635181_000191"
+              ],
+              "fresh_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "not_seen_fact_ids": [
+                "tac_page_visible",
+                "fcs_page_visible",
+                "fcs_page_x_marks_visible",
+                "fcsmc_page_visible",
+                "fcsmc_intermediate_result_visible",
+                "fcsmc_in_test_visible",
+                "fcsmc_final_go_result_visible",
+                "ins_grnd_alignment_text_visible",
+                "ins_ok_text_visible"
+              ],
+              "seen_fact_ids": [
+                "supt_page_visible",
+                "bit_root_page_visible",
+                "hsi_page_visible",
+                "hsi_map_layer_visible"
+              ],
+              "status": "available",
+              "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+              "uncertain_fact_ids": []
+            },
+            "vision_facts": [
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "tac_page_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "supt_page_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "fcs_page_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "fcs_page_x_marks_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "bit_root_page_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "fcsmc_page_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "fcsmc_intermediate_result_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "fcsmc_in_test_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 600000,
+                "expires_at_wall_ms": 1779192235122,
+                "fact_id": "fcsmc_final_go_result_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": true
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "hsi_page_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "hsi_map_layer_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "ins_grnd_alignment_text_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              },
+              {
+                "evidence_note": "",
+                "expires_after_ms": 2000,
+                "expires_at_wall_ms": 1779191637122,
+                "fact_id": "ins_ok_text_visible",
+                "observed_at_wall_ms": 1779191635122,
+                "source_frame_id": "1779191635181_000191",
+                "state": "not_seen",
+                "sticky": false
+              }
+            ],
+            "vision_fallback_reason": null,
+            "vision_frame_capture_selected": true,
+            "vision_frame_ids": [
+              "1779191635181_000191"
+            ],
+            "vision_status": "partial",
+            "vision_used": true,
+            "vlm_call_reason": "missing_pre_trigger_frame",
+            "vlm_call_status": "called"
+          },
+          "response_id": "7fbba9a9-bbbc-4326-bcb7-0b6086575be8",
+          "status": "ok",
+          "timestamp": "2026-05-19T11:54:06.480075+00:00",
+          "version": "v1"
+        },
+        "related_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "vision_refs": [
+          "1779191635181_000191"
+        ]
+      }
+    ],
+    "tutor_request": {
+      "actor": "learner",
+      "context": {
+        "delta_dropped_count": 0,
+        "deterministic_step_hint": {
+          "gate_blocker_count": 0,
+          "inferred_step_id": "S08",
+          "missing_conditions_count": 1,
+          "observability": "observable",
+          "observability_status": "observable",
+          "overlay_step_id": "S08",
+          "recent_ui_targets": [
+            "left_mdi_pb18"
+          ],
+          "requires_visual_confirmation": false,
+          "scenario_profile": "airfield",
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "visual_action_hint": {
+            "target": "left_mdi_pb15"
+          }
+        },
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 3534,
+            "frame_count": 20,
+            "latest_seq": 3553
+          },
+          "vision_fresh_count": 4,
+          "vision_seen_count": 4,
+          "vision_status": "available"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+          "source_observation_seq": 3553,
+          "source_observation_t_wall": 1779191635.122316,
+          "telemetry_window_first_seq": 3534,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 3553,
+          "telemetry_window_latest_t_wall": 1779191635.122316,
+          "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "grounding_missing": false,
+        "grounding_query": "[REDACTED_GROUNDING_QUERY]",
+        "grounding_reason": null,
+        "rag_topk": [
+          {
+            "chunk_id": "fa18c_startup_master_1",
+            "doc_id": "fa18c_startup_master",
+            "page_or_heading": "Master Step Table",
+            "score": 27.483645499655296,
+            "section": "Master Step Table",
+            "snippet_id": "fa18c_startup_master_1"
+          },
+          {
+            "chunk_id": "Appendix - Training Task Syllabus_5",
+            "doc_id": "Appendix - Training Task Syllabus",
+            "page_or_heading": "Phase P3 – Displays & Communications (S08–S09)",
+            "score": 20.699647560075256,
+            "section": "Phase P3 – Displays & Communications (S08–S09)",
+            "snippet_id": "Appendix - Training Task Syllabus_5"
+          },
+          {
+            "chunk_id": "fa18c_coldstart_quiz_8",
+            "doc_id": "fa18c_coldstart_quiz",
+            "page_or_heading": "Q8. Displays and Pages",
+            "score": 17.438278465832695,
+            "section": "Q8. Displays and Pages",
+            "snippet_id": "fa18c_coldstart_quiz_8"
+          },
+          {
+            "chunk_id": "fa18c_fcs_bit_procedure_note_0",
+            "doc_id": "fa18c_fcs_bit_procedure_note",
+            "score": 16.6046650051719,
+            "snippet_id": "fa18c_fcs_bit_procedure_note_0"
+          },
+          {
+            "chunk_id": "fa18c_error_coding_guide_5",
+            "doc_id": "fa18c_error_coding_guide",
+            "page_or_heading": "2.3 Order Error (OR)",
+            "score": 15.663994692502675,
+            "section": "2.3 Order Error (OR)",
+            "snippet_id": "fa18c_error_coding_guide_5"
+          }
+        ],
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "state_harness": {
+          "conflicts": [],
+          "deterministic_candidate": {
+            "missing_conditions": [
+              "vision_facts.fcs_page_visible==seen"
+            ],
+            "overlay_step_id": "S08",
+            "role": "candidate_not_authoritative",
+            "step_id": "S08"
+          },
+          "telemetry_evidence": {
+            "confidence": "medium",
+            "early_vars": {
+              "battery_on": true,
+              "fire_test_a_complete": true,
+              "fire_test_b_complete": true,
+              "power_available": true
+            },
+            "observation_seq": 3553,
+            "source_status": "nominal",
+            "vars_source_missing_count": 4
+          },
+          "telemetry_window_digest": {
+            "changed_vars": [],
+            "contradictions": [],
+            "first_frame_only_values": [],
+            "first_seq": 3534,
+            "frame_count": 20,
+            "last_seen_true": [
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "battery_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "fire_test_a_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "fire_test_b_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "fire_test_complete"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "hud_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "left_ddi_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "mpcd_on"
+              },
+              {
+                "age_s": 0.0,
+                "seq": 3553,
+                "var": "power_available"
+              }
+            ],
+            "latest_seq": 3553,
+            "latest_t_wall": 1779191635.122316,
+            "stable_false_vars": [
+              "fcs_bit_switch_up",
+              "flap_auto",
+              "pitot_heat_on"
+            ],
+            "stable_true_vars": [
+              "battery_on",
+              "fire_test_a_complete",
+              "fire_test_b_complete",
+              "fire_test_complete",
+              "hud_on",
+              "left_ddi_on",
+              "mpcd_on",
+              "power_available",
+              "right_ddi_on"
+            ],
+            "unknown_or_missing_vars": [
+              "ins_fast_align_pressed",
+              "ufc_scratchpad_number_display",
+              "ufc_scratchpad_string_1_display",
+              "ufc_scratchpad_string_2_display"
+            ],
+            "window_duration_s": 0.709
+          },
+          "vision_evidence": {
+            "confidence": "high",
+            "fresh_fact_ids": [
+              "bit_root_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "supt_page_visible"
+            ],
+            "late_display_anchors": [
+              "bit_root_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "supt_page_visible"
+            ],
+            "not_seen_fact_ids": [
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_final_go_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_page_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible",
+              "tac_page_visible"
+            ],
+            "seen_fact_ids": [
+              "bit_root_page_visible",
+              "hsi_map_layer_visible",
+              "hsi_page_visible",
+              "supt_page_visible"
+            ],
+            "source_status": "available",
+            "visual_candidate_steps": [
+              "S08",
+              "S09",
+              "S12",
+              "S13"
+            ]
+          }
+        },
+        "vision": {
+          "frame_id": "1779191635181_000191",
+          "frame_ids": [
+            "1779191635181_000191"
+          ],
+          "frame_stale": false,
+          "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+          "observation_seq": 3553,
+          "observation_t_wall_ms": 1779191635122,
+          "observation_t_wall_s": 1779191635.122316,
+          "status": "partial",
+          "sync_delta_ms": 59,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_wall_ms": 1779191635122,
+          "vision_used": true
+        },
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191635181_000191"
+          ],
+          "fresh_fact_ids": [
+            "supt_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "supt_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "fact_id": "tac_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "supt_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcs_page_x_marks_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "bit_root_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_in_test_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "fcsmc_final_go_result_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_page_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "hsi_map_layer_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "frame_ids": null,
+            "status": null
+          },
+          {
+            "fact_id": "ins_ok_text_visible",
+            "frame_ids": null,
+            "status": null
+          }
+        ]
+      },
+      "intent": "help",
+      "message": "[REDACTED_USER_MESSAGE]",
+      "metadata": {
+        "evidence_packet_summary": {
+          "blocked_gate_count": 6,
+          "conflicts": [],
+          "recent_action_count": 1,
+          "telemetry_missing_source_count": 4,
+          "telemetry_status": "nominal",
+          "telemetry_window_digest": {
+            "changed_var_count": 0,
+            "contradiction_count": 0,
+            "first_seq": 3534,
+            "frame_count": 20,
+            "latest_seq": 3553
+          },
+          "vision_fresh_count": 4,
+          "vision_seen_count": 4,
+          "vision_status": "available"
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+          "source_observation_seq": 3553,
+          "source_observation_t_wall": 1779191635.122316,
+          "telemetry_window_first_seq": 3534,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 3553,
+          "telemetry_window_latest_t_wall": 1779191635.122316,
+          "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "frame_id": "1779191635181_000191",
+        "fused_missing_conditions": [
+          "vision_facts.fcs_page_visible==seen"
+        ],
+        "fused_step_id": "S08",
+        "grounding_cache_hit": false,
+        "grounding_error_type": null,
+        "grounding_missing": false,
+        "grounding_missing_requested": false,
+        "grounding_policy_filtered_out_count": 0,
+        "grounding_policy_id": null,
+        "grounding_policy_version": null,
+        "grounding_reason": null,
+        "grounding_reason_requested": null,
+        "grounding_snippet_ids": [
+          "fa18c_startup_master_1"
+        ],
+        "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "layout_id": "fa18c_composite_panel_v2",
+        "prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+        "prompt_tokens_est": 1146,
+        "prompt_trimmed": true,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "source_chunk_refs": [
+          "fa18c_startup_master/fa18c_startup_master_1",
+          "Appendix - Training Task Syllabus/Appendix - Training Task Syllabus_5",
+          "fa18c_coldstart_quiz/fa18c_coldstart_quiz_8",
+          "fa18c_fcs_bit_procedure_note/fa18c_fcs_bit_procedure_note_0",
+          "fa18c_error_coding_guide/fa18c_error_coding_guide_5"
+        ],
+        "state_harness_conflicts": [],
+        "state_harness_telemetry_status": "nominal",
+        "sync_delta_ms": 59,
+        "vision_fact_seen_ids": [
+          "supt_page_visible",
+          "bit_root_page_visible",
+          "hsi_page_visible",
+          "hsi_map_layer_visible"
+        ],
+        "vision_fact_status": "available",
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191635181_000191"
+          ],
+          "fresh_fact_ids": [
+            "supt_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "supt_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_fallback_reason": null,
+        "vision_frame_ids": [
+          "1779191635181_000191"
+        ],
+        "vision_status": "partial",
+        "vision_used": true
+      },
+      "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+      "request_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+      "timestamp": "2026-05-19T11:54:02.017119+00:00",
+      "version": "v1"
+    },
+    "tutor_response": {
+      "actions": [
+        {
+          "element_id": "pnt_124",
+          "evidence_refs": [
+            "VARS.left_ddi_on"
+          ],
+          "evidence_required": true,
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "frame_id": "1779191635181_000191",
+          "fused_missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "fused_step_id": "S08",
+          "generation_mode": "model",
+          "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+          "intent": "highlight",
+          "layout_id": "fa18c_composite_panel_v2",
+          "message_category": "harness_validator_repair",
+          "style": {
+            "color": "#00ffcc",
+            "style": "highlight",
+            "thickness": 2
+          },
+          "sync_delta_ms": 59,
+          "target": "ufc_comm1_channel_selector_pull",
+          "type": "overlay",
+          "vision_fact_cached_count": 1,
+          "vision_fact_extractor_used": true,
+          "vision_fact_ignored_count": 0,
+          "vision_fact_sticky_count": 1,
+          "vision_fact_summary": {
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "fresh_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "not_seen_fact_ids": [
+              "tac_page_visible",
+              "fcs_page_visible",
+              "fcs_page_x_marks_visible",
+              "fcsmc_page_visible",
+              "fcsmc_intermediate_result_visible",
+              "fcsmc_in_test_visible",
+              "fcsmc_final_go_result_visible",
+              "ins_grnd_alignment_text_visible",
+              "ins_ok_text_visible"
+            ],
+            "seen_fact_ids": [
+              "supt_page_visible",
+              "bit_root_page_visible",
+              "hsi_page_visible",
+              "hsi_map_layer_visible"
+            ],
+            "status": "available",
+            "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+            "uncertain_fact_ids": []
+          },
+          "vision_fallback_reason": null,
+          "vision_frame_capture_selected": true,
+          "vision_used": true,
+          "vlm_call_reason": "missing_pre_trigger_frame",
+          "vlm_call_status": "called"
+        }
+      ],
+      "actor": "tutor",
+      "explanations": [
+        "S08 的最新证据已经满足。现在进入 S09。"
+      ],
+      "in_reply_to": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+      "message": "S08 的最新证据已经满足。现在进入 S09。",
+      "metadata": {
+        "allowed_evidence_ref_count": 131,
+        "dcs_tutor_text": {
+          "clear_view": false,
+          "cmd_id": "ce82bc47-8b79-4061-a3de-b68d720b5451",
+          "display_time_s": 12.0,
+          "reason": null,
+          "status": "ok",
+          "text": "S08 的最新证据已经满足。现在进入 S09。"
+        },
+        "delta_dropped_count": 0,
+        "deterministic_inference_error": null,
+        "deterministic_step_hint": {
+          "inferred_step_id": "S08",
+          "missing_conditions": [
+            "vision_facts.fcs_page_visible==seen"
+          ],
+          "observability": "observable",
+          "observability_status": "observable",
+          "recent_ui_targets": [
+            "left_mdi_pb18"
+          ],
+          "requires_visual_confirmation": false,
+          "step_evidence_requirements": [
+            "var",
+            "gate",
+            "delta"
+          ],
+          "step_ui_targets": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "superseded_by_snapshot": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "diagnosis": {
+          "error_category": "OM",
+          "step_id": "S09"
+        },
+        "evidence_guardrail_applied": false,
+        "evidence_guardrail_reasons": [],
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "evidence_snapshot": {
+          "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "schema_version": "evidence_snapshot.v1",
+          "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+          "source_observation_seq": 3553,
+          "source_observation_t_wall": 1779191635.122316,
+          "telemetry_window_first_seq": 3534,
+          "telemetry_window_frame_count": 20,
+          "telemetry_window_latest_seq": 3553,
+          "telemetry_window_latest_t_wall": 1779191635.122316,
+          "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "evidence_snapshot_consistency": {
+          "deterministic_hint_matches_request": false,
+          "final_action_plan_matches_snapshot": true,
+          "superseded_by_snapshot": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "final_action_plan": {
+          "evidence_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "overlay_step_id": "S09",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "text_only": false
+        },
+        "final_action_plan_source": "final_evidence_consistency_validator",
+        "final_evidence_consistency_mapping": {
+          "allowed_evidence_ref_count": 131,
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "next": {
+            "step_id": "S09"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "final_evidence_consistency_original_actions": [
+          {
+            "element_id": "pnt_72",
+            "evidence_refs": [
+              "VISION_FACTS.tac_page_visible@1779191635181_000191"
+            ],
+            "evidence_required": true,
+            "intent": "highlight",
+            "style": {
+              "color": "#00ffcc",
+              "style": "highlight",
+              "thickness": 2
+            },
+            "target": "left_mdi_pb18",
+            "type": "overlay"
+          }
+        ],
+        "final_evidence_consistency_overlay_applied": true,
+        "final_evidence_consistency_overlay_reason": "deterministic_step:S09",
+        "final_evidence_consistency_reasons": [
+          "completion_gate_already_satisfied:S08"
+        ],
+        "final_evidence_consistency_repair_applied": true,
+        "final_evidence_consistency_validator_applied": true,
+        "final_overlay_targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "final_public_response": {
+          "actions": [
+            {
+              "element_id": "pnt_124",
+              "evidence_refs": [
+                "VARS.left_ddi_on"
+              ],
+              "evidence_required": true,
+              "final_overlay_targets": [
+                "ufc_comm1_channel_selector_pull"
+              ],
+              "frame_id": "1779191635181_000191",
+              "fused_missing_conditions": [
+                "vision_facts.fcs_page_visible==seen"
+              ],
+              "fused_step_id": "S08",
+              "generation_mode": "model",
+              "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+              "intent": "highlight",
+              "layout_id": "fa18c_composite_panel_v2",
+              "message_category": "harness_validator_repair",
+              "style": {
+                "color": "#00ffcc",
+                "style": "highlight",
+                "thickness": 2
+              },
+              "sync_delta_ms": 59,
+              "target": "ufc_comm1_channel_selector_pull",
+              "type": "overlay",
+              "vision_fact_cached_count": 1,
+              "vision_fact_extractor_used": true,
+              "vision_fact_ignored_count": 0,
+              "vision_fact_sticky_count": 1,
+              "vision_fact_summary": {
+                "frame_ids": [
+                  "1779191635181_000191"
+                ],
+                "fresh_fact_ids": [
+                  "supt_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "not_seen_fact_ids": [
+                  "tac_page_visible",
+                  "fcs_page_visible",
+                  "fcs_page_x_marks_visible",
+                  "fcsmc_page_visible",
+                  "fcsmc_intermediate_result_visible",
+                  "fcsmc_in_test_visible",
+                  "fcsmc_final_go_result_visible",
+                  "ins_grnd_alignment_text_visible",
+                  "ins_ok_text_visible"
+                ],
+                "seen_fact_ids": [
+                  "supt_page_visible",
+                  "bit_root_page_visible",
+                  "hsi_page_visible",
+                  "hsi_map_layer_visible"
+                ],
+                "status": "available",
+                "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+                "uncertain_fact_ids": []
+              },
+              "vision_fallback_reason": null,
+              "vision_frame_capture_selected": true,
+              "vision_used": true,
+              "vlm_call_reason": "missing_pre_trigger_frame",
+              "vlm_call_status": "called"
+            }
+          ],
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "S08 的最新证据已经满足。现在进入 S09。"
+          ],
+          "message": "S08 的最新证据已经满足。现在进入 S09。",
+          "next": {
+            "step_id": "S09"
+          }
+        },
+        "frame_id": "1779191635181_000191",
+        "fused_missing_conditions": [
+          "vision_facts.fcs_page_visible==seen"
+        ],
+        "fused_step_id": "S08",
+        "generation_mode": "model",
+        "generation_prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+        "generation_prompt_tokens_est": 1146,
+        "generation_prompt_trimmed": true,
+        "harness_action_plan": {
+          "overlay_step_id": "S09",
+          "source": "final_evidence_consistency_validator",
+          "step_id": "S09",
+          "targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "text_only": false
+        },
+        "harness_trace": {
+          "candidates": [
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S08",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.supt_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.supt_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "ins_mode_knob",
+                "ampcd_pb19"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S12",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.supt_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.86,
+              "proposed_next_action_target_ids": [
+                "radar_mode_knob"
+              ],
+              "role": "candidate",
+              "source": "visual_anchor",
+              "step_id": "S13",
+              "supporting_evidence_refs": [
+                "VISION_FACTS.bit_root_page_visible",
+                "VISION_FACTS.hsi_map_layer_visible",
+                "VISION_FACTS.hsi_page_visible",
+                "VISION_FACTS.supt_page_visible"
+              ]
+            },
+            {
+              "confidence": 0.55,
+              "proposed_next_action_target_ids": [
+                "left_mdi_brightness_selector",
+                "right_mdi_brightness_selector",
+                "ampcd_off_brightness_knob",
+                "hud_symbology_brightness_knob",
+                "left_mdi_pb18",
+                "left_mdi_pb15",
+                "right_mdi_pb18",
+                "right_mdi_pb5"
+              ],
+              "role": "candidate_not_authoritative",
+              "source": "deterministic",
+              "step_id": "S08",
+              "supporting_evidence_refs": []
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "ufc_comm1_channel_selector_pull",
+                "ufc_key_1",
+                "ufc_key_3",
+                "ufc_key_4",
+                "ufc_key_0",
+                "ufc_ent_button"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S09",
+              "supporting_evidence_refs": [
+                "GATES.S09.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [
+                "eng_crank_switch"
+              ],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S10",
+              "supporting_evidence_refs": [
+                "GATES.S10.completion"
+              ]
+            },
+            {
+              "confidence": 0.66,
+              "proposed_next_action_target_ids": [],
+              "role": "candidate",
+              "source": "gate_blocker",
+              "step_id": "S11",
+              "supporting_evidence_refs": [
+                "GATES.S11.completion"
+              ]
+            }
+          ],
+          "chosen_candidate": {
+            "confidence": 0.86,
+            "proposed_next_action_target_ids": [
+              "ufc_comm1_channel_selector_pull",
+              "ufc_key_1",
+              "ufc_key_3",
+              "ufc_key_4",
+              "ufc_key_0",
+              "ufc_ent_button"
+            ],
+            "role": "candidate",
+            "source": "visual_anchor",
+            "step_id": "S09",
+            "supporting_evidence_refs": [
+              "VISION_FACTS.bit_root_page_visible",
+              "VISION_FACTS.hsi_map_layer_visible",
+              "VISION_FACTS.hsi_page_visible",
+              "VISION_FACTS.supt_page_visible"
+            ]
+          },
+          "evidence_packet_summary": {
+            "blocked_gate_count": 6,
+            "conflicts": [],
+            "recent_action_count": 1,
+            "telemetry_missing_source_count": 4,
+            "telemetry_status": "nominal",
+            "telemetry_window_digest": {
+              "changed_var_count": 0,
+              "contradiction_count": 0,
+              "first_seq": 3534,
+              "frame_count": 20,
+              "latest_seq": 3553
+            },
+            "vision_fresh_count": 4,
+            "vision_seen_count": 4,
+            "vision_status": "available"
+          },
+          "evidence_snapshot": {
+            "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "schema_version": "evidence_snapshot.v1",
+            "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+            "source_observation_seq": 3553,
+            "source_observation_t_wall": 1779191635.122316,
+            "telemetry_window_first_seq": 3534,
+            "telemetry_window_frame_count": 20,
+            "telemetry_window_latest_seq": 3553,
+            "telemetry_window_latest_t_wall": 1779191635.122316,
+            "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+          },
+          "evidence_snapshot_consistency": {
+            "deterministic_hint_matches_request": false,
+            "final_action_plan_matches_snapshot": true,
+            "superseded_by_snapshot": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+          },
+          "final_action_plan": {
+            "evidence_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "overlay_step_id": "S09",
+            "source": "final_evidence_consistency_validator",
+            "step_id": "S09",
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ],
+            "text_only": false
+          },
+          "final_overlay_targets": [
+            "ufc_comm1_channel_selector_pull"
+          ],
+          "message_category": "harness_validator_repair",
+          "model_decision": {
+            "evidence_refs": [
+              "VISION_FACTS.tac_page_visible@1779191635181_000191"
+            ],
+            "generation_mode": "model",
+            "overlay_targets": [
+              "left_mdi_pb18"
+            ],
+            "status": "ok",
+            "step_id": "S08"
+          },
+          "rejected_candidates": [
+            {
+              "step_id": "S08"
+            }
+          ],
+          "repair_result": {
+            "applied": true,
+            "evidence_ref_repair": {
+              "details": [],
+              "repair_applied": false
+            },
+            "json_repaired": false,
+            "path": "final_evidence_consistency_validator"
+          },
+          "schema_version": "v1",
+          "snapshot_ids": {
+            "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+            "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+          },
+          "validator_result": {
+            "fallback_overlay_reason": "not_needed",
+            "fallback_overlay_used": false,
+            "reasons": [
+              "completion_gate_already_satisfied:S08"
+            ],
+            "rejected": true,
+            "rejected_model_step_id": "S08"
+          },
+          "vlm_call": {
+            "cached_fact_count": 1,
+            "extractor_called": true,
+            "extractor_used": true,
+            "frame_capture_selected": true,
+            "frame_ids": [
+              "1779191635181_000191"
+            ],
+            "ignored_fact_count": 0,
+            "reason": "missing_pre_trigger_frame",
+            "status": "called",
+            "sticky_fact_count": 1,
+            "sync_delta_ms": 59,
+            "sync_status": "matched_future_fallback",
+            "vision_fact_status": "available",
+            "vision_status": "partial"
+          }
+        },
+        "harness_validation_reasons": [
+          "completion_gate_already_satisfied:S08"
+        ],
+        "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+        "help_response": {
+          "diagnosis": {
+            "error_category": "OM",
+            "step_id": "S09"
+          },
+          "explanations": [
+            "S08 的最新证据已经满足。现在进入 S09。"
+          ],
+          "next": {
+            "step_id": "S09"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.51,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VARS.left_ddi_on",
+                "target": "ufc_comm1_channel_selector_pull",
+                "type": "var"
+              }
+            ],
+            "targets": [
+              "ufc_comm1_channel_selector_pull"
+            ]
+          }
+        },
+        "help_response_pre_guardrail": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "explanations": [
+            "当前左 DDI 显示 TAC 页面，需按左 MDI PB18 切换至 FCS 页面以完成 S08。"
+          ],
+          "next": {
+            "step_id": "S08"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.tac_page_visible@1779191635181_000191",
+                "target": "left_mdi_pb18",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "left_mdi_pb18"
+            ]
+          }
+        },
+        "json_repair_reasons": [],
+        "json_repaired": false,
+        "latency_ms": 4461,
+        "layout_id": "fa18c_composite_panel_v2",
+        "main_help_multimodal_input_enabled": false,
+        "message_category": "harness_validator_repair",
+        "model": "simtutor-base",
+        "model_raw_diagnosis": {
+          "error_category": "CO",
+          "step_id": "S08"
+        },
+        "model_raw_explanations": [
+          "当前左 DDI 显示 TAC 页面，需按左 MDI PB18 切换至 FCS 页面以完成 S08。"
+        ],
+        "model_raw_help_response": {
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "explanations": [
+            "当前左 DDI 显示 TAC 页面，需按左 MDI PB18 切换至 FCS 页面以完成 S08。"
+          ],
+          "next": {
+            "step_id": "S08"
+          },
+          "overlay": {
+            "evidence": [
+              {
+                "grounding_confidence": 0.9,
+                "quote": "[REDACTED_SOURCE_QUOTE]",
+                "ref": "VISION_FACTS.tac_page_visible@1779191635181_000191",
+                "target": "left_mdi_pb18",
+                "type": "visual"
+              }
+            ],
+            "targets": [
+              "left_mdi_pb18"
+            ]
+          }
+        },
+        "model_raw_next": {
+          "step_id": "S08"
+        },
+        "multimodal_candidate_frame_ids": [
+          "1779191635181_000191"
+        ],
+        "multimodal_capability_enabled": true,
+        "multimodal_failed_frame_ids": [],
+        "multimodal_failure_reason": null,
+        "multimodal_fallback_to_text": false,
+        "multimodal_frame_failures": {},
+        "multimodal_frame_ids": [],
+        "multimodal_image_count": 0,
+        "multimodal_images_built": false,
+        "multimodal_input_present": true,
+        "multimodal_path_attempted": false,
+        "multimodal_path_success": false,
+        "multimodal_primary_frame_id": "1779191635181_000191",
+        "next": {
+          "step_id": "S09"
+        },
+        "observability_status": "observable",
+        "prompt_budget_used": 920,
+        "prompt_build": {
+          "allowed_evidence_refs": [
+            "RAG_SNIPPETS.fa18c_startup_master_1",
+            "VISION_FACTS.tac_page_visible@1779191635181_000191",
+            "VISION_FACTS.supt_page_visible@1779191635181_000191"
+          ],
+          "delta_summary_items": 0,
+          "delta_summary_top_k": 20,
+          "evidence_refs_count": 3,
+          "grounding_applied": true,
+          "grounding_missing": false,
+          "grounding_missing_requested": false,
+          "grounding_reason": null,
+          "max_overlay_targets": 4,
+          "max_prompt_chars": 9000,
+          "max_prompt_tokens_est": 2400,
+          "preferred_overlay_target": "left_mdi_pb18",
+          "prompt_chars": 4582,
+          "prompt_tokens_est": 1146,
+          "prompt_trimmed": true,
+          "rag_snippet_count": 1,
+          "rag_snippet_ids": [
+            "fa18c_startup_master_1"
+          ],
+          "state_harness_conflicts": [],
+          "state_harness_telemetry_status": "nominal",
+          "state_harness_visual_candidate_steps": [
+            "S08",
+            "S09",
+            "S12",
+            "S13"
+          ],
+          "trim_reasons": [
+            "trimmed_delta_summary",
+            "trimmed_step_enum",
+            "trimmed_vars",
+            "trimmed_overlay_enum",
+            "trimmed_rag_snippets",
+            "compact_template"
+          ],
+          "vision_fact_seen_ids": [
+            "supt_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "vision_fact_status": "available"
+        },
+        "prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+        "prompt_tokens_est": 1146,
+        "prompt_trimmed": true,
+        "provider": "openai_compat",
+        "rejected_missing_conditions": [
+          "vision_facts.fcs_page_visible==seen"
+        ],
+        "rejected_model_step_id": "S08",
+        "rejected_model_target": "left_mdi_pb18",
+        "rejected_model_targets": [
+          "left_mdi_pb18"
+        ],
+        "repair_applied": true,
+        "repair_details": {
+          "details": [],
+          "dropped_unrepairable_evidence": 0,
+          "repair_applied": false,
+          "repaired_evidence_types": 0
+        },
+        "request_prompt_hash": "b25a5f31ba1f3eeb9c3646a73f8e2b7f836a8ddc6393d17510289de58bb2b330",
+        "request_prompt_tokens_est": 1146,
+        "request_prompt_trimmed": true,
+        "requires_visual_confirmation": false,
+        "response_mapping": {
+          "allowed_evidence_ref_count": 131,
+          "diagnosis": {
+            "error_category": "CO",
+            "step_id": "S08"
+          },
+          "next": {
+            "step_id": "S08"
+          },
+          "observability_status": "observable",
+          "requires_visual_confirmation": false
+        },
+        "retry_count": 0,
+        "retry_reason": null,
+        "scenario_profile": "airfield",
+        "snapshot_ids": {
+          "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+          "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+        },
+        "state_key": "82d7e34954e2617ce25e1147d5110549fddbe9f7b9debe33d67c0d0fa0d7a15e",
+        "sync_delta_ms": 59,
+        "validator_rejected": true,
+        "vision": {
+          "frame_id": "1779191635181_000191",
+          "frame_ids": [
+            "1779191635181_000191"
+          ],
+          "frame_stale": false,
+          "observation_ref": "fefb2997-845c-454b-a014-397e665c2289",
+          "observation_seq": 3553,
+          "observation_t_wall_ms": 1779191635122,
+          "observation_t_wall_s": 1779191635.122316,
+          "pre_trigger_frame": null,
+          "selected_frames": [
+            {
+              "capture_wall_ms": 1779191635181,
+              "channel": "composite_panel",
+              "frame_id": "1779191635181_000191",
+              "frame_seq": 191,
+              "frame_stale": false,
+              "height": 1440,
+              "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191635181_000191_vlm.png",
+              "layout_id": "fa18c_composite_panel_v2",
+              "role": "trigger_frame",
+              "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191635181_000191.png",
+              "sync_delta_ms": 59,
+              "sync_miss_reason": null,
+              "sync_status": "matched_future_fallback",
+              "width": 3440
+            }
+          ],
+          "status": "partial",
+          "sync_delta_ms": 59,
+          "sync_miss_reason": "missing_pre_trigger_frame",
+          "sync_status": "matched_future_fallback",
+          "sync_window_ms": 250,
+          "trigger_frame": {
+            "capture_wall_ms": 1779191635181,
+            "channel": "composite_panel",
+            "frame_id": "1779191635181_000191",
+            "frame_seq": 191,
+            "frame_stale": false,
+            "height": 1440,
+            "image_uri": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\artifacts\\1779191635181_000191_vlm.png",
+            "layout_id": "fa18c_composite_panel_v2",
+            "role": "trigger_frame",
+            "source_image_path": "C:\\Users\\15423\\Saved Games\\DCS\\SimTutor\\frames\\sess-live\\composite_panel\\1779191635181_000191.png",
+            "sync_delta_ms": 59,
+            "sync_miss_reason": null,
+            "sync_status": "matched_future_fallback",
+            "width": 3440
+          },
+          "trigger_wall_ms": 1779191635122,
+          "vision_used": true
+        },
+        "vision_fact_active_step_ids": [
+          "S08"
+        ],
+        "vision_fact_cached_count": 1,
+        "vision_fact_extractor_used": true,
+        "vision_fact_ignored_count": 0,
+        "vision_fact_status": "available",
+        "vision_fact_sticky_count": 1,
+        "vision_fact_summary": {
+          "frame_ids": [
+            "1779191635181_000191"
+          ],
+          "fresh_fact_ids": [
+            "supt_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "not_seen_fact_ids": [
+            "tac_page_visible",
+            "fcs_page_visible",
+            "fcs_page_x_marks_visible",
+            "fcsmc_page_visible",
+            "fcsmc_intermediate_result_visible",
+            "fcsmc_in_test_visible",
+            "fcsmc_final_go_result_visible",
+            "ins_grnd_alignment_text_visible",
+            "ins_ok_text_visible"
+          ],
+          "seen_fact_ids": [
+            "supt_page_visible",
+            "bit_root_page_visible",
+            "hsi_page_visible",
+            "hsi_map_layer_visible"
+          ],
+          "status": "available",
+          "summary_text": "seen=supt_page_visible,bit_root_page_visible,hsi_page_visible,hsi_map_layer_visible; not_seen=tac_page_visible,fcs_page_visible,fcs_page_x_marks_visible,fcsmc_page_visible,fcsmc_intermediate_result_visible,fcsmc_in_test_visible,fcsmc_final_go_result_visible,ins_grnd_alignment_text_visible,ins_ok_text_visible",
+          "uncertain_fact_ids": []
+        },
+        "vision_facts": [
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "tac_page_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "supt_page_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "fcs_page_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "fcs_page_x_marks_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "bit_root_page_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "fcsmc_page_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "fcsmc_intermediate_result_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "fcsmc_in_test_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 600000,
+            "expires_at_wall_ms": 1779192235122,
+            "fact_id": "fcsmc_final_go_result_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": true
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "hsi_page_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "hsi_map_layer_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "ins_grnd_alignment_text_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          },
+          {
+            "evidence_note": "",
+            "expires_after_ms": 2000,
+            "expires_at_wall_ms": 1779191637122,
+            "fact_id": "ins_ok_text_visible",
+            "observed_at_wall_ms": 1779191635122,
+            "source_frame_id": "1779191635181_000191",
+            "state": "not_seen",
+            "sticky": false
+          }
+        ],
+        "vision_fallback_reason": null,
+        "vision_frame_capture_selected": true,
+        "vision_frame_ids": [
+          "1779191635181_000191"
+        ],
+        "vision_status": "partial",
+        "vision_used": true,
+        "vlm_call_reason": "missing_pre_trigger_frame",
+        "vlm_call_status": "called"
+      },
+      "response_id": "7fbba9a9-bbbc-4326-bcb7-0b6086575be8",
+      "status": "ok",
+      "timestamp": "2026-05-19T11:54:06.480075+00:00",
+      "version": "v1"
+    }
+  },
+  "expectations": {
+    "expected_final_step_id": "S09",
+    "expected_overlay_target_ids": [
+      "ufc_comm1_channel_selector_pull"
+    ],
+    "final_response_source": "final_evidence_consistency_validator",
+    "llm_decision_status": "repaired",
+    "vlm_call_status": "called"
+  },
+  "extraction_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+  "harness": {
+    "candidate_steps": [
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "left_mdi_brightness_selector",
+          "right_mdi_brightness_selector",
+          "ampcd_off_brightness_knob",
+          "hud_symbology_brightness_knob",
+          "left_mdi_pb18",
+          "left_mdi_pb15",
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S08",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.supt_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.supt_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ins_mode_knob",
+          "ampcd_pb19"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S12",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.supt_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "radar_mode_knob"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S13",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.supt_page_visible"
+        ]
+      },
+      {
+        "confidence": 0.55,
+        "proposed_next_action_target_ids": [
+          "left_mdi_brightness_selector",
+          "right_mdi_brightness_selector",
+          "ampcd_off_brightness_knob",
+          "hud_symbology_brightness_knob",
+          "left_mdi_pb18",
+          "left_mdi_pb15",
+          "right_mdi_pb18",
+          "right_mdi_pb5"
+        ],
+        "role": "candidate_not_authoritative",
+        "source": "deterministic",
+        "step_id": "S08",
+        "supporting_evidence_refs": []
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "GATES.S09.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [
+          "eng_crank_switch"
+        ],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S10",
+        "supporting_evidence_refs": [
+          "GATES.S10.completion"
+        ]
+      },
+      {
+        "confidence": 0.66,
+        "proposed_next_action_target_ids": [],
+        "role": "candidate",
+        "source": "gate_blocker",
+        "step_id": "S11",
+        "supporting_evidence_refs": [
+          "GATES.S11.completion"
+        ]
+      }
+    ],
+    "final_action_plan": {
+      "evidence_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+      "overlay_step_id": "S09",
+      "source": "final_evidence_consistency_validator",
+      "step_id": "S09",
+      "targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "text_only": false
+    },
+    "model_decision": {
+      "evidence_refs": [
+        "VISION_FACTS.tac_page_visible@1779191635181_000191"
+      ],
+      "generation_mode": "model",
+      "overlay_targets": [
+        "left_mdi_pb18"
+      ],
+      "status": "ok",
+      "step_id": "S08"
+    },
+    "repair_result": {
+      "applied": true,
+      "evidence_ref_repair": {
+        "details": [],
+        "repair_applied": false
+      },
+      "json_repaired": false,
+      "path": "final_evidence_consistency_validator"
+    },
+    "trace": {
+      "candidates": [
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S08",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.supt_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.supt_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "ins_mode_knob",
+            "ampcd_pb19"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S12",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.supt_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.86,
+          "proposed_next_action_target_ids": [
+            "radar_mode_knob"
+          ],
+          "role": "candidate",
+          "source": "visual_anchor",
+          "step_id": "S13",
+          "supporting_evidence_refs": [
+            "VISION_FACTS.bit_root_page_visible",
+            "VISION_FACTS.hsi_map_layer_visible",
+            "VISION_FACTS.hsi_page_visible",
+            "VISION_FACTS.supt_page_visible"
+          ]
+        },
+        {
+          "confidence": 0.55,
+          "proposed_next_action_target_ids": [
+            "left_mdi_brightness_selector",
+            "right_mdi_brightness_selector",
+            "ampcd_off_brightness_knob",
+            "hud_symbology_brightness_knob",
+            "left_mdi_pb18",
+            "left_mdi_pb15",
+            "right_mdi_pb18",
+            "right_mdi_pb5"
+          ],
+          "role": "candidate_not_authoritative",
+          "source": "deterministic",
+          "step_id": "S08",
+          "supporting_evidence_refs": []
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "ufc_comm1_channel_selector_pull",
+            "ufc_key_1",
+            "ufc_key_3",
+            "ufc_key_4",
+            "ufc_key_0",
+            "ufc_ent_button"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S09",
+          "supporting_evidence_refs": [
+            "GATES.S09.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [
+            "eng_crank_switch"
+          ],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S10",
+          "supporting_evidence_refs": [
+            "GATES.S10.completion"
+          ]
+        },
+        {
+          "confidence": 0.66,
+          "proposed_next_action_target_ids": [],
+          "role": "candidate",
+          "source": "gate_blocker",
+          "step_id": "S11",
+          "supporting_evidence_refs": [
+            "GATES.S11.completion"
+          ]
+        }
+      ],
+      "chosen_candidate": {
+        "confidence": 0.86,
+        "proposed_next_action_target_ids": [
+          "ufc_comm1_channel_selector_pull",
+          "ufc_key_1",
+          "ufc_key_3",
+          "ufc_key_4",
+          "ufc_key_0",
+          "ufc_ent_button"
+        ],
+        "role": "candidate",
+        "source": "visual_anchor",
+        "step_id": "S09",
+        "supporting_evidence_refs": [
+          "VISION_FACTS.bit_root_page_visible",
+          "VISION_FACTS.hsi_map_layer_visible",
+          "VISION_FACTS.hsi_page_visible",
+          "VISION_FACTS.supt_page_visible"
+        ]
+      },
+      "evidence_packet_summary": {
+        "blocked_gate_count": 6,
+        "conflicts": [],
+        "recent_action_count": 1,
+        "telemetry_missing_source_count": 4,
+        "telemetry_status": "nominal",
+        "telemetry_window_digest": {
+          "changed_var_count": 0,
+          "contradiction_count": 0,
+          "first_seq": 3534,
+          "frame_count": 20,
+          "latest_seq": 3553
+        },
+        "vision_fresh_count": 4,
+        "vision_seen_count": 4,
+        "vision_status": "available"
+      },
+      "evidence_snapshot": {
+        "candidate_generation_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "final_decision_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "model_request_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "schema_version": "evidence_snapshot.v1",
+        "snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "source_observation_id": "fefb2997-845c-454b-a014-397e665c2289",
+        "source_observation_seq": 3553,
+        "source_observation_t_wall": 1779191635.122316,
+        "telemetry_window_first_seq": 3534,
+        "telemetry_window_frame_count": 20,
+        "telemetry_window_latest_seq": 3553,
+        "telemetry_window_latest_t_wall": 1779191635.122316,
+        "validator_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+      },
+      "evidence_snapshot_consistency": {
+        "deterministic_hint_matches_request": false,
+        "final_action_plan_matches_snapshot": true,
+        "superseded_by_snapshot": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+      },
+      "final_action_plan": {
+        "evidence_snapshot_id": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "overlay_step_id": "S09",
+        "source": "final_evidence_consistency_validator",
+        "step_id": "S09",
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ],
+        "text_only": false
+      },
+      "final_overlay_targets": [
+        "ufc_comm1_channel_selector_pull"
+      ],
+      "message_category": "harness_validator_repair",
+      "model_decision": {
+        "evidence_refs": [
+          "VISION_FACTS.tac_page_visible@1779191635181_000191"
+        ],
+        "generation_mode": "model",
+        "overlay_targets": [
+          "left_mdi_pb18"
+        ],
+        "status": "ok",
+        "step_id": "S08"
+      },
+      "rejected_candidates": [
+        {
+          "step_id": "S08"
+        }
+      ],
+      "repair_result": {
+        "applied": true,
+        "evidence_ref_repair": {
+          "details": [],
+          "repair_applied": false
+        },
+        "json_repaired": false,
+        "path": "final_evidence_consistency_validator"
+      },
+      "schema_version": "v1",
+      "snapshot_ids": {
+        "candidate_generation": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "final_decision": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "model_request": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9",
+        "validator": "2b522f8dd37d71445e378ea2680044b4de1a943e38abe09b47dcd20b68daa5d9"
+      },
+      "validator_result": {
+        "fallback_overlay_reason": "not_needed",
+        "fallback_overlay_used": false,
+        "reasons": [
+          "completion_gate_already_satisfied:S08"
+        ],
+        "rejected": true,
+        "rejected_model_step_id": "S08"
+      },
+      "vlm_call": {
+        "cached_fact_count": 1,
+        "extractor_called": true,
+        "extractor_used": true,
+        "frame_capture_selected": true,
+        "frame_ids": [
+          "1779191635181_000191"
+        ],
+        "ignored_fact_count": 0,
+        "reason": "missing_pre_trigger_frame",
+        "status": "called",
+        "sticky_fact_count": 1,
+        "sync_delta_ms": 59,
+        "sync_status": "matched_future_fallback",
+        "vision_fact_status": "available",
+        "vision_status": "partial"
+      }
+    },
+    "validator_result": {
+      "fallback_overlay_reason": "not_needed",
+      "fallback_overlay_used": false,
+      "reasons": [
+        "completion_gate_already_satisfied:S08"
+      ],
+      "rejected": true,
+      "rejected_model_step_id": "S08"
+    }
+  },
+  "help_cycle_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+  "model_io": {
+    "help_response": {
+      "diagnosis": {
+        "error_category": "OM",
+        "step_id": "S09"
+      },
+      "explanations": [
+        "S08 的最新证据已经满足。现在进入 S09。"
+      ],
+      "next": {
+        "step_id": "S09"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.51,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VARS.left_ddi_on",
+            "target": "ufc_comm1_channel_selector_pull",
+            "type": "var"
+          }
+        ],
+        "targets": [
+          "ufc_comm1_channel_selector_pull"
+        ]
+      }
+    },
+    "model_raw_help_response": {
+      "diagnosis": {
+        "error_category": "CO",
+        "step_id": "S08"
+      },
+      "explanations": [
+        "当前左 DDI 显示 TAC 页面，需按左 MDI PB18 切换至 FCS 页面以完成 S08。"
+      ],
+      "next": {
+        "step_id": "S08"
+      },
+      "overlay": {
+        "evidence": [
+          {
+            "grounding_confidence": 0.9,
+            "quote": "[REDACTED_SOURCE_QUOTE]",
+            "ref": "VISION_FACTS.tac_page_visible@1779191635181_000191",
+            "target": "left_mdi_pb18",
+            "type": "visual"
+          }
+        ],
+        "targets": [
+          "left_mdi_pb18"
+        ]
+      }
+    },
+    "raw_llm_text_attempt_count": 0,
+    "raw_llm_text_present": false
+  },
+  "request_id": "e6e6838b-b8ef-4e51-a4a8-1ea3d4771dad",
+  "request_id_missing": false,
+  "schema_version": "live_help_replay_fixture.v1",
+  "source_log": {
+    "event_count": 12408,
+    "malformed_lines": [],
+    "path": "/mnt/l/Documents/files/Yu Zhang TU Clausthal/Thesis/IEFMMQ/logs/live_help_harness_smoke_20260519_115004.jsonl"
+  }
+}

--- a/core/experiment_export.py
+++ b/core/experiment_export.py
@@ -59,6 +59,9 @@ def _opt_bool(raw: Any) -> bool | None:
 # ── experiment-layer metadata ──────────────────────────────────────────
 
 EXPECTED_PACK_STEP_IDS = [f"S{i:02d}" for i in range(1, 34)]
+NO_HELP_BASELINE_CONDITIONS = frozenset({"without_tutor", "baseline", "no_tutor"})
+VISUAL_STEP_MANUAL_REVIEW_NOTE = "visual_step_requires_manual_review"
+VISUAL_STEP_MANUAL_REVIEW_REF = "manual_review:visual_step_without_passive_evidence"
 
 HELP_CYCLES_CSV_FIELDS = [
     "cycle_index", "help_cycle_id", "trigger_wall_s", "generation_mode",
@@ -1630,7 +1633,7 @@ def _passive_completion_enabled(
     scoring: Mapping[str, Any] | None,
 ) -> bool:
     condition = meta.condition.strip().lower()
-    if condition in {"without_tutor", "baseline", "no_tutor"}:
+    if condition in NO_HELP_BASELINE_CONDITIONS:
         return True
     if isinstance(scoring, Mapping):
         return _opt_bool(scoring.get("passive_step_inference")) is True
@@ -1906,9 +1909,61 @@ def _load_gate_config_for_export(
     return config
 
 
-def _mark_om_candidates(rows: Sequence[StepCodingRecord]) -> None:
+def _baseline_visual_manual_review_step_ids(
+    *,
+    pack_steps: Sequence[Mapping[str, Any]],
+    completion_gates: Mapping[str, Any],
+) -> set[str]:
+    step_ids: set[str] = set()
+    for step in pack_steps:
+        step_id = _opt_str(step.get("id"))
+        if not step_id:
+            continue
+        evidence_requirements = set(_str_list(step.get("evidence_requirements")))
+        requires_visual = (
+            _opt_bool(step.get("requires_visual_confirmation")) is True
+            or "visual" in evidence_requirements
+        )
+        if not requires_visual:
+            continue
+        if _gate_rules(completion_gates.get(step_id)):
+            continue
+        step_ids.add(step_id)
+    return step_ids
+
+
+def _mark_baseline_visual_manual_review(
+    *,
+    rows_by_step: Mapping[str, StepCodingRecord],
+    step_ids: set[str],
+) -> None:
+    for step_id in step_ids:
+        row = rows_by_step.get(step_id)
+        if row is None or row.Completed == "yes":
+            continue
+        if row.Condition.strip().lower() not in NO_HELP_BASELINE_CONDITIONS:
+            continue
+        row.NeedsHumanReview = "yes"
+        row.AutoEvidenceRefs = _append_unique_ref(
+            row.AutoEvidenceRefs,
+            VISUAL_STEP_MANUAL_REVIEW_REF,
+        )
+        row.AutoCodingNotes = _append_unique_ref(
+            row.AutoCodingNotes,
+            VISUAL_STEP_MANUAL_REVIEW_NOTE,
+        )
+
+
+def _mark_om_candidates(
+    rows: Sequence[StepCodingRecord],
+    *,
+    skip_step_ids: set[str] | None = None,
+) -> None:
+    skipped = skip_step_ids or set()
     for row in rows:
         if row.Completed == "yes":
+            continue
+        if row.StepID in skipped and row.Condition.strip().lower() in NO_HELP_BASELINE_CONDITIONS:
             continue
         evidence = "om:not_completed"
         _set_auto_candidate(row, "OM", evidence, confidence="high")
@@ -2265,8 +2320,16 @@ def _apply_pre_scoring_candidates(
     gate_config = _load_gate_config_for_export(pack_path, scenario_profile=scenario_profile)
     vars_history = _vars_history_by_event(events)
     vars_by_event = _vars_by_event(events)
+    manual_review_step_ids = _baseline_visual_manual_review_step_ids(
+        pack_steps=pack_steps,
+        completion_gates=gate_config["completion_gates"],
+    )
 
-    _mark_om_candidates(step_coding)
+    _mark_baseline_visual_manual_review(
+        rows_by_step=rows_by_step,
+        step_ids=manual_review_step_ids,
+    )
+    _mark_om_candidates(step_coding, skip_step_ids=manual_review_step_ids)
     _mark_action_candidates(
         rows_by_step=rows_by_step,
         step_order=step_order,

--- a/docs/wiki/experiment-forms.md
+++ b/docs/wiki/experiment-forms.md
@@ -286,9 +286,12 @@ For `without_tutor`:
 | Participant could access checklist without removing Quest 3 | yes / no |
 | Participant used checklist | yes / no / partially |
 | Manual coding required | yes / no |
+| S18/S19 visual review completed | yes / no / N/A |
+| S18/S19 review source | video / offline VLM / both / N/A |
 | Notes |  |
 
 为了避免弱证据，正式 baseline 推荐使用 VR 内可访问 checklist，而不是要求参与者摘下头显查看外部 PDF。
+S18/S19 依赖右 DDI FCS-MC 页面和 final GO 视觉确认；如果 `step_coding.csv` 标记 `visual_step_requires_manual_review`，需要用录像或 trial 后离线 VLM 复核，不能把缺少 passive visual evidence 直接视为确认遗漏。
 
 ## 11. Tutor-Specific Notes
 

--- a/docs/wiki/experiment-operation-manual.md
+++ b/docs/wiki/experiment-operation-manual.md
@@ -604,8 +604,8 @@ python -m simtutor extract-live-fixture `
 baseline 条件通常没有 help cycles，但 `experiment-export` 会优先使用 passive telemetry、derived vars 和 pack completion gates 自动填充 `step_coding.csv`。处理方式：
 
 1. 保留 raw log 和录像，确保自动编码可追溯。
-2. 先检查 `EvidenceRefs` 和 `AutoCodingNotes`；自动完成通常会标记 `completed_from_passive_gate`、`passive_gate:*` 和 `telemetry_var:*`。
-3. 对 S18/S19 这类依赖 DDI 页面状态或 final GO 视觉确认、且 baseline passive log 没有视觉证据的步骤，`step_coding.csv` 会保留 `Completed=no`，同时标记 `NeedsHumanReview=yes` 和 `visual_step_requires_manual_review`。这表示“需要复核”，不是自动确认参与者遗漏。
+2. 先检查 `EvidenceRefs`、`AutoEvidenceRefs` 和 `AutoCodingNotes`；自动完成通常会标记 `completed_from_passive_gate`、`passive_gate:*` 和 `telemetry_var:*`。
+3. 对 S18/S19 这类依赖 DDI 页面状态或 final GO 视觉确认、且 baseline passive log 没有视觉证据的步骤，`step_coding.csv` 会保留 `Completed=no`，同时标记 `NeedsHumanReview=yes`、`manual_review:visual_step_without_passive_evidence` 和 `visual_step_requires_manual_review`。这表示“需要复核”，不是自动确认参与者遗漏。
 4. 人工复核 S18 时，从录像确认右 DDI 是否从 BIT root/FCS-MC 入口进入 FCS-MC BIT 页面；人工复核 S19 时，从录像确认 FCS-MC BIT final GO 是否出现并被参与者查看。
 5. 如果使用离线/passive VLM 辅助复核，只能在 trial 结束后运行，并在 `CoderNotes` 或外部审计记录中注明来源；不要把它记作 live tutor 的 VLM/help evidence。
 6. 对 telemetry 不足、不可观测动作、实验异常或自动编码明显不符合录像的步骤，再用录像进行人工复核和修正。

--- a/docs/wiki/experiment-operation-manual.md
+++ b/docs/wiki/experiment-operation-manual.md
@@ -605,8 +605,11 @@ baseline 条件通常没有 help cycles，但 `experiment-export` 会优先使�
 
 1. 保留 raw log 和录像，确保自动编码可追溯。
 2. 先检查 `EvidenceRefs` 和 `AutoCodingNotes`；自动完成通常会标记 `completed_from_passive_gate`、`passive_gate:*` 和 `telemetry_var:*`。
-3. 对 telemetry 不足、不可观测动作、实验异常或自动编码明显不符合录像的步骤，再用录像进行人工复核和修正。
-4. 分析时区分自动字段（如 `Completed`、`EvidenceRefs`、`AutoCodingNotes`）和人工字段（如 `Error_*`、`CoderID`、`CoderNotes`）。
+3. 对 S18/S19 这类依赖 DDI 页面状态或 final GO 视觉确认、且 baseline passive log 没有视觉证据的步骤，`step_coding.csv` 会保留 `Completed=no`，同时标记 `NeedsHumanReview=yes` 和 `visual_step_requires_manual_review`。这表示“需要复核”，不是自动确认参与者遗漏。
+4. 人工复核 S18 时，从录像确认右 DDI 是否从 BIT root/FCS-MC 入口进入 FCS-MC BIT 页面；人工复核 S19 时，从录像确认 FCS-MC BIT final GO 是否出现并被参与者查看。
+5. 如果使用离线/passive VLM 辅助复核，只能在 trial 结束后运行，并在 `CoderNotes` 或外部审计记录中注明来源；不要把它记作 live tutor 的 VLM/help evidence。
+6. 对 telemetry 不足、不可观测动作、实验异常或自动编码明显不符合录像的步骤，再用录像进行人工复核和修正。
+7. 分析时区分自动字段（如 `Completed`、`EvidenceRefs`、`AutoCodingNotes`）和人工字段（如 `Error_*`、`CoderID`、`CoderNotes`）。
 
 ## 12. 实验当天一页清单
 

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -1429,6 +1429,38 @@ def test_without_tutor_export_marks_passive_telemetry_gate_completions() -> None
     assert trial.StepCompletionAccuracy > 0
 
 
+def test_without_tutor_visual_only_steps_require_manual_review_not_auto_om() -> None:
+    root = _repo_root()
+    export = build_experiment_export(
+        _make_observation_only_baseline_events(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P_BASE", "condition": "without_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    rows = {row.StepID: row for row in export.step_coding}
+    for step_id in ("S18", "S19"):
+        assert rows[step_id].Completed == "no"
+        assert rows[step_id].NeedsHumanReview == "yes"
+        assert rows[step_id].Auto_Error_OM == "0"
+        assert rows[step_id].AutoConfidence != "high"
+        assert "visual_step_requires_manual_review" in rows[step_id].AutoCodingNotes
+        assert "manual_review:visual_step_without_passive_evidence" in rows[step_id].AutoEvidenceRefs
+
+    with_tutor = build_experiment_export(
+        _make_observation_only_baseline_events(),
+        meta_overrides={"trial_id": "T01", "participant_id": "P_HELP", "condition": "with_tutor"},
+        pack_path=root / "packs/fa18c_startup/pack.yaml",
+        bios_to_ui_path=root / "packs/fa18c_startup/bios_to_ui.yaml",
+        ui_map_path=root / "packs/fa18c_startup/ui_map.yaml",
+    )
+
+    with_tutor_rows = {row.StepID: row for row in with_tutor.step_coding}
+    assert with_tutor_rows["S18"].Auto_Error_OM == "1"
+    assert "visual_step_requires_manual_review" not in with_tutor_rows["S18"].AutoCodingNotes
+
+
 def test_without_tutor_export_preserves_logged_latch_vars_over_resolver_recompute() -> None:
     root = _repo_root()
     t0 = datetime(2026, 5, 9, 10, 0, 0, tzinfo=timezone.utc)

--- a/tests/test_experiment_export.py
+++ b/tests/test_experiment_export.py
@@ -1457,8 +1457,14 @@ def test_without_tutor_visual_only_steps_require_manual_review_not_auto_om() -> 
     )
 
     with_tutor_rows = {row.StepID: row for row in with_tutor.step_coding}
-    assert with_tutor_rows["S18"].Auto_Error_OM == "1"
-    assert "visual_step_requires_manual_review" not in with_tutor_rows["S18"].AutoCodingNotes
+    for step_id in ("S18", "S19"):
+        assert with_tutor_rows[step_id].Auto_Error_OM == "1"
+        assert with_tutor_rows[step_id].NeedsHumanReview == "yes"
+        assert "visual_step_requires_manual_review" not in with_tutor_rows[step_id].AutoCodingNotes
+        assert (
+            "manual_review:visual_step_without_passive_evidence"
+            not in with_tutor_rows[step_id].AutoEvidenceRefs
+        )
 
 
 def test_without_tutor_export_preserves_logged_latch_vars_over_resolver_recompute() -> None:


### PR DESCRIPTION
## Summary
- mark baseline visual-only S18/S19-style steps as manual-review-required instead of high-confidence auto OM
- keep with_tutor OM prefill behavior unchanged
- document S18/S19 video/offline VLM review workflow for baseline coding

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_export.py tests/test_experiment_analysis.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q -s --basetemp=.tmp/pytest-full

Closes #375