### PR TITLE
Generate experiment form commands

### DIFF
--- a/docs/wiki/experiment-forms.html
+++ b/docs/wiki/experiment-forms.html
@@ -282,6 +282,43 @@
       font-size: 13px;
     }
 
+    .command-actions {
+      display: flex;
+      justify-content: flex-end;
+      margin: 8px 0 12px;
+    }
+
+    .command-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .command-card {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      background: #fbfcfe;
+    }
+
+    .command-card h3 {
+      margin-top: 0;
+    }
+
+    .command-card textarea {
+      min-height: 260px;
+      font-family: Consolas, "Courier New", monospace;
+      font-size: 12px;
+      line-height: 1.35;
+      white-space: pre;
+      overflow: auto;
+    }
+
+    .command-card .toolbar {
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+
     .status {
       color: var(--muted);
       font-size: 13px;
@@ -327,7 +364,8 @@
 
       .grid,
       .grid.two,
-      .grid.three {
+      .grid.three,
+      .command-grid {
         grid-template-columns: 1fr;
       }
 
@@ -395,6 +433,7 @@
       <a href="#post">实验后</a>
       <a href="#quality">导出质检</a>
       <a href="#condition">条件分配</a>
+      <a href="#generated-commands">Generated commands</a>
     </nav>
 
     <form id="experimentForm">
@@ -606,6 +645,45 @@
               <option value="mixed">mixed</option>
             </select>
           </label>
+        </div>
+      </section>
+
+      <section id="generated-commands">
+        <h2>Generated commands</h2>
+        <p class="section-note">根据实验前字段自动生成 PowerShell 命令；复制前确认 participant、trial、condition 和路径一致。</p>
+        <div class="notice" id="generatedCommandWarning" hidden></div>
+        <div class="command-actions">
+          <button type="button" id="copyAllCommands">复制全部命令</button>
+        </div>
+        <div class="command-grid">
+          <article class="command-card">
+            <div class="toolbar">
+              <h3>with_tutor live run</h3>
+              <button type="button" data-copy-target="commandWithTutor">复制</button>
+            </div>
+            <textarea id="commandWithTutor" readonly></textarea>
+          </article>
+          <article class="command-card">
+            <div class="toolbar">
+              <h3>without_tutor passive live run</h3>
+              <button type="button" data-copy-target="commandWithoutTutor">复制</button>
+            </div>
+            <textarea id="commandWithoutTutor" readonly></textarea>
+          </article>
+          <article class="command-card">
+            <div class="toolbar">
+              <h3>experiment-export</h3>
+              <button type="button" data-copy-target="commandExport">复制</button>
+            </div>
+            <textarea id="commandExport" readonly></textarea>
+          </article>
+          <article class="command-card">
+            <div class="toolbar">
+              <h3>experiment-analyze</h3>
+              <button type="button" data-copy-target="commandAnalyze">复制</button>
+            </div>
+            <textarea id="commandAnalyze" readonly></textarea>
+          </article>
         </div>
       </section>
 
@@ -896,6 +974,13 @@
     const assignmentRows = document.getElementById("assignmentRows");
     const form = document.getElementById("experimentForm");
     const status = document.getElementById("status");
+    const generatedCommandWarning = document.getElementById("generatedCommandWarning");
+    const generatedCommandIds = [
+      "commandWithTutor",
+      "commandWithoutTutor",
+      "commandExport",
+      "commandAnalyze"
+    ];
 
     const usabilityItems = [
       ["U1", "I understood what I was expected to do during the task."],
@@ -1057,6 +1142,7 @@
       }
       syncAllTlxFromNumbers();
       updateRawTlx();
+      updateGeneratedCommands();
       markStatus("已加载");
     }
 
@@ -1156,6 +1242,7 @@
       localStorage.removeItem(STORAGE_KEY);
       syncAllTlxFromNumbers();
       updateRawTlx();
+      updateGeneratedCommands();
       markStatus("已清空");
     }
 
@@ -1196,6 +1283,238 @@
       document.getElementById("tlxRawHidden").value = text;
     }
 
+    function fieldValue(name, fallback = "") {
+      const el = form.elements.namedItem(name);
+      if (!el || typeof el.value !== "string") {
+        return fallback;
+      }
+      const value = el.value.trim();
+      return value || fallback;
+    }
+
+    function psQuote(value) {
+      return `"${String(value).replace(/"/g, '`"')}"`;
+    }
+
+    function psCommand(lines) {
+      return lines.map((line, idx) => (idx === lines.length - 1 ? line : `${line} \``)).join("\n");
+    }
+
+    function derivedCommandData() {
+      const study = fieldValue("study_id", "fa18c_quest3_simitutor_2026");
+      const participant = fieldValue("participant_id", "ParticipantID");
+      const trial = fieldValue("trial_id", "TrialID");
+      const condition = fieldValue("condition", "condition");
+      const sessionId = `sess-${participant}-${trial}`;
+      const rawLogPath = fieldValue("raw_log_path") || `logs\\${participant}_${trial}_${condition}.jsonl`;
+      const questionnairePath = fieldValue("questionnaire_path") || `questionnaires\\${participant}_${trial}.json`;
+      const recordingPath = fieldValue("recording_path") || `recordings\\${participant}_${trial}.mp4`;
+      const exportOutputDir = `artifacts\\experiments\\${study}`;
+      const analysisOutputDir = `artifacts\\analysis\\${study}`;
+
+      return {
+        study,
+        participant,
+        trial,
+        condition,
+        sessionId,
+        rawLogPath,
+        questionnairePath,
+        recordingPath,
+        exportOutputDir,
+        analysisOutputDir,
+        group: fieldValue("participant_group", "novice"),
+        experimenter: fieldValue("experimenter_id", "ExperimenterID"),
+        modelEndpoint: fieldValue("model_endpoint", "http://127.0.0.1:16324"),
+        textModel: fieldValue("text_model", "simtutor-base"),
+        visionModel: fieldValue("vision_model", "simtutor-vision"),
+        dcsMission: fieldValue("dcs_mission", "fa18c_cold_start_fixed.miz"),
+        dcsAircraft: fieldValue("dcs_aircraft", "FA-18C_hornet"),
+        vrSetup: fieldValue("vr_setup", "Quest 3 Link"),
+        monitorSetup: fieldValue("monitor_setup", "fa18c_composite_panel_v2"),
+        helpHotkey: fieldValue("help_hotkey"),
+        language: fieldValue("tutor_language", "zh")
+      };
+    }
+
+    function buildWithTutorCommand(data) {
+      const hotkeyLines = data.helpHotkey
+        ? [`  --global-help-hotkey ${psQuote(data.helpHotkey)}`]
+        : [];
+      return [
+        "# PowerShell window 1: vision sidecar",
+        psCommand([
+          "python .\\tools\\capture_vision_sidecar.py",
+          "  --saved-games-dir \"C:\\Users\\<USER>\\Saved Games\\DCS\"",
+          `  --session-id ${psQuote(data.sessionId)}`,
+          "  --capture-fps 0",
+          "  --trigger-host \"127.0.0.1\"",
+          "  --trigger-port 7795"
+        ]),
+        "",
+        "# PowerShell window 2: with_tutor live run",
+        psCommand([
+          "python -m simtutor live-dcs",
+          "  --bios-source raw",
+          "  --raw-bios-host 239.255.50.10",
+          "  --raw-bios-port 5010",
+          `  --raw-bios-aircraft ${data.dcsAircraft}`,
+          "  --raw-bios-control-dir \"DCS\\Scripts\\DCS-BIOS\\doc\\json\"",
+          "  --timeout 0.5",
+          `  --session-id ${psQuote(data.sessionId)}`,
+          "  --vision-saved-games-dir \"C:\\Users\\<USER>\\Saved Games\\DCS\"",
+          `  --vision-session-id ${psQuote(data.sessionId)}`,
+          "  --vision-trigger-wait-ms 4000",
+          "  --vision-capture-trigger-host \"127.0.0.1\"",
+          "  --vision-capture-trigger-port 7795",
+          ...hotkeyLines,
+          "  --global-help-cooldown-ms 800",
+          "  --model-provider openai_compat",
+          `  --model-base-url ${psQuote(data.modelEndpoint)}`,
+          `  --model-name ${psQuote(data.textModel)}`,
+          `  --vision-model-name ${psQuote(data.visionModel)}`,
+          "  --model-timeout-s 60",
+          "  --max-overlay-targets 4",
+          "  --knowledge-index \"Doc\\Evaluation\\index.json\"",
+          "  --rag-top-k 5",
+          "  --model-enable-multimodal",
+          "  --no-cold-start-production",
+          `  --lang ${data.language}`,
+          "  --scenario-profile airfield",
+          "  --log-raw-llm-text",
+          "  --print-model-io",
+          `  --output ${psQuote(data.rawLogPath)}`
+        ])
+      ].join("\n");
+    }
+
+    function buildWithoutTutorCommand(data) {
+      return [
+        "# without_tutor passive baseline: No LLM/VLM/overlay/help is expected.",
+        psCommand([
+          "python -m simtutor live-dcs",
+          "  --bios-source raw",
+          "  --raw-bios-host 239.255.50.10",
+          "  --raw-bios-port 5010",
+          `  --raw-bios-aircraft ${data.dcsAircraft}`,
+          "  --raw-bios-control-dir \"DCS\\Scripts\\DCS-BIOS\\doc\\json\"",
+          "  --timeout 0.5",
+          `  --session-id ${psQuote(data.sessionId)}`,
+          "  --help-udp-port 0",
+          "  --model-provider stub",
+          "  --stub-mode correct",
+          "  --no-model-enable-multimodal",
+          `  --lang ${data.language}`,
+          "  --scenario-profile airfield",
+          `  --output ${psQuote(data.rawLogPath)}`
+        ])
+      ].join("\n");
+    }
+
+    function buildExportCommand(data) {
+      const isWithoutTutor = data.condition === "without_tutor";
+      const provider = isWithoutTutor ? "stub" : "openai_compat";
+      const textModel = isWithoutTutor ? "not_used" : data.textModel;
+      const visionModel = isWithoutTutor ? "not_used" : data.visionModel;
+      return psCommand([
+        `python -m simtutor experiment-export ${psQuote(data.rawLogPath)}`,
+        `  --study-id ${psQuote(data.study)}`,
+        `  --participant-id ${psQuote(data.participant)}`,
+        `  --condition ${psQuote(data.condition)}`,
+        `  --group ${psQuote(data.group)}`,
+        `  --trial-id ${psQuote(data.trial)}`,
+        `  --experimenter-id ${psQuote(data.experimenter)}`,
+        `  --questionnaire ${psQuote(data.questionnairePath)}`,
+        `  --recording-ref ${psQuote(data.recordingPath)}`,
+        `  --output-dir ${psQuote(data.exportOutputDir)}`,
+        "  --pack \"packs\\fa18c_startup\\pack.yaml\"",
+        "  --taxonomy \"packs\\fa18c_startup\\taxonomy.yaml\"",
+        "  --ui-map \"packs\\fa18c_startup\\ui_map.yaml\"",
+        "  --bios-to-ui \"packs\\fa18c_startup\\bios_to_ui.yaml\"",
+        `  --model-provider ${provider}`,
+        `  --model-name ${textModel}`,
+        `  --vision-model-name ${visionModel}`,
+        "  --prompt-version form-v0.1",
+        "  --scenario-profile airfield",
+        `  --dcs-mission ${psQuote(data.dcsMission)}`,
+        `  --dcs-aircraft ${data.dcsAircraft}`,
+        `  --vr-setup ${psQuote(data.vrSetup)}`,
+        `  --monitor-setup ${data.monitorSetup}`,
+        "  --strict"
+      ]);
+    }
+
+    function buildAnalyzeCommand(data) {
+      return psCommand([
+        `python -m simtutor experiment-analyze ${psQuote(data.exportOutputDir)}`,
+        `  --output-dir ${psQuote(data.analysisOutputDir)}`
+      ]);
+    }
+
+    function updateGeneratedWarning(data) {
+      const missing = [];
+      if (!fieldValue("study_id")) missing.push("StudyID");
+      if (!fieldValue("participant_id")) missing.push("ParticipantID");
+      if (!fieldValue("trial_id")) missing.push("TrialID");
+      if (!fieldValue("condition")) missing.push("Condition");
+      if (data.condition === "with_tutor" && !fieldValue("model_endpoint")) {
+        missing.push("Model endpoint");
+      }
+      generatedCommandWarning.hidden = missing.length === 0;
+      generatedCommandWarning.textContent = missing.length
+        ? `缺少必填字段，命令中已使用占位或默认值：${missing.join(", ")}`
+        : "";
+    }
+
+    function updateGeneratedCommands() {
+      const data = derivedCommandData();
+      document.getElementById("commandWithTutor").value = buildWithTutorCommand(data);
+      document.getElementById("commandWithoutTutor").value = buildWithoutTutorCommand(data);
+      document.getElementById("commandExport").value = buildExportCommand(data);
+      document.getElementById("commandAnalyze").value = buildAnalyzeCommand(data);
+      updateGeneratedWarning(data);
+    }
+
+    async function copyCommandText(targetId) {
+      const textarea = document.getElementById(targetId);
+      if (!textarea) {
+        return;
+      }
+      try {
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          throw new Error("Clipboard API unavailable");
+        }
+        await navigator.clipboard.writeText(textarea.value);
+        markStatus("命令已复制");
+      } catch {
+        textarea.focus();
+        textarea.select();
+        document.execCommand("copy");
+        markStatus("命令已选中，可手动复制");
+      }
+    }
+
+    async function copyAllGeneratedCommands() {
+      const text = generatedCommandIds
+        .map((id) => document.getElementById(id).value)
+        .join("\n\n");
+      const fallback = document.getElementById("commandWithTutor");
+      try {
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          throw new Error("Clipboard API unavailable");
+        }
+        await navigator.clipboard.writeText(text);
+        markStatus("全部命令已复制");
+      } catch {
+        fallback.value = text;
+        fallback.focus();
+        fallback.select();
+        document.execCommand("copy");
+        updateGeneratedCommands();
+        markStatus("全部命令已选中，可手动复制");
+      }
+    }
+
     buildRows();
 
     document.querySelectorAll("[data-tlx]").forEach((range) => {
@@ -1210,8 +1529,14 @@
     document.getElementById("loadJson").addEventListener("change", (ev) => loadJsonFile(ev.target.files[0]));
     document.getElementById("printForm").addEventListener("click", () => window.print());
     document.getElementById("clearForm").addEventListener("click", clearForm);
+    document.getElementById("copyAllCommands").addEventListener("click", copyAllGeneratedCommands);
+    document.querySelectorAll("[data-copy-target]").forEach((button) => {
+      button.addEventListener("click", () => copyCommandText(button.dataset.copyTarget));
+    });
 
     let saveTimer = null;
+    form.addEventListener("input", updateGeneratedCommands);
+    form.addEventListener("change", updateGeneratedCommands);
     form.addEventListener("input", () => {
       clearTimeout(saveTimer);
       saveTimer = setTimeout(saveLocal, 300);
@@ -1229,6 +1554,7 @@
 
     loadLocal();
     updateRawTlx();
+    updateGeneratedCommands();
   </script>
 </body>
 </html>

--- a/docs/wiki/experiment-forms.html
+++ b/docs/wiki/experiment-forms.html
@@ -319,6 +319,13 @@
       margin-bottom: 8px;
     }
 
+    .copy-all-fallback {
+      margin-top: 12px;
+      min-height: 180px;
+      font-family: Consolas, "Courier New", monospace;
+      font-size: 12px;
+    }
+
     .status {
       color: var(--muted);
       font-size: 13px;
@@ -685,6 +692,7 @@
             <textarea id="commandAnalyze" readonly></textarea>
           </article>
         </div>
+        <textarea id="commandAllFallback" class="copy-all-fallback" readonly hidden aria-label="All generated commands"></textarea>
       </section>
 
       <section id="during">
@@ -1305,6 +1313,8 @@
       const participant = fieldValue("participant_id", "ParticipantID");
       const trial = fieldValue("trial_id", "TrialID");
       const condition = fieldValue("condition", "condition");
+      const formLanguage = fieldValue("tutor_language", "zh");
+      const commandLanguage = formLanguage === "en" ? "en" : "zh";
       const sessionId = `sess-${participant}-${trial}`;
       const rawLogPath = fieldValue("raw_log_path") || `logs\\${participant}_${trial}_${condition}.jsonl`;
       const questionnairePath = fieldValue("questionnaire_path") || `questionnaires\\${participant}_${trial}.json`;
@@ -1333,7 +1343,8 @@
         vrSetup: fieldValue("vr_setup", "Quest 3 Link"),
         monitorSetup: fieldValue("monitor_setup", "fa18c_composite_panel_v2"),
         helpHotkey: fieldValue("help_hotkey"),
-        language: fieldValue("tutor_language", "zh")
+        formLanguage,
+        commandLanguage
       };
     }
 
@@ -1379,7 +1390,7 @@
           "  --rag-top-k 5",
           "  --model-enable-multimodal",
           "  --no-cold-start-production",
-          `  --lang ${data.language}`,
+          `  --lang ${data.commandLanguage}`,
           "  --scenario-profile airfield",
           "  --log-raw-llm-text",
           "  --print-model-io",
@@ -1404,7 +1415,7 @@
           "  --model-provider stub",
           "  --stub-mode correct",
           "  --no-model-enable-multimodal",
-          `  --lang ${data.language}`,
+          `  --lang ${data.commandLanguage}`,
           "  --scenario-profile airfield",
           `  --output ${psQuote(data.rawLogPath)}`
         ])
@@ -1460,6 +1471,9 @@
       if (data.condition === "with_tutor" && !fieldValue("model_endpoint")) {
         missing.push("Model endpoint");
       }
+      if (data.formLanguage === "mixed") {
+        missing.push("Tutor message language=mixed maps to --lang zh");
+      }
       generatedCommandWarning.hidden = missing.length === 0;
       generatedCommandWarning.textContent = missing.length
         ? `缺少必填字段，命令中已使用占位或默认值：${missing.join(", ")}`
@@ -1472,6 +1486,7 @@
       document.getElementById("commandWithoutTutor").value = buildWithoutTutorCommand(data);
       document.getElementById("commandExport").value = buildExportCommand(data);
       document.getElementById("commandAnalyze").value = buildAnalyzeCommand(data);
+      document.getElementById("commandAllFallback").hidden = true;
       updateGeneratedWarning(data);
     }
 
@@ -1498,7 +1513,7 @@
       const text = generatedCommandIds
         .map((id) => document.getElementById(id).value)
         .join("\n\n");
-      const fallback = document.getElementById("commandWithTutor");
+      const fallback = document.getElementById("commandAllFallback");
       try {
         if (!navigator.clipboard || !navigator.clipboard.writeText) {
           throw new Error("Clipboard API unavailable");
@@ -1506,11 +1521,11 @@
         await navigator.clipboard.writeText(text);
         markStatus("全部命令已复制");
       } catch {
+        fallback.hidden = false;
         fallback.value = text;
         fallback.focus();
         fallback.select();
         document.execCommand("copy");
-        updateGeneratedCommands();
         markStatus("全部命令已选中，可手动复制");
       }
     }

--- a/docs/wiki/experiment-forms.md
+++ b/docs/wiki/experiment-forms.md
@@ -4,6 +4,10 @@
 
 可填写并导出 JSON/CSV 的 HTML 版本见：[Experiment forms HTML](experiment-forms.html)。
 
+## Generated commands
+
+HTML 表单会根据 StudyID、ParticipantID、TrialID、Condition、模型 endpoint 和实验路径自动生成可复制的 PowerShell 命令，包括 `live-dcs`（`with_tutor` 和 `without_tutor` passive baseline）、`experiment-export` 与 `experiment-analyze`。实验执行前应优先从 HTML 表单复制这些命令，避免手工改错 participant、condition、session 或 log/questionnaire/recording 路径。
+
 ## 1. 条件顺序建议
 
 ### 推荐主设计：between-subject

--- a/tests/test_experiment_forms_html.py
+++ b/tests/test_experiment_forms_html.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HTML = ROOT / "docs" / "wiki" / "experiment-forms.html"
+FORMS_MD = ROOT / "docs" / "wiki" / "experiment-forms.md"
+
+
+def _html() -> str:
+    return HTML.read_text(encoding="utf-8")
+
+
+def test_experiment_form_exposes_generated_command_blocks() -> None:
+    html = _html()
+
+    assert 'href="#generated-commands"' in html
+    assert 'id="generated-commands"' in html
+    assert 'id="copyAllCommands"' in html
+
+    for command_id in (
+        "commandWithTutor",
+        "commandWithoutTutor",
+        "commandExport",
+        "commandAnalyze",
+    ):
+        assert f'id="{command_id}"' in html
+        assert "readonly" in html
+
+
+def test_experiment_form_generates_condition_specific_command_args() -> None:
+    html = _html()
+
+    for expected in (
+        "--model-provider openai_compat",
+        "--model-base-url",
+        "--model-name",
+        "--vision-model-name",
+        "--model-enable-multimodal",
+        "--global-help-hotkey",
+        "--max-overlay-targets 4",
+        "--model-provider stub",
+        "--stub-mode correct",
+        "--no-model-enable-multimodal",
+        "--help-udp-port 0",
+        "No LLM/VLM/overlay/help is expected",
+        'logs\\\\${participant}_${trial}_${condition}.jsonl',
+        'questionnaires\\\\${participant}_${trial}.json',
+        'recordings\\\\${participant}_${trial}.mp4',
+        'artifacts\\\\experiments\\\\${study}',
+        'artifacts\\\\analysis\\\\${study}',
+    ):
+        assert expected in html
+
+
+def test_experiment_form_copy_buttons_have_clipboard_fallback() -> None:
+    html = _html()
+
+    assert "navigator.clipboard.writeText" in html
+    assert ".select()" in html
+    assert "document.execCommand(\"copy\")" in html
+    assert "copyCommandText" in html
+
+
+def test_experiment_form_load_regenerates_commands() -> None:
+    html = _html()
+
+    assert "function updateGeneratedCommands()" in html
+    assert "updateGeneratedCommands();" in html
+    assert "form.addEventListener(\"input\", updateGeneratedCommands)" in html
+    assert "form.addEventListener(\"change\", updateGeneratedCommands)" in html
+
+
+def test_experiment_forms_markdown_mentions_generated_commands() -> None:
+    text = FORMS_MD.read_text(encoding="utf-8")
+
+    assert "Generated commands" in text
+    assert "live-dcs" in text
+    assert "experiment-export" in text
+    assert "experiment-analyze" in text

--- a/tests/test_experiment_forms_html.py
+++ b/tests/test_experiment_forms_html.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -59,6 +60,34 @@ def test_experiment_form_copy_buttons_have_clipboard_fallback() -> None:
     assert ".select()" in html
     assert "document.execCommand(\"copy\")" in html
     assert "copyCommandText" in html
+    assert 'id="commandAllFallback"' in html
+
+
+def test_experiment_form_keeps_passive_command_free_of_tutor_setup() -> None:
+    html = _html()
+    match = re.search(
+        r"function buildWithoutTutorCommand\(data\) \{(?P<body>.*?)function buildExportCommand",
+        html,
+        re.S,
+    )
+    assert match is not None
+    body = match.group("body")
+
+    assert "--help-udp-port 0" in body
+    assert "--model-provider stub" in body
+    assert "--stub-mode correct" in body
+    assert "--no-model-enable-multimodal" in body
+    assert "--global-help-hotkey" not in body
+    assert "--model-base-url" not in body
+    assert "vision-saved-games-dir" not in body
+
+
+def test_experiment_form_maps_mixed_language_to_cli_supported_zh() -> None:
+    html = _html()
+
+    assert 'const commandLanguage = formLanguage === "en" ? "en" : "zh";' in html
+    assert "Tutor message language=mixed maps to --lang zh" in html
+    assert "--lang ${data.commandLanguage}" in html
 
 
 def test_experiment_form_load_regenerates_commands() -> None:

--- a/tests/test_experiment_forms_html.py
+++ b/tests/test_experiment_forms_html.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import re
 
 
@@ -9,6 +10,47 @@ FORMS_MD = ROOT / "docs" / "wiki" / "experiment-forms.md"
 
 def _html() -> str:
     return HTML.read_text(encoding="utf-8")
+
+
+def _function_body(html: str, name: str) -> str:
+    match = re.search(rf"function {name}\([^)]*\) \{{(?P<body>.*?)\n    \}}", html, re.S)
+    assert match is not None
+    return match.group("body")
+
+
+def _first_ps_command_lines(function_body: str) -> list[str]:
+    start = function_body.index("psCommand([") + len("psCommand([")
+    depth = 1
+    pos = start
+    while depth:
+        ch = function_body[pos]
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+        pos += 1
+    array_source = function_body[start : pos - 1]
+    tokens = re.findall(r'(`(?:\\.|[^`])*`|"(?:\\.|[^"])*")', array_source)
+    lines = []
+    for token in tokens:
+        if token.startswith('"'):
+            lines.append(json.loads(token))
+        else:
+            lines.append(token[1:-1])
+    return lines
+
+
+def _render_lines(lines: list[str], data: dict[str, str]) -> str:
+    rendered = []
+    for line in lines:
+        for key, value in data.items():
+            line = line.replace(f"${{data.{key}}}", value)
+            line = line.replace(f"${{psQuote(data.{key})}}", f'"{value}"')
+        rendered.append(line)
+    return "\n".join(
+        line if idx == len(rendered) - 1 else f"{line} `"
+        for idx, line in enumerate(rendered)
+    )
 
 
 def test_experiment_form_exposes_generated_command_blocks() -> None:
@@ -65,13 +107,7 @@ def test_experiment_form_copy_buttons_have_clipboard_fallback() -> None:
 
 def test_experiment_form_keeps_passive_command_free_of_tutor_setup() -> None:
     html = _html()
-    match = re.search(
-        r"function buildWithoutTutorCommand\(data\) \{(?P<body>.*?)function buildExportCommand",
-        html,
-        re.S,
-    )
-    assert match is not None
-    body = match.group("body")
+    body = _function_body(html, "buildWithoutTutorCommand")
 
     assert "--help-udp-port 0" in body
     assert "--model-provider stub" in body
@@ -80,6 +116,59 @@ def test_experiment_form_keeps_passive_command_free_of_tutor_setup() -> None:
     assert "--global-help-hotkey" not in body
     assert "--model-base-url" not in body
     assert "vision-saved-games-dir" not in body
+
+
+def test_experiment_form_renders_p02_without_tutor_acceptance_commands() -> None:
+    html = _html()
+    data = {
+        "study": "fa18c_quest3_simitutor_2026",
+        "participant": "P02",
+        "trial": "T01",
+        "condition": "without_tutor",
+        "sessionId": "sess-P02-T01",
+        "rawLogPath": r"logs\P02_T01_without_tutor.jsonl",
+        "questionnairePath": r"questionnaires\P02_T01.json",
+        "recordingPath": r"recordings\P02_T01.mp4",
+        "exportOutputDir": r"artifacts\experiments\fa18c_quest3_simitutor_2026",
+        "analysisOutputDir": r"artifacts\analysis\fa18c_quest3_simitutor_2026",
+        "group": "novice",
+        "experimenter": "E01",
+        "commandLanguage": "zh",
+        "dcsAircraft": "FA-18C_hornet",
+        "dcsMission": "fa18c_cold_start_fixed.miz",
+        "vrSetup": "Quest 3 Link",
+        "monitorSetup": "fa18c_composite_panel_v2",
+    }
+
+    passive = _render_lines(
+        _first_ps_command_lines(_function_body(html, "buildWithoutTutorCommand")),
+        data,
+    )
+    assert '--session-id "sess-P02-T01"' in passive
+    assert "--help-udp-port 0" in passive
+    assert "--model-provider stub" in passive
+    assert "--stub-mode correct" in passive
+    assert "--no-model-enable-multimodal" in passive
+    assert '--output "logs\\P02_T01_without_tutor.jsonl"' in passive
+
+    export = _render_lines(
+        _first_ps_command_lines(_function_body(html, "buildExportCommand")),
+        data | {"provider": "stub", "textModel": "not_used", "visionModel": "not_used"},
+    )
+    assert 'experiment-export "logs\\P02_T01_without_tutor.jsonl"' in export
+    assert '--participant-id "P02"' in export
+    assert '--condition "without_tutor"' in export
+    assert '--questionnaire "questionnaires\\P02_T01.json"' in export
+    assert '--recording-ref "recordings\\P02_T01.mp4"' in export
+    assert '--output-dir "artifacts\\experiments\\fa18c_quest3_simitutor_2026"' in export
+    assert "--strict" in export
+
+    analyze = _render_lines(
+        _first_ps_command_lines(_function_body(html, "buildAnalyzeCommand")),
+        data,
+    )
+    assert 'experiment-analyze "artifacts\\experiments\\fa18c_quest3_simitutor_2026"' in analyze
+    assert '--output-dir "artifacts\\analysis\\fa18c_quest3_simitutor_2026"' in analyze
 
 
 def test_experiment_form_maps_mixed_language_to_cli_supported_zh() -> None:


### PR DESCRIPTION
## Summary
- add a Generated commands section to the offline experiment HTML form
- generate with_tutor, without_tutor passive baseline, export, and analyze PowerShell commands from form fields
- document the HTML command generator and add focused static coverage

## Tests
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_forms_html.py
- source ~/venvs/iefmmq-wsl/bin/activate && PYTHONPATH=/usr/lib/python3/dist-packages python -m pytest -q tests/test_experiment_forms_html.py tests/test_launcher_session.py

Closes #376